### PR TITLE
Closes #12 and closes #15

### DIFF
--- a/app/models/dump.rb
+++ b/app/models/dump.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require 'voyager_helpers'
+require 'nokogiri'
 
 class Dump < ActiveRecord::Base
 
@@ -54,7 +55,8 @@ class Dump < ActiveRecord::Base
       connection do |c|
         ids.each do |id|
           r = VoyagerHelpers::Liberator.get_bib_record(id, c)
-          f.write(r.to_xml.to_s.force_encoding('UTF-8')+"\n") unless r.nil?
+          f.write(Nokogiri::XML(r.to_xml.to_s).to_xml(:save_with => Nokogiri::XML::Node::SaveOptions::AS_XML | 
+                  Nokogiri::XML::Node::SaveOptions::NO_DECLARATION).to_s+"\n") unless r.nil?
         end
       end
       f.write('</collection>')

--- a/spec/requests/bib_items_spec.rb
+++ b/spec/requests/bib_items_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Bibliographic Items", :type => :request do
+  describe "GET /bibliographic/430472/items" do
+    it "Properly encoded item records" do
+      get '/bibliographic/430472/items'
+      expect(response.status).to be(200)
+    end
+  end
+end

--- a/voyager_helpers/lib/voyager_helpers/liberator.rb
+++ b/voyager_helpers/lib/voyager_helpers/liberator.rb
@@ -42,7 +42,7 @@ module VoyagerHelpers
       def get_holding_record(mfhd_id, conn=nil)
         unless mfhd_is_suppressed?(mfhd_id, conn)
           segments = get_mfhd_segments(mfhd_id, conn)
-          MARC::Reader.decode(segments.join('')) unless segments.empty?
+          MARC::Reader.decode(segments.join(''), :external_encoding => "UTF-8") unless segments.empty?
         end
       end
 
@@ -316,7 +316,7 @@ module VoyagerHelpers
 
       def get_bib_without_holdings(bib_id, conn=nil)
         segments = get_bib_segments(bib_id, conn)
-        MARC::Reader.decode(segments.join('')) unless segments.empty?
+        MARC::Reader.decode(segments.join(''), :external_encoding => "UTF-8") unless segments.empty?
       end
 
       def get_bib_with_holdings(bib_id, conn=nil, opts={})


### PR DESCRIPTION
nokogiri strips out the the invalid xml characters. These are mainly escape characters that are valid unicode but not valid xml. 

The Marc::Reader needs to have an external_encoding provided to properly spit out utf-8. This eliminated the need for the force_encoding method on the dumps, but wasn't sufficient for stripping out the invalid characters.
