### PR TITLE
Add electronic_portfolio_s field

### DIFF
--- a/marc_to_solr/lib/electronic_portfolio_builder.rb
+++ b/marc_to_solr/lib/electronic_portfolio_builder.rb
@@ -1,0 +1,51 @@
+# Class for building electronic portfolio JSON from marc fields
+class ElectronicPortfolioBuilder
+  # Build electronic portfolio JSON from marc fields
+  # @param field [MARC::DataField] data from 951 field
+  # @param date [MARC::DataField] date range data from 953 field
+  # @param embargo [MARC::DataField] embargo data from 954 field
+  # @return [String] JSON string
+  def self.build(field:, date:, embargo:)
+    new(field: field, date: date, embargo: embargo).build
+  end
+
+  attr_reader :embargo, :field, :date
+
+  # Constructor
+  # @param field [MARC::DataField] data from 951 field
+  # @param date [MARC::DataField] date range data from 953 field
+  # @param embargo [MARC::DataField] embargo data from 954 field
+  def initialize(field:, date:, embargo:)
+    @field = field
+    @date = date
+    @embargo = embargo
+  end
+
+  def build
+    {
+      'desc': field['k'],
+      'title': field['n'],
+      'url': field['x'],
+      'start': start_date,
+      'end': end_date
+    }.to_json
+  end
+
+  private
+
+    def start_date
+      return unless date
+      date['b']
+    end
+
+    def end_date
+      return unless date
+      if embargo && embargo['c']
+        (DateTime.now.year - embargo['c'].to_i).to_s
+      elsif date['c']
+        date['c']
+      else
+        'latest'
+      end
+    end
+end

--- a/spec/fixtures/marc_to_solr/alma/991213506421.mrx
+++ b/spec/fixtures/marc_to_solr/alma/991213506421.mrx
@@ -1,1 +1,731 @@
-<record><leader>01585cas a2200421 a 4500</leader><controlfield tag="005">20200728155602.0</controlfield><controlfield tag="008">801003c19789999enkbr p       0    0eng d</controlfield><controlfield tag="001">991213506421</controlfield><datafield tag="010" ind1=" " ind2=" "><subfield code="a">   80642988  </subfield></datafield><datafield tag="022" ind1=" " ind2=" "><subfield code="a">0142-0798</subfield><subfield code="0">(uri) http://worldcat.org/issn/0142-0798</subfield></datafield><datafield tag="035" ind1=" " ind2=" "><subfield code="a">(OCoLC)5083241</subfield><subfield code="0">(uri) http://www.worldcat.org/oclc/5083241</subfield></datafield><datafield tag="035" ind1=" " ind2=" "><subfield code="a">(CStRLIN)NJPG0326-S</subfield></datafield><datafield tag="035" ind1=" " ind2=" "><subfield code="9">AAF4355TS</subfield></datafield><datafield tag="035" ind1=" " ind2=" "><subfield code="a">121</subfield></datafield><datafield tag="035" ind1=" " ind2=" "><subfield code="a">(NjP)121-princetondb</subfield></datafield><datafield tag="040" ind1=" " ind2=" "><subfield code="a">DNG-A</subfield><subfield code="b">eng</subfield><subfield code="c">DNG-A</subfield><subfield code="d">CtY</subfield><subfield code="d">DLC</subfield><subfield code="d">NjP</subfield></datafield><datafield tag="041" ind1="0" ind2=" "><subfield code="a">eng</subfield><subfield code="a">ger</subfield></datafield><datafield tag="042" ind1=" " ind2=" "><subfield code="a">lc</subfield></datafield><datafield tag="050" ind1="0" ind2="0"><subfield code="a">NK2808</subfield><subfield code="b">.H17</subfield></datafield><datafield tag="245" ind1="0" ind2="0"><subfield code="a">HALI :</subfield><subfield code="b">the international journal of Oriental carpets and textiles.</subfield></datafield><datafield tag="260" ind1=" " ind2=" "><subfield code="a">London :</subfield><subfield code="b">Oguz Press,</subfield><subfield code="c">1978-</subfield></datafield><datafield tag="300" ind1=" " ind2=" "><subfield code="a">v. :</subfield><subfield code="b">ill. ;</subfield><subfield code="c">31 cm.</subfield></datafield><datafield tag="310" ind1=" " ind2=" "><subfield code="a">Quarterly,</subfield><subfield code="b">&lt;2013&gt;-</subfield></datafield><datafield tag="321" ind1=" " ind2=" "><subfield code="a">Quarterly,</subfield><subfield code="b">1978-1987</subfield></datafield><datafield tag="321" ind1=" " ind2=" "><subfield code="a">Bimonthly,</subfield><subfield code="b">1988-&lt;2005&gt;</subfield></datafield><datafield tag="362" ind1="0" ind2=" "><subfield code="a">Vol. 1, no. 1 (spring 1978)-v. 17, no. 6 (Jan./Feb. 1996) ; issue 85 (Mar./Apr. 1996)-</subfield></datafield><datafield tag="500" ind1=" " ind2=" "><subfield code="a">Subtitle varies.</subfield></datafield><datafield tag="500" ind1=" " ind2=" "><subfield code="a">Each issue has also a distinctive title.</subfield></datafield><datafield tag="515" ind1=" " ind2=" "><subfield code="a">Vol. 6, no. 3-v. 17, no. 6 called also issue 23-84; beginning with issue 85, issues carry whole numbering only.</subfield></datafield><datafield tag="546" ind1=" " ind2=" "><subfield code="a">English and German.</subfield></datafield><datafield tag="555" ind1=" " ind2=" "><subfield code="a">Vols. 1 (1978)-17 (1995/96). 1 v.</subfield></datafield><datafield tag="588" ind1=" " ind2=" "><subfield code="a">Description based on: Vol. 2, no. 1 (spring 1979); title from cover.</subfield></datafield><datafield tag="588" ind1=" " ind2=" "><subfield code="a">Latest issue consulted: Issue 175 (spring 2013).</subfield></datafield><datafield tag="650" ind1=" " ind2="0"><subfield code="a">Rugs, Oriental</subfield><subfield code="v">Periodicals.</subfield></datafield><datafield tag="650" ind1=" " ind2="0"><subfield code="a">Textile fabrics, Oriental</subfield><subfield code="v">Periodicals.</subfield></datafield><datafield tag="655" ind1=" " ind2="7"><subfield code="a">Periodicals.</subfield><subfield code="2">lcgft</subfield><subfield code="0">http://id.loc.gov/authorities/genreForms/gf2014026139</subfield></datafield><datafield tag="998" ind1=" " ind2=" "><subfield code="a">03/30/95</subfield><subfield code="s">9110</subfield><subfield code="n">NjP</subfield><subfield code="w">DCLC80642988S</subfield><subfield code="d">10/05/81</subfield><subfield code="c">HS</subfield><subfield code="b">EE</subfield><subfield code="i">950330</subfield><subfield code="l">NJPG</subfield></datafield><datafield tag="911" ind1=" " ind2=" "><subfield code="a">19950425</subfield></datafield><datafield tag="912" ind1=" " ind2=" "><subfield code="a">19990830034636.0</subfield></datafield><datafield tag="950" ind1=" " ind2=" "><subfield code="b">2020-12-02 20:58:19 US/Eastern</subfield><subfield code="a">false</subfield></datafield><datafield tag="852" ind1="0" ind2="1"><subfield code="b">firestone</subfield><subfield code="c">nec</subfield><subfield code="h">NK2808</subfield><subfield code="i">.H17q</subfield><subfield code="k">Oversize</subfield><subfield code="8">22261907460006421</subfield></datafield><datafield tag="866" ind1=" " ind2="0"><subfield code="a">Vol. 1, no. 1 (spring 1978)-v. 17, no. 6 (Jan./Feb. 1996) ; issue 85 (Mar./Apr. 1996)-issue 144 (Jan./Feb. 2006); issue 150 (Jan./Feb. 2007); issue 175 (spring 2013); issue 179 (spring 2014)-issue 181 (autumn 2014)</subfield><subfield code="8">22261907460006421</subfield></datafield><datafield tag="866" ind1=" " ind2="0"><subfield code="z">LACKS: v. 2, no. 2; issue 180</subfield><subfield code="8">22261907460006421</subfield></datafield><datafield tag="866" ind1=" " ind2="0"><subfield code="z">CURRENT ISSUES IN: Near East Periodicals Collection (PRNE). Firestone</subfield><subfield code="8">22261907460006421</subfield></datafield><datafield tag="868" ind1=" " ind2="0"><subfield code="a">Index, v. 1/17</subfield><subfield code="8">22261907460006421</subfield></datafield><datafield tag="952" ind1=" " ind2=" "><subfield code="a">2020-12-03 01:58:19</subfield><subfield code="8">22261907460006421</subfield><subfield code="b">Firestone Library</subfield><subfield code="c">nec Near East Coll</subfield><subfield code="e">false</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261906900006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 6, no. 1-2</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">1983-1984</subfield><subfield code="p">32101014612715</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261906920006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 5, no. 3-4</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">1983</subfield><subfield code="p">32101014612699</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907450006421</subfield><subfield code="j">1</subfield><subfield code="3">183</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">2012</subfield><subfield code="p">ISSitm101-2432.760-princetondb</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907240006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 4, no. 1-2</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">1981</subfield><subfield code="p">32101014612681</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907060006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 111-113</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">July/Aug.-Nov./Dec. 2000</subfield><subfield code="p">32101039388556</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907080006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 12, no. 4-6</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 52-54;  Aug.-Dec. 1990</subfield><subfield code="p">32101024132431</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907170006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 8, no. 3-4</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 31-32; July/Sept.-Oct./Dec. 1986</subfield><subfield code="p">32101014612749</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907130006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 3</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">1980-1981</subfield><subfield code="p">32101014630279</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907150006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 9, no. 3-4</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 35-36; July/Sept.-Oct./Dec. 1987</subfield><subfield code="p">32101014612798</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907400006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 15, no. 4-6</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 70-72; Aug./Sept. 1993-Dec. 1993/Jan. 1994</subfield><subfield code="p">32101024303628</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907420006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 14, no. 4-6</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 64-66; Aug.-Dec. 1992</subfield><subfield code="p">32101022760753</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907440006421</subfield><subfield code="j">0</subfield><subfield code="3">184</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">2012</subfield><subfield code="p">ISSitm2432.770-princetondb</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907280006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 96-98</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">Jan.-May 1998</subfield><subfield code="p">32101037117965</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907190006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 7, no. 3-4</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 27-28; July/Sept.-Oct./Dec. 1985</subfield><subfield code="p">32101014612764</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907200006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 7, no. 1-2</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 25-26; Jan.-Apr./June 1985</subfield><subfield code="p">32101014612756</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261906980006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 10, no. 1-3</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 37-39; Jan./Feb.-May/June 1988</subfield><subfield code="p">32101014612806</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907350006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 84-86</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">Jan./Feb.-May 1996</subfield><subfield code="p">32101024588467</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907370006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 79-81</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">vol. 17, no. 1-3; Feb./Mar.-June/July 1995</subfield><subfield code="p">32101080904475</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907260006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 117-119</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">July/Aug.-Nov./Dec. 2001</subfield><subfield code="p">32101044801387</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907310006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 90-92</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">Jan.-May 1997</subfield><subfield code="p">32101033765445</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907220006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 126-128</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">Jan./Feb.-May/June 2003</subfield><subfield code="p">32101050543139</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261906870006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 135-137</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">July/Aug.-Nov./Dec. 2004</subfield><subfield code="p">32101059702140</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907000006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 13, no. 1-3</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 55-57; Feb.-June 1991</subfield><subfield code="p">32101021888985</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261906780006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 150</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">Jan/Feb 2007</subfield><subfield code="p">32101085146635</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261906940006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 4, no. 3-4</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">1982</subfield><subfield code="p">32101014612673</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261906890006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 6, no. 3-4</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 23-24; 1984</subfield><subfield code="p">32101014612723</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261906830006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 141-143</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">July/Aug.-Nov./Dec. 2005</subfield><subfield code="p">32101060531801</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907040006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 123-125</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">July/Aug.-Nov./Dec. 2002</subfield><subfield code="p">32101047547243</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907020006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 11, no. 4-6</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 46-48; Aug.-Dec. 1989</subfield><subfield code="p">32101016294272</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261906800006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 82-83</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">vol. 17, no. 4-5; Aug./Sept.-Oct./Nov. 1995</subfield><subfield code="p">32101080904541</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261906810006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 175</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">spring 2013</subfield><subfield code="p">32101085141941</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907390006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 16, no. 1-2</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 73-74; Feb./Mar.-Apr. 1994</subfield><subfield code="p">32101028666939</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907380006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 16, no. 3-4</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 75-76; June/July-Aug./Sept. 1994</subfield><subfield code="p">32101028666947</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907160006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 9, no. 1-2</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 33-34; Jan./Mar.-Apr./June 1987</subfield><subfield code="p">32101014612780</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907410006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 15, no. 1-3</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 67-69; Feb./Mar.-June/July 1993</subfield><subfield code="p">32101024303636</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907070006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 108-110</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">Jan./Feb.-May/June 2000</subfield><subfield code="p">32101039388549</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907340006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 87-89</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">July-Nov. 1996</subfield><subfield code="p">32101024588475</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907090006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 105-107</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">July/Aug.-Nov./Dec. 1999</subfield><subfield code="p">32101038939375</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907140006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 2 (inc.)</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">1979-1980</subfield><subfield code="p">32101014630428</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907430006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 14, no. 1-3</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 61-63; Feb.-June 1992</subfield><subfield code="p">32101022760746</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907180006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 8, no. 1-2</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 29-30; Jan./Mar.-Apr./June 1986</subfield><subfield code="p">32101014612731</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261906990006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 13, no. 4-6</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 58-60; Aug.-Dec. 1991</subfield><subfield code="p">32101021888977</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907120006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 102-104</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">Jan.-May/June 1999</subfield><subfield code="p">32101038939367</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907210006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 129-131</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">July/Aug.-Nov./Dec. 2003</subfield><subfield code="p">32101050543345</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907360006421</subfield><subfield code="j">1</subfield><subfield code="3">Index, v. 1/17</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 1/84; 1978/95</subfield><subfield code="p">32101024588707</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907230006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 5, no. 1-2</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">1982</subfield><subfield code="p">32101014612707</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907250006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 114-116</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">Jan./Feb.-May/June 2001</subfield><subfield code="p">32101044799086</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907270006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 99-101</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">July-Nov. 1998</subfield><subfield code="p">32101037117973</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907290006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 93-95</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">July-Nov. 1997</subfield><subfield code="p">32101033765452</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261906790006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 144</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">Jan/Feb 2006</subfield><subfield code="p">32101085146627</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907010006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 12, no. 1-3</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 49-51; Feb.-June 1990</subfield><subfield code="p">32101024132449</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261906950006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 10, no. 4-6</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 40-42; Aug.-Dec. 1988</subfield><subfield code="p">32101014612772</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261906860006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 138-140</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">Jan./Feb.-May/June 2005</subfield><subfield code="p">32101060530738</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261906880006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 132-134</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">Jan./Feb.-May/June 2004</subfield><subfield code="p">32101054737976</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907030006421</subfield><subfield code="j">1</subfield><subfield code="3">vol. 11, no. 1-3</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">issue 43-45; Feb.-June 1989</subfield><subfield code="p">32101016294264</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261907050006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 120-122</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">Jan./Feb.-May/June 2002</subfield><subfield code="p">32101047547136</subfield><subfield code="t">1</subfield></datafield><datafield tag="876" ind1=" " ind2=" "><subfield code="0">22261907460006421</subfield><subfield code="a">23261906770006421</subfield><subfield code="j">1</subfield><subfield code="3">issue 179-181 (inc)</subfield><subfield code="d">2020-12-03 01:58:19</subfield><subfield code="4">spring-Autumn 2014</subfield><subfield code="p">32101099861278</subfield><subfield code="t">1</subfield></datafield></record>
+<record>
+  <leader>01585cas a2200421 a 4500</leader>
+  <controlfield tag="005">20200728155602.0</controlfield>
+  <controlfield tag="008">801003c19789999enkbr p 0 0eng d</controlfield>
+  <controlfield tag="001">991213506421</controlfield>
+  <datafield tag="010" ind1="" ind2="">
+    <subfield code="a">80642988</subfield>
+  </datafield>
+  <datafield tag="022" ind1="" ind2="">
+    <subfield code="a">0142-0798</subfield>
+    <subfield code="0">(uri) http://worldcat.org/issn/0142-0798</subfield>
+  </datafield>
+  <datafield tag="035" ind1="" ind2="">
+    <subfield code="a">(OCoLC)5083241</subfield>
+    <subfield code="0">(uri) http://www.worldcat.org/oclc/5083241</subfield>
+  </datafield>
+  <datafield tag="035" ind1="" ind2="">
+    <subfield code="a">(CStRLIN)NJPG0326-S</subfield>
+  </datafield>
+  <datafield tag="035" ind1="" ind2="">
+    <subfield code="9">AAF4355TS</subfield>
+  </datafield>
+  <datafield tag="035" ind1="" ind2="">
+    <subfield code="a">121</subfield>
+  </datafield>
+  <datafield tag="035" ind1="" ind2="">
+    <subfield code="a">(NjP)121-princetondb</subfield>
+  </datafield>
+  <datafield tag="040" ind1="" ind2="">
+    <subfield code="a">DNG-A</subfield>
+    <subfield code="b">eng</subfield>
+    <subfield code="c">DNG-A</subfield>
+    <subfield code="d">CtY</subfield>
+    <subfield code="d">DLC</subfield>
+    <subfield code="d">NjP</subfield>
+  </datafield>
+  <datafield tag="041" ind1="0" ind2="">
+    <subfield code="a">eng</subfield>
+    <subfield code="a">ger</subfield>
+  </datafield>
+  <datafield tag="042" ind1="" ind2="">
+    <subfield code="a">lc</subfield>
+  </datafield>
+  <datafield tag="050" ind1="0" ind2="0">
+    <subfield code="a">NK2808</subfield>
+    <subfield code="b">.H17</subfield>
+  </datafield>
+  <datafield tag="245" ind1="0" ind2="0">
+    <subfield code="a">HALI :</subfield>
+    <subfield code="b">the international journal of Oriental carpets and textiles.</subfield>
+  </datafield>
+  <datafield tag="260" ind1="" ind2="">
+    <subfield code="a">London :</subfield>
+    <subfield code="b">Oguz Press,</subfield>
+    <subfield code="c">1978-</subfield>
+  </datafield>
+  <datafield tag="300" ind1="" ind2="">
+    <subfield code="a">v. :</subfield>
+    <subfield code="b">ill. ;</subfield>
+    <subfield code="c">31 cm.</subfield>
+  </datafield>
+  <datafield tag="310" ind1="" ind2="">
+    <subfield code="a">Quarterly,</subfield>
+    <subfield code="b">&lt;2013&gt;-</subfield>
+  </datafield>
+  <datafield tag="321" ind1="" ind2="">
+    <subfield code="a">Quarterly,</subfield>
+    <subfield code="b">1978-1987</subfield>
+  </datafield>
+  <datafield tag="321" ind1="" ind2="">
+    <subfield code="a">Bimonthly,</subfield>
+    <subfield code="b">1988-&lt;2005&gt;</subfield>
+  </datafield>
+  <datafield tag="362" ind1="0" ind2="">
+    <subfield code="a">Vol. 1, no. 1 (spring 1978)-v. 17, no. 6 (Jan./Feb. 1996) ; issue 85 (Mar./Apr. 1996)-</subfield>
+  </datafield>
+  <datafield tag="500" ind1="" ind2="">
+    <subfield code="a">Subtitle varies.</subfield>
+  </datafield>
+  <datafield tag="500" ind1="" ind2="">
+    <subfield code="a">Each issue has also a distinctive title.</subfield>
+  </datafield>
+  <datafield tag="515" ind1="" ind2="">
+    <subfield code="a">Vol. 6, no. 3-v. 17, no. 6 called also issue 23-84; beginning with issue 85, issues carry whole numbering only.</subfield>
+  </datafield>
+  <datafield tag="546" ind1="" ind2="">
+    <subfield code="a">English and German.</subfield>
+  </datafield>
+  <datafield tag="555" ind1="" ind2="">
+    <subfield code="a">Vols. 1 (1978)-17 (1995/96). 1 v.</subfield>
+  </datafield>
+  <datafield tag="588" ind1="" ind2="">
+    <subfield code="a">Description based on: Vol. 2, no. 1 (spring 1979); title from cover.</subfield>
+  </datafield>
+  <datafield tag="588" ind1="" ind2="">
+    <subfield code="a">Latest issue consulted: Issue 175 (spring 2013).</subfield>
+  </datafield>
+  <datafield tag="650" ind1="" ind2="0">
+    <subfield code="a">Rugs, Oriental</subfield>
+    <subfield code="v">Periodicals.</subfield>
+  </datafield>
+  <datafield tag="650" ind1="" ind2="0">
+    <subfield code="a">Textile fabrics, Oriental</subfield>
+    <subfield code="v">Periodicals.</subfield>
+  </datafield>
+  <datafield tag="655" ind1="" ind2="7">
+    <subfield code="a">Periodicals.</subfield>
+    <subfield code="2">lcgft</subfield>
+    <subfield code="0">http://id.loc.gov/authorities/genreForms/gf2014026139</subfield>
+  </datafield>
+  <datafield tag="998" ind1="" ind2="">
+    <subfield code="a">03/30/95</subfield>
+    <subfield code="s">9110</subfield>
+    <subfield code="n">NjP</subfield>
+    <subfield code="w">DCLC80642988S</subfield>
+    <subfield code="d">10/05/81</subfield>
+    <subfield code="c">HS</subfield>
+    <subfield code="b">EE</subfield>
+    <subfield code="i">950330</subfield>
+    <subfield code="l">NJPG</subfield>
+  </datafield>
+  <datafield tag="911" ind1="" ind2="">
+    <subfield code="a">19950425</subfield>
+  </datafield>
+  <datafield tag="912" ind1="" ind2="">
+    <subfield code="a">19990830034636.0</subfield>
+  </datafield>
+  <datafield tag="950" ind1="" ind2="">
+    <subfield code="b">2020-12-02 20:58:19 US/Eastern</subfield>
+    <subfield code="a">false</subfield>
+  </datafield>
+  <datafield tag="852" ind1="0" ind2="1">
+    <subfield code="b">firestone</subfield>
+    <subfield code="c">nec</subfield>
+    <subfield code="h">NK2808</subfield>
+    <subfield code="i">.H17q</subfield>
+    <subfield code="k">Oversize</subfield>
+    <subfield code="8">22261907460006421</subfield>
+  </datafield>
+  <datafield tag="866" ind1="" ind2="0">
+    <subfield code="a">Vol. 1, no. 1 (spring 1978)-v. 17, no. 6 (Jan./Feb. 1996) ; issue 85 (Mar./Apr. 1996)-issue 144 (Jan./Feb. 2006); issue 150 (Jan./Feb. 2007); issue 175 (spring 2013); issue 179 (spring 2014)-issue 181 (autumn 2014)</subfield>
+    <subfield code="8">22261907460006421</subfield>
+  </datafield>
+  <datafield tag="866" ind1="" ind2="0">
+    <subfield code="z">LACKS: v. 2, no. 2; issue 180</subfield>
+    <subfield code="8">22261907460006421</subfield>
+  </datafield>
+  <datafield tag="866" ind1="" ind2="0">
+    <subfield code="z">CURRENT ISSUES IN: Near East Periodicals Collection (PRNE). Firestone</subfield>
+    <subfield code="8">22261907460006421</subfield>
+  </datafield>
+  <datafield tag="868" ind1="" ind2="0">
+    <subfield code="a">Index, v. 1/17</subfield>
+    <subfield code="8">22261907460006421</subfield>
+  </datafield>
+  <datafield tag="952" ind1="" ind2="">
+    <subfield code="a">2020-12-03 01:58:19</subfield>
+    <subfield code="8">22261907460006421</subfield>
+    <subfield code="b">Firestone Library</subfield>
+    <subfield code="c">nec Near East Coll</subfield>
+    <subfield code="e">false</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261906900006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 6, no. 1-2</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">1983-1984</subfield>
+    <subfield code="p">32101014612715</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261906920006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 5, no. 3-4</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">1983</subfield>
+    <subfield code="p">32101014612699</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907450006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">183</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">2012</subfield>
+    <subfield code="p">ISSitm101-2432.760-princetondb</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907240006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 4, no. 1-2</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">1981</subfield>
+    <subfield code="p">32101014612681</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907060006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 111-113</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">July/Aug.-Nov./Dec. 2000</subfield>
+    <subfield code="p">32101039388556</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907080006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 12, no. 4-6</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 52-54; Aug.-Dec. 1990</subfield>
+    <subfield code="p">32101024132431</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907170006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 8, no. 3-4</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 31-32; July/Sept.-Oct./Dec. 1986</subfield>
+    <subfield code="p">32101014612749</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907130006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 3</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">1980-1981</subfield>
+    <subfield code="p">32101014630279</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907150006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 9, no. 3-4</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 35-36; July/Sept.-Oct./Dec. 1987</subfield>
+    <subfield code="p">32101014612798</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907400006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 15, no. 4-6</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 70-72; Aug./Sept. 1993-Dec. 1993/Jan. 1994</subfield>
+    <subfield code="p">32101024303628</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907420006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 14, no. 4-6</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 64-66; Aug.-Dec. 1992</subfield>
+    <subfield code="p">32101022760753</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907440006421</subfield>
+    <subfield code="j">0</subfield>
+    <subfield code="3">184</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">2012</subfield>
+    <subfield code="p">ISSitm2432.770-princetondb</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907280006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 96-98</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">Jan.-May 1998</subfield>
+    <subfield code="p">32101037117965</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907190006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 7, no. 3-4</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 27-28; July/Sept.-Oct./Dec. 1985</subfield>
+    <subfield code="p">32101014612764</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907200006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 7, no. 1-2</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 25-26; Jan.-Apr./June 1985</subfield>
+    <subfield code="p">32101014612756</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261906980006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 10, no. 1-3</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 37-39; Jan./Feb.-May/June 1988</subfield>
+    <subfield code="p">32101014612806</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907350006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 84-86</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">Jan./Feb.-May 1996</subfield>
+    <subfield code="p">32101024588467</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907370006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 79-81</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">vol. 17, no. 1-3; Feb./Mar.-June/July 1995</subfield>
+    <subfield code="p">32101080904475</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907260006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 117-119</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">July/Aug.-Nov./Dec. 2001</subfield>
+    <subfield code="p">32101044801387</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907310006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 90-92</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">Jan.-May 1997</subfield>
+    <subfield code="p">32101033765445</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907220006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 126-128</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">Jan./Feb.-May/June 2003</subfield>
+    <subfield code="p">32101050543139</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261906870006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 135-137</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">July/Aug.-Nov./Dec. 2004</subfield>
+    <subfield code="p">32101059702140</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907000006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 13, no. 1-3</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 55-57; Feb.-June 1991</subfield>
+    <subfield code="p">32101021888985</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261906780006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 150</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">Jan/Feb 2007</subfield>
+    <subfield code="p">32101085146635</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261906940006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 4, no. 3-4</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">1982</subfield>
+    <subfield code="p">32101014612673</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261906890006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 6, no. 3-4</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 23-24; 1984</subfield>
+    <subfield code="p">32101014612723</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261906830006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 141-143</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">July/Aug.-Nov./Dec. 2005</subfield>
+    <subfield code="p">32101060531801</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907040006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 123-125</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">July/Aug.-Nov./Dec. 2002</subfield>
+    <subfield code="p">32101047547243</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907020006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 11, no. 4-6</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 46-48; Aug.-Dec. 1989</subfield>
+    <subfield code="p">32101016294272</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261906800006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 82-83</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">vol. 17, no. 4-5; Aug./Sept.-Oct./Nov. 1995</subfield>
+    <subfield code="p">32101080904541</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261906810006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 175</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">spring 2013</subfield>
+    <subfield code="p">32101085141941</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907390006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 16, no. 1-2</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 73-74; Feb./Mar.-Apr. 1994</subfield>
+    <subfield code="p">32101028666939</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907380006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 16, no. 3-4</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 75-76; June/July-Aug./Sept. 1994</subfield>
+    <subfield code="p">32101028666947</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907160006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 9, no. 1-2</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 33-34; Jan./Mar.-Apr./June 1987</subfield>
+    <subfield code="p">32101014612780</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907410006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 15, no. 1-3</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 67-69; Feb./Mar.-June/July 1993</subfield>
+    <subfield code="p">32101024303636</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907070006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 108-110</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">Jan./Feb.-May/June 2000</subfield>
+    <subfield code="p">32101039388549</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907340006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 87-89</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">July-Nov. 1996</subfield>
+    <subfield code="p">32101024588475</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907090006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 105-107</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">July/Aug.-Nov./Dec. 1999</subfield>
+    <subfield code="p">32101038939375</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907140006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 2 (inc.)</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">1979-1980</subfield>
+    <subfield code="p">32101014630428</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907430006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 14, no. 1-3</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 61-63; Feb.-June 1992</subfield>
+    <subfield code="p">32101022760746</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907180006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 8, no. 1-2</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 29-30; Jan./Mar.-Apr./June 1986</subfield>
+    <subfield code="p">32101014612731</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261906990006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 13, no. 4-6</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 58-60; Aug.-Dec. 1991</subfield>
+    <subfield code="p">32101021888977</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907120006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 102-104</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">Jan.-May/June 1999</subfield>
+    <subfield code="p">32101038939367</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907210006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 129-131</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">July/Aug.-Nov./Dec. 2003</subfield>
+    <subfield code="p">32101050543345</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907360006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">Index, v. 1/17</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 1/84; 1978/95</subfield>
+    <subfield code="p">32101024588707</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907230006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 5, no. 1-2</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">1982</subfield>
+    <subfield code="p">32101014612707</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907250006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 114-116</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">Jan./Feb.-May/June 2001</subfield>
+    <subfield code="p">32101044799086</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907270006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 99-101</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">July-Nov. 1998</subfield>
+    <subfield code="p">32101037117973</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907290006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 93-95</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">July-Nov. 1997</subfield>
+    <subfield code="p">32101033765452</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261906790006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 144</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">Jan/Feb 2006</subfield>
+    <subfield code="p">32101085146627</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907010006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 12, no. 1-3</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 49-51; Feb.-June 1990</subfield>
+    <subfield code="p">32101024132449</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261906950006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 10, no. 4-6</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 40-42; Aug.-Dec. 1988</subfield>
+    <subfield code="p">32101014612772</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261906860006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 138-140</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">Jan./Feb.-May/June 2005</subfield>
+    <subfield code="p">32101060530738</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261906880006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 132-134</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">Jan./Feb.-May/June 2004</subfield>
+    <subfield code="p">32101054737976</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907030006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">vol. 11, no. 1-3</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">issue 43-45; Feb.-June 1989</subfield>
+    <subfield code="p">32101016294264</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261907050006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 120-122</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">Jan./Feb.-May/June 2002</subfield>
+    <subfield code="p">32101047547136</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+  <datafield tag="876" ind1="" ind2="">
+    <subfield code="0">22261907460006421</subfield>
+    <subfield code="a">23261906770006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="3">issue 179-181 (inc)</subfield>
+    <subfield code="d">2020-12-03 01:58:19</subfield>
+    <subfield code="4">spring-Autumn 2014</subfield>
+    <subfield code="p">32101099861278</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+</record>

--- a/spec/fixtures/marc_to_solr/alma/99122306151806421.mrx
+++ b/spec/fixtures/marc_to_solr/alma/99122306151806421.mrx
@@ -1,1 +1,442 @@
-<record><leader>02646nas a2200673 i 4500</leader><controlfield tag="001">99122306151806421</controlfield><controlfield tag="005">20201203154027.0</controlfield><controlfield tag="006">m---- o--d- ------</controlfield><controlfield tag="007">cr-mnu||||||||</controlfield><controlfield tag="008">010606c18699999enkwr-pso     0---b0eng c</controlfield><datafield tag="010" ind1=" " ind2=" "><subfield code="a">  2005233250</subfield></datafield><datafield tag="016" ind1="7" ind2=" "><subfield code="a">N07600000</subfield><subfield code="2">DNLM</subfield></datafield><datafield tag="016" ind1="7" ind2=" "><subfield code="a">012434483</subfield><subfield code="2">Uk</subfield></datafield><datafield tag="016" ind1="7" ind2=" "><subfield code="a">014374374</subfield><subfield code="2">Uk</subfield></datafield><datafield tag="022" ind1=" " ind2=" "><subfield code="a">1476-4687</subfield></datafield><datafield tag="030" ind1=" " ind2=" "><subfield code="a">NATUAS</subfield></datafield><datafield tag="035" ind1=" " ind2=" "><subfield code="a">(DE-599)ZDB1413423 8</subfield></datafield><datafield tag="035" ind1=" " ind2=" "><subfield code="a">(OCoLC)47076528</subfield><subfield code="0">(uri) http://www.worldcat.org/oclc/47076528</subfield></datafield><datafield tag="035" ind1=" " ind2=" "><subfield code="a">(CKB)954925427238</subfield></datafield><datafield tag="035" ind1=" " ind2=" "><subfield code="a">(CONSER)--2005233250</subfield></datafield><datafield tag="035" ind1=" " ind2=" "><subfield code="a">(EXLCZ)99954925427238</subfield></datafield><datafield tag="042" ind1=" " ind2=" "><subfield code="a">pcc</subfield><subfield code="a">dlr</subfield><subfield code="d">UK-SaU</subfield><subfield code="e">rda</subfield></datafield><datafield tag="050" ind1="0" ind2="0"><subfield code="a">Q1</subfield></datafield><datafield tag="060" ind1="0" ind2=" "><subfield code="a">W1 NA81</subfield></datafield><datafield tag="130" ind1="0" ind2=" "><subfield code="a">Nature (Online)</subfield></datafield><datafield tag="210" ind1=" " ind2=" "><subfield code="a">NATURE (LOND)</subfield></datafield><datafield tag="210" ind1="1" ind2=" "><subfield code="a">Nature</subfield><subfield code="b">(Basingstoke, Online)</subfield></datafield><datafield tag="222" ind1=" " ind2="0"><subfield code="a">Nature</subfield><subfield code="b">(Basingstoke. Online)</subfield></datafield><datafield tag="245" ind1="1" ind2="0"><subfield code="a">Nature.</subfield></datafield><datafield tag="264" ind1=" " ind2="1"><subfield code="a">London :</subfield><subfield code="b">Springer Nature.</subfield></datafield><datafield tag="310" ind1=" " ind2=" "><subfield code="a">Weekly</subfield></datafield><datafield tag="336" ind1=" " ind2=" "><subfield code="a">text</subfield><subfield code="b">txt</subfield><subfield code="2">rdacontent</subfield></datafield><datafield tag="337" ind1=" " ind2=" "><subfield code="a">computer</subfield><subfield code="b">c</subfield><subfield code="2">rdamedia</subfield></datafield><datafield tag="338" ind1=" " ind2=" "><subfield code="a">online resource</subfield><subfield code="b">cr</subfield><subfield code="2">rdacarrier</subfield></datafield><datafield tag="362" ind1="1" ind2=" "><subfield code="a">Print began with v. 1 (Nov. 4, 1869).</subfield></datafield><datafield tag="500" ind1=" " ind2=" "><subfield code="a">Weekly international journal publishing peer-reviewed research in all fields of science and technology.</subfield></datafield><datafield tag="506" ind1=" " ind2=" "><subfield code="3">Use copy</subfield><subfield code="f">Restrictions unspecified</subfield><subfield code="2">star</subfield><subfield code="5">MiAaHDL</subfield></datafield><datafield tag="533" ind1=" " ind2=" "><subfield code="a">Electronic reproduction.</subfield><subfield code="b">[Place of publication not identified] :</subfield><subfield code="c">HathiTrust Digital Library,</subfield><subfield code="d">2010.</subfield><subfield code="5">MiAaHDL</subfield></datafield><datafield tag="538" ind1=" " ind2=" "><subfield code="a">Master and use copy. Digital master created according to Benchmark for Faithful Digital Reproductions of Monographs and Serials, Version 1. Digital Library Federation, December 2002.</subfield><subfield code="u">http://purl.oclc.org/DLF/benchrepro0212</subfield><subfield code="5">MiAaHDL</subfield></datafield><datafield tag="538" ind1=" " ind2=" "><subfield code="a">Mode of access: World Wide Web.</subfield></datafield><datafield tag="583" ind1="1" ind2=" "><subfield code="a">digitized</subfield><subfield code="c">2010</subfield><subfield code="h">HathiTrust Digital Library</subfield><subfield code="l">committed to preserve</subfield><subfield code="2">pda</subfield><subfield code="5">MiAaHDL</subfield></datafield><datafield tag="588" ind1="0" ind2=" "><subfield code="a">Vol. 385, no. 6612 (Jan. 9, 1997); title from journal homepage (publisher's Web site, viewed Sept. 28, 2005).</subfield></datafield><datafield tag="588" ind1="1" ind2=" "><subfield code="a">Vol. 576, no. 7787 (19 Dec. 2019) (SpringerLink website, viewed Dec. 30, 2019).</subfield></datafield><datafield tag="650" ind1=" " ind2="0"><subfield code="a">Science</subfield><subfield code="v">Periodicals.</subfield></datafield><datafield tag="650" ind1=" " ind2="2"><subfield code="a">Science.</subfield></datafield><datafield tag="650" ind1=" " ind2="6"><subfield code="a">Sciences</subfield><subfield code="v">Periodicals.</subfield></datafield><datafield tag="650" ind1=" " ind2="6"><subfield code="a">Biology</subfield><subfield code="v">Periodicals.</subfield></datafield><datafield tag="650" ind1=" " ind2="6"><subfield code="a">Physique</subfield><subfield code="v">Periodicals.</subfield></datafield><datafield tag="650" ind1=" " ind2="7"><subfield code="a">Science.</subfield><subfield code="2">fast</subfield><subfield code="0">(OCoLC)fst01108176</subfield></datafield><datafield tag="650" ind1="1" ind2="7"><subfield code="a">NATURAL HISTORY.</subfield><subfield code="2">unbist</subfield></datafield><datafield tag="650" ind1="1" ind2="7"><subfield code="a">BIOLOGY.</subfield><subfield code="2">unbist</subfield></datafield><datafield tag="650" ind1="1" ind2="7"><subfield code="a">SCIENCE.</subfield><subfield code="2">unbist</subfield></datafield><datafield tag="655" ind1=" " ind2="0"><subfield code="a">Electronic journals.</subfield></datafield><datafield tag="655" ind1=" " ind2="2"><subfield code="a">Periodical.</subfield></datafield><datafield tag="655" ind1=" " ind2="7"><subfield code="a">Periodicals.</subfield><subfield code="2">fast</subfield><subfield code="0">(OCoLC)fst01411641</subfield></datafield><datafield tag="776" ind1="1" ind2=" "><subfield code="x">0028-0836</subfield><subfield code="0">(uri) http://worldcat.org/issn/0028-0836</subfield></datafield><datafield tag="780" ind1="0" ind2="6"><subfield code="t">Nature New Biology</subfield><subfield code="w">(CKB)954927601631</subfield><subfield code="w">(DLC)72026185</subfield><subfield code="x">2058-1092</subfield></datafield><datafield tag="780" ind1="0" ind2="5"><subfield code="t">Nature Physical Science</subfield><subfield code="w">(CKB)958480240332</subfield><subfield code="x">2058-1106</subfield></datafield><datafield tag="710" ind1="2" ind2=" "><subfield code="a">Nature Publishing Group</subfield><subfield code="e">issuing body</subfield></datafield><datafield tag="906" ind1=" " ind2=" "><subfield code="a">JOURNAL</subfield></datafield><datafield tag="950" ind1=" " ind2=" "><subfield code="c">2020-12-03 08:40:27 US/Eastern</subfield><subfield code="b">2012-02-25 17:34:55 US/Eastern</subfield><subfield code="a">false</subfield></datafield><datafield tag="951" ind1=" " ind2=" "><subfield code="v">2020-12-14 04:40:40 US/Eastern</subfield><subfield code="g">Nature</subfield><subfield code="u">System</subfield><subfield code="t">2020-12-14 04:40:34 US/Eastern</subfield><subfield code="x">https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53443322610006421&amp;Force_direct=true</subfield><subfield code="s">SFX</subfield><subfield code="0">53443322610006421</subfield><subfield code="k"> Available from 1869 volume: 1 issue: 1.</subfield><subfield code="f">true</subfield><subfield code="m">61428536390006421</subfield><subfield code="n">Nature</subfield><subfield code="b">param</subfield><subfield code="1">62428550710006421</subfield><subfield code="c">d?u.ignore_date_coverage=true&amp;rft.mms_id=99122306151806421</subfield><subfield code="a">Available</subfield><subfield code="l">61110974981369253</subfield><subfield code="e">JOURNAL</subfield><subfield code="8">53443322610006421</subfield></datafield><datafield tag="953" ind1=" " ind2=" "><subfield code="a">53443322610006421</subfield><subfield code="b">1869</subfield><subfield code="d">1</subfield><subfield code="f">1</subfield><subfield code="h">1</subfield><subfield code="j">1</subfield></datafield><datafield tag="951" ind1=" " ind2=" "><subfield code="v">2020-12-14 04:40:40 US/Eastern</subfield><subfield code="g">EBSCOhost</subfield><subfield code="u">System</subfield><subfield code="t">2020-12-14 04:40:34 US/Eastern</subfield><subfield code="x">https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53443322590006421&amp;Force_direct=true</subfield><subfield code="s">SFX</subfield><subfield code="0">53443322590006421</subfield><subfield code="k"> Available from 06/05/1997 until 11/27/2015.</subfield><subfield code="f">true</subfield><subfield code="m">61428535800006421</subfield><subfield code="n">EBSCOhost MasterFILE Elite</subfield><subfield code="b">param</subfield><subfield code="1">62428550700006421</subfield><subfield code="c">d?u.ignore_date_coverage=true&amp;rft.mms_id=99122306151806421</subfield><subfield code="a">Available</subfield><subfield code="l">61110976112790155</subfield><subfield code="e">JOURNAL</subfield><subfield code="8">53443322590006421</subfield></datafield><datafield tag="953" ind1=" " ind2=" "><subfield code="a">53443322590006421</subfield><subfield code="b">1997</subfield><subfield code="c">2015</subfield><subfield code="d">6</subfield><subfield code="e">11</subfield><subfield code="f">5</subfield><subfield code="g">27</subfield></datafield><datafield tag="951" ind1=" " ind2=" "><subfield code="v">2020-12-14 04:40:40 US/Eastern</subfield><subfield code="g">EBSCOhost</subfield><subfield code="u">System</subfield><subfield code="t">2020-12-14 04:40:34 US/Eastern</subfield><subfield code="x">https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53443322580006421&amp;Force_direct=true</subfield><subfield code="s">SFX</subfield><subfield code="0">53443322580006421</subfield><subfield code="k"> Available from 1997 until 2015.</subfield><subfield code="f">true</subfield><subfield code="m">61428537640006421</subfield><subfield code="n">EBSCOhost Academic Search Ultimate</subfield><subfield code="b">param</subfield><subfield code="1">62428558560006421</subfield><subfield code="c">d?u.ignore_date_coverage=true&amp;rft.mms_id=99122306151806421</subfield><subfield code="a">Available</subfield><subfield code="l">614340000000000211</subfield><subfield code="e">JOURNAL</subfield><subfield code="8">53443322580006421</subfield></datafield><datafield tag="953" ind1=" " ind2=" "><subfield code="a">53443322580006421</subfield><subfield code="b">1997</subfield><subfield code="c">2015</subfield><subfield code="d">1</subfield><subfield code="e">12</subfield><subfield code="f">1</subfield><subfield code="g">31</subfield></datafield><datafield tag="951" ind1=" " ind2=" "><subfield code="v">2020-12-14 04:40:40 US/Eastern</subfield><subfield code="g">ProQuest</subfield><subfield code="u">System</subfield><subfield code="t">2020-12-14 04:40:34 US/Eastern</subfield><subfield code="x">https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53443322630006421&amp;Force_direct=true</subfield><subfield code="s">SFX</subfield><subfield code="0">53443322630006421</subfield><subfield code="k"> Available from 01/04/1990. Most recent 1 year(s) not available.</subfield><subfield code="f">true</subfield><subfield code="m">61428538600006421</subfield><subfield code="n">ProQuest Central</subfield><subfield code="b">param</subfield><subfield code="1">62428551430006421</subfield><subfield code="c">d?u.ignore_date_coverage=true&amp;rft.mms_id=99122306151806421</subfield><subfield code="a">Available</subfield><subfield code="l">613790000000000466</subfield><subfield code="e">JOURNAL</subfield><subfield code="8">53443322630006421</subfield></datafield><datafield tag="953" ind1=" " ind2=" "><subfield code="a">53443322630006421</subfield><subfield code="b">1990</subfield><subfield code="d">1</subfield><subfield code="f">4</subfield></datafield><datafield tag="954" ind1=" " ind2=" "><subfield code="a">53443322630006421</subfield><subfield code="b">&gt;=</subfield><subfield code="c">1</subfield></datafield><datafield tag="951" ind1=" " ind2=" "><subfield code="v">2020-12-14 04:40:40 US/Eastern</subfield><subfield code="g">Free E- Journals</subfield><subfield code="u">System</subfield><subfield code="t">2020-12-14 04:40:34 US/Eastern</subfield><subfield code="x">https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53443322600006421&amp;Force_direct=true</subfield><subfield code="s">SFX</subfield><subfield code="0">53443322600006421</subfield><subfield code="k"> Available from 1869 volume: 1 issue: 1 until 1875 volume: 12 issue: 313.</subfield><subfield code="f">false</subfield><subfield code="m">61428542400006421</subfield><subfield code="n">free eJournals</subfield><subfield code="b">param</subfield><subfield code="1">62428556870006421</subfield><subfield code="c">d?u.ignore_date_coverage=true&amp;rft.mms_id=99122306151806421</subfield><subfield code="a">Available</subfield><subfield code="l">61110976638852340</subfield><subfield code="e">JOURNAL</subfield><subfield code="8">53443322600006421</subfield></datafield><datafield tag="953" ind1=" " ind2=" "><subfield code="a">53443322600006421</subfield><subfield code="b">1869</subfield><subfield code="c">1875</subfield><subfield code="d">1</subfield><subfield code="e">12</subfield><subfield code="f">1</subfield><subfield code="g">31</subfield><subfield code="h">1</subfield><subfield code="i">12</subfield><subfield code="j">1</subfield><subfield code="k">313</subfield></datafield><datafield tag="951" ind1=" " ind2=" "><subfield code="v">2020-12-14 04:40:40 US/Eastern</subfield><subfield code="g">PressReader</subfield><subfield code="u">System</subfield><subfield code="j">lacks title-specific thresholds; target-level threshold set for latest 1 year, shortest period available (actual threshold in most cases is only a few months) --nb, 12/17</subfield><subfield code="t">2020-12-14 04:40:34 US/Eastern</subfield><subfield code="x">https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53443322620006421&amp;Force_direct=true</subfield><subfield code="s">SFX</subfield><subfield code="0">53443322620006421</subfield><subfield code="f">true</subfield><subfield code="m">61428541610006421</subfield><subfield code="n">PressReader</subfield><subfield code="b">param</subfield><subfield code="1">62428545810006421</subfield><subfield code="c">d?u.ignore_date_coverage=true&amp;rft.mms_id=99122306151806421</subfield><subfield code="a">Available</subfield><subfield code="l">611000000000002086</subfield><subfield code="e">JOURNAL</subfield><subfield code="8">53443322620006421</subfield></datafield><datafield tag="951" ind1=" " ind2=" "><subfield code="v">2020-12-14 04:40:40 US/Eastern</subfield><subfield code="g">ProQuest</subfield><subfield code="u">System</subfield><subfield code="t">2020-12-14 04:40:34 US/Eastern</subfield><subfield code="x">https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53443322640006421&amp;Force_direct=true</subfield><subfield code="s">SFX</subfield><subfield code="0">53443322640006421</subfield><subfield code="k"> Available from 01/04/1990. Most recent 1 year(s) not available.</subfield><subfield code="f">true</subfield><subfield code="m">61428538710006421</subfield><subfield code="n">SciTech Premium Collection</subfield><subfield code="b">param</subfield><subfield code="1">62428551050006421</subfield><subfield code="c">d?u.ignore_date_coverage=true&amp;rft.mms_id=99122306151806421</subfield><subfield code="a">Available</subfield><subfield code="l">613790000000000496</subfield><subfield code="e">JOURNAL</subfield><subfield code="8">53443322640006421</subfield></datafield><datafield tag="953" ind1=" " ind2=" "><subfield code="a">53443322640006421</subfield><subfield code="b">1990</subfield><subfield code="d">1</subfield><subfield code="f">4</subfield></datafield><datafield tag="954" ind1=" " ind2=" "><subfield code="a">53443322640006421</subfield><subfield code="b">&gt;=</subfield><subfield code="c">1</subfield></datafield><datafield tag="951" ind1=" " ind2=" "><subfield code="v">2020-12-14 04:40:40 US/Eastern</subfield><subfield code="g">Biodiversity Heritage Library</subfield><subfield code="u">System</subfield><subfield code="j">open access</subfield><subfield code="t">2020-12-14 04:40:34 US/Eastern</subfield><subfield code="x">https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53443322570006421&amp;Force_direct=true</subfield><subfield code="s">SFX</subfield><subfield code="0">53443322570006421</subfield><subfield code="k"> Available from 1869 until 1923.</subfield><subfield code="f">false</subfield><subfield code="m">61428538230006421</subfield><subfield code="n">Biodiversity Heritage Library Free</subfield><subfield code="b">param</subfield><subfield code="1">62428552660006421</subfield><subfield code="c">d?u.ignore_date_coverage=true&amp;rft.mms_id=99122306151806421</subfield><subfield code="a">Available</subfield><subfield code="l">613780000000001162</subfield><subfield code="e">JOURNAL</subfield><subfield code="8">53443322570006421</subfield></datafield><datafield tag="953" ind1=" " ind2=" "><subfield code="a">53443322570006421</subfield><subfield code="b">1869</subfield><subfield code="c">1923</subfield><subfield code="d">1</subfield><subfield code="e">12</subfield><subfield code="f">1</subfield><subfield code="g">31</subfield></datafield></record>
+<record>
+  <leader>02646nas a2200673 i 4500</leader>
+  <controlfield tag="001">99122306151806421</controlfield>
+  <controlfield tag="005">20201203154027.0</controlfield>
+  <controlfield tag="006">m---- o--d- ------</controlfield>
+  <controlfield tag="007">cr-mnu||||||||</controlfield>
+  <controlfield tag="008">010606c18699999enkwr-pso 0---b0eng c</controlfield>
+  <datafield tag="010" ind1="" ind2="">
+    <subfield code="a">2005233250</subfield>
+  </datafield>
+  <datafield tag="016" ind1="7" ind2="">
+    <subfield code="a">N07600000</subfield>
+    <subfield code="2">DNLM</subfield>
+  </datafield>
+  <datafield tag="016" ind1="7" ind2="">
+    <subfield code="a">012434483</subfield>
+    <subfield code="2">Uk</subfield>
+  </datafield>
+  <datafield tag="016" ind1="7" ind2="">
+    <subfield code="a">014374374</subfield>
+    <subfield code="2">Uk</subfield>
+  </datafield>
+  <datafield tag="022" ind1="" ind2="">
+    <subfield code="a">1476-4687</subfield>
+  </datafield>
+  <datafield tag="030" ind1="" ind2="">
+    <subfield code="a">NATUAS</subfield>
+  </datafield>
+  <datafield tag="035" ind1="" ind2="">
+    <subfield code="a">(DE-599)ZDB1413423 8</subfield>
+  </datafield>
+  <datafield tag="035" ind1="" ind2="">
+    <subfield code="a">(OCoLC)47076528</subfield>
+    <subfield code="0">(uri) http://www.worldcat.org/oclc/47076528</subfield>
+  </datafield>
+  <datafield tag="035" ind1="" ind2="">
+    <subfield code="a">(CKB)954925427238</subfield>
+  </datafield>
+  <datafield tag="035" ind1="" ind2="">
+    <subfield code="a">(CONSER)--2005233250</subfield>
+  </datafield>
+  <datafield tag="035" ind1="" ind2="">
+    <subfield code="a">(EXLCZ)99954925427238</subfield>
+  </datafield>
+  <datafield tag="042" ind1="" ind2="">
+    <subfield code="a">pcc</subfield>
+    <subfield code="a">dlr</subfield>
+    <subfield code="d">UK-SaU</subfield>
+    <subfield code="e">rda</subfield>
+  </datafield>
+  <datafield tag="050" ind1="0" ind2="0">
+    <subfield code="a">Q1</subfield>
+  </datafield>
+  <datafield tag="060" ind1="0" ind2="">
+    <subfield code="a">W1 NA81</subfield>
+  </datafield>
+  <datafield tag="130" ind1="0" ind2="">
+    <subfield code="a">Nature (Online)</subfield>
+  </datafield>
+  <datafield tag="210" ind1="" ind2="">
+    <subfield code="a">NATURE (LOND)</subfield>
+  </datafield>
+  <datafield tag="210" ind1="1" ind2="">
+    <subfield code="a">Nature</subfield>
+    <subfield code="b">(Basingstoke, Online)</subfield>
+  </datafield>
+  <datafield tag="222" ind1="" ind2="0">
+    <subfield code="a">Nature</subfield>
+    <subfield code="b">(Basingstoke. Online)</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Nature.</subfield>
+  </datafield>
+  <datafield tag="264" ind1="" ind2="1">
+    <subfield code="a">London :</subfield>
+    <subfield code="b">Springer Nature.</subfield>
+  </datafield>
+  <datafield tag="310" ind1="" ind2="">
+    <subfield code="a">Weekly</subfield>
+  </datafield>
+  <datafield tag="336" ind1="" ind2="">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1="" ind2="">
+    <subfield code="a">computer</subfield>
+    <subfield code="b">c</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1="" ind2="">
+    <subfield code="a">online resource</subfield>
+    <subfield code="b">cr</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="362" ind1="1" ind2="">
+    <subfield code="a">Print began with v. 1 (Nov. 4, 1869).</subfield>
+  </datafield>
+  <datafield tag="500" ind1="" ind2="">
+    <subfield code="a">Weekly international journal publishing peer-reviewed research in all fields of science and technology.</subfield>
+  </datafield>
+  <datafield tag="506" ind1="" ind2="">
+    <subfield code="3">Use copy</subfield>
+    <subfield code="f">Restrictions unspecified</subfield>
+    <subfield code="2">star</subfield>
+    <subfield code="5">MiAaHDL</subfield>
+  </datafield>
+  <datafield tag="533" ind1="" ind2="">
+    <subfield code="a">Electronic reproduction.</subfield>
+    <subfield code="b">[Place of publication not identified] :</subfield>
+    <subfield code="c">HathiTrust Digital Library,</subfield>
+    <subfield code="d">2010.</subfield>
+    <subfield code="5">MiAaHDL</subfield>
+  </datafield>
+  <datafield tag="538" ind1="" ind2="">
+    <subfield code="a">Master and use copy. Digital master created according to Benchmark for Faithful Digital Reproductions of Monographs and Serials, Version 1. Digital Library Federation, December 2002.</subfield>
+    <subfield code="u">http://purl.oclc.org/DLF/benchrepro0212</subfield>
+    <subfield code="5">MiAaHDL</subfield>
+  </datafield>
+  <datafield tag="538" ind1="" ind2="">
+    <subfield code="a">Mode of access: World Wide Web.</subfield>
+  </datafield>
+  <datafield tag="583" ind1="1" ind2="">
+    <subfield code="a">digitized</subfield>
+    <subfield code="c">2010</subfield>
+    <subfield code="h">HathiTrust Digital Library</subfield>
+    <subfield code="l">committed to preserve</subfield>
+    <subfield code="2">pda</subfield>
+    <subfield code="5">MiAaHDL</subfield>
+  </datafield>
+  <datafield tag="588" ind1="0" ind2="">
+    <subfield code="a">Vol. 385, no. 6612 (Jan. 9, 1997); title from journal homepage (publisher's Web site, viewed Sept. 28, 2005).</subfield>
+  </datafield>
+  <datafield tag="588" ind1="1" ind2="">
+    <subfield code="a">Vol. 576, no. 7787 (19 Dec. 2019) (SpringerLink website, viewed Dec. 30, 2019).</subfield>
+  </datafield>
+  <datafield tag="650" ind1="" ind2="0">
+    <subfield code="a">Science</subfield>
+    <subfield code="v">Periodicals.</subfield>
+  </datafield>
+  <datafield tag="650" ind1="" ind2="2">
+    <subfield code="a">Science.</subfield>
+  </datafield>
+  <datafield tag="650" ind1="" ind2="6">
+    <subfield code="a">Sciences</subfield>
+    <subfield code="v">Periodicals.</subfield>
+  </datafield>
+  <datafield tag="650" ind1="" ind2="6">
+    <subfield code="a">Biology</subfield>
+    <subfield code="v">Periodicals.</subfield>
+  </datafield>
+  <datafield tag="650" ind1="" ind2="6">
+    <subfield code="a">Physique</subfield>
+    <subfield code="v">Periodicals.</subfield>
+  </datafield>
+  <datafield tag="650" ind1="" ind2="7">
+    <subfield code="a">Science.</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst01108176</subfield>
+  </datafield>
+  <datafield tag="650" ind1="1" ind2="7">
+    <subfield code="a">NATURAL HISTORY.</subfield>
+    <subfield code="2">unbist</subfield>
+  </datafield>
+  <datafield tag="650" ind1="1" ind2="7">
+    <subfield code="a">BIOLOGY.</subfield>
+    <subfield code="2">unbist</subfield>
+  </datafield>
+  <datafield tag="650" ind1="1" ind2="7">
+    <subfield code="a">SCIENCE.</subfield>
+    <subfield code="2">unbist</subfield>
+  </datafield>
+  <datafield tag="655" ind1="" ind2="0">
+    <subfield code="a">Electronic journals.</subfield>
+  </datafield>
+  <datafield tag="655" ind1="" ind2="2">
+    <subfield code="a">Periodical.</subfield>
+  </datafield>
+  <datafield tag="655" ind1="" ind2="7">
+    <subfield code="a">Periodicals.</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst01411641</subfield>
+  </datafield>
+  <datafield tag="776" ind1="1" ind2="">
+    <subfield code="x">0028-0836</subfield>
+    <subfield code="0">(uri) http://worldcat.org/issn/0028-0836</subfield>
+  </datafield>
+  <datafield tag="780" ind1="0" ind2="6">
+    <subfield code="t">Nature New Biology</subfield>
+    <subfield code="w">(CKB)954927601631</subfield>
+    <subfield code="w">(DLC)72026185</subfield>
+    <subfield code="x">2058-1092</subfield>
+  </datafield>
+  <datafield tag="780" ind1="0" ind2="5">
+    <subfield code="t">Nature Physical Science</subfield>
+    <subfield code="w">(CKB)958480240332</subfield>
+    <subfield code="x">2058-1106</subfield>
+  </datafield>
+  <datafield tag="710" ind1="2" ind2="">
+    <subfield code="a">Nature Publishing Group</subfield>
+    <subfield code="e">issuing body</subfield>
+  </datafield>
+  <datafield tag="906" ind1="" ind2="">
+    <subfield code="a">JOURNAL</subfield>
+  </datafield>
+  <datafield tag="950" ind1="" ind2="">
+    <subfield code="c">2020-12-03 08:40:27 US/Eastern</subfield>
+    <subfield code="b">2012-02-25 17:34:55 US/Eastern</subfield>
+    <subfield code="a">false</subfield>
+  </datafield>
+  <datafield tag="951" ind1="" ind2="">
+    <subfield code="v">2020-12-14 04:40:40 US/Eastern</subfield>
+    <subfield code="g">Nature</subfield>
+    <subfield code="u">System</subfield>
+    <subfield code="t">2020-12-14 04:40:34 US/Eastern</subfield>
+    <subfield code="x">https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53443322610006421&amp;Force_direct=true</subfield>
+    <subfield code="s">SFX</subfield>
+    <subfield code="0">53443322610006421</subfield>
+    <subfield code="k">Available from 1869 volume: 1 issue: 1.</subfield>
+    <subfield code="f">true</subfield>
+    <subfield code="m">61428536390006421</subfield>
+    <subfield code="n">Nature</subfield>
+    <subfield code="b">param</subfield>
+    <subfield code="1">62428550710006421</subfield>
+    <subfield code="c">d?u.ignore_date_coverage=true&amp;rft.mms_id=99122306151806421</subfield>
+    <subfield code="a">Available</subfield>
+    <subfield code="l">61110974981369253</subfield>
+    <subfield code="e">JOURNAL</subfield>
+    <subfield code="8">53443322610006421</subfield>
+  </datafield>
+  <datafield tag="953" ind1="" ind2="">
+    <subfield code="a">53443322610006421</subfield>
+    <subfield code="b">1869</subfield>
+    <subfield code="d">1</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="h">1</subfield>
+    <subfield code="j">1</subfield>
+  </datafield>
+  <datafield tag="951" ind1="" ind2="">
+    <subfield code="v">2020-12-14 04:40:40 US/Eastern</subfield>
+    <subfield code="g">EBSCOhost</subfield>
+    <subfield code="u">System</subfield>
+    <subfield code="t">2020-12-14 04:40:34 US/Eastern</subfield>
+    <subfield code="x">https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53443322590006421&amp;Force_direct=true</subfield>
+    <subfield code="s">SFX</subfield>
+    <subfield code="0">53443322590006421</subfield>
+    <subfield code="k">Available from 06/05/1997 until 11/27/2015.</subfield>
+    <subfield code="f">true</subfield>
+    <subfield code="m">61428535800006421</subfield>
+    <subfield code="n">EBSCOhost MasterFILE Elite</subfield>
+    <subfield code="b">param</subfield>
+    <subfield code="1">62428550700006421</subfield>
+    <subfield code="c">d?u.ignore_date_coverage=true&amp;rft.mms_id=99122306151806421</subfield>
+    <subfield code="a">Available</subfield>
+    <subfield code="l">61110976112790155</subfield>
+    <subfield code="e">JOURNAL</subfield>
+    <subfield code="8">53443322590006421</subfield>
+  </datafield>
+  <datafield tag="953" ind1="" ind2="">
+    <subfield code="a">53443322590006421</subfield>
+    <subfield code="b">1997</subfield>
+    <subfield code="c">2015</subfield>
+    <subfield code="d">6</subfield>
+    <subfield code="e">11</subfield>
+    <subfield code="f">5</subfield>
+    <subfield code="g">27</subfield>
+  </datafield>
+  <datafield tag="951" ind1="" ind2="">
+    <subfield code="v">2020-12-14 04:40:40 US/Eastern</subfield>
+    <subfield code="g">EBSCOhost</subfield>
+    <subfield code="u">System</subfield>
+    <subfield code="t">2020-12-14 04:40:34 US/Eastern</subfield>
+    <subfield code="x">https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53443322580006421&amp;Force_direct=true</subfield>
+    <subfield code="s">SFX</subfield>
+    <subfield code="0">53443322580006421</subfield>
+    <subfield code="k">Available from 1997 until 2015.</subfield>
+    <subfield code="f">true</subfield>
+    <subfield code="m">61428537640006421</subfield>
+    <subfield code="n">EBSCOhost Academic Search Ultimate</subfield>
+    <subfield code="b">param</subfield>
+    <subfield code="1">62428558560006421</subfield>
+    <subfield code="c">d?u.ignore_date_coverage=true&amp;rft.mms_id=99122306151806421</subfield>
+    <subfield code="a">Available</subfield>
+    <subfield code="l">614340000000000211</subfield>
+    <subfield code="e">JOURNAL</subfield>
+    <subfield code="8">53443322580006421</subfield>
+  </datafield>
+  <datafield tag="953" ind1="" ind2="">
+    <subfield code="a">53443322580006421</subfield>
+    <subfield code="b">1997</subfield>
+    <subfield code="c">2015</subfield>
+    <subfield code="d">1</subfield>
+    <subfield code="e">12</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="g">31</subfield>
+  </datafield>
+  <datafield tag="951" ind1="" ind2="">
+    <subfield code="v">2020-12-14 04:40:40 US/Eastern</subfield>
+    <subfield code="g">ProQuest</subfield>
+    <subfield code="u">System</subfield>
+    <subfield code="t">2020-12-14 04:40:34 US/Eastern</subfield>
+    <subfield code="x">https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53443322630006421&amp;Force_direct=true</subfield>
+    <subfield code="s">SFX</subfield>
+    <subfield code="0">53443322630006421</subfield>
+    <subfield code="k">Available from 01/04/1990. Most recent 1 year(s) not available.</subfield>
+    <subfield code="f">true</subfield>
+    <subfield code="m">61428538600006421</subfield>
+    <subfield code="n">ProQuest Central</subfield>
+    <subfield code="b">param</subfield>
+    <subfield code="1">62428551430006421</subfield>
+    <subfield code="c">d?u.ignore_date_coverage=true&amp;rft.mms_id=99122306151806421</subfield>
+    <subfield code="a">Available</subfield>
+    <subfield code="l">613790000000000466</subfield>
+    <subfield code="e">JOURNAL</subfield>
+    <subfield code="8">53443322630006421</subfield>
+  </datafield>
+  <datafield tag="953" ind1="" ind2="">
+    <subfield code="a">53443322630006421</subfield>
+    <subfield code="b">1990</subfield>
+    <subfield code="d">1</subfield>
+    <subfield code="f">4</subfield>
+  </datafield>
+  <datafield tag="954" ind1="" ind2="">
+    <subfield code="a">53443322630006421</subfield>
+    <subfield code="b">&gt;=</subfield>
+    <subfield code="c">1</subfield>
+  </datafield>
+  <datafield tag="951" ind1="" ind2="">
+    <subfield code="v">2020-12-14 04:40:40 US/Eastern</subfield>
+    <subfield code="g">Free E- Journals</subfield>
+    <subfield code="u">System</subfield>
+    <subfield code="t">2020-12-14 04:40:34 US/Eastern</subfield>
+    <subfield code="x">https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53443322600006421&amp;Force_direct=true</subfield>
+    <subfield code="s">SFX</subfield>
+    <subfield code="0">53443322600006421</subfield>
+    <subfield code="k">Available from 1869 volume: 1 issue: 1 until 1875 volume: 12 issue: 313.</subfield>
+    <subfield code="f">false</subfield>
+    <subfield code="m">61428542400006421</subfield>
+    <subfield code="n">free eJournals</subfield>
+    <subfield code="b">param</subfield>
+    <subfield code="1">62428556870006421</subfield>
+    <subfield code="c">d?u.ignore_date_coverage=true&amp;rft.mms_id=99122306151806421</subfield>
+    <subfield code="a">Available</subfield>
+    <subfield code="l">61110976638852340</subfield>
+    <subfield code="e">JOURNAL</subfield>
+    <subfield code="8">53443322600006421</subfield>
+  </datafield>
+  <datafield tag="953" ind1="" ind2="">
+    <subfield code="a">53443322600006421</subfield>
+    <subfield code="b">1869</subfield>
+    <subfield code="c">1875</subfield>
+    <subfield code="d">1</subfield>
+    <subfield code="e">12</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="g">31</subfield>
+    <subfield code="h">1</subfield>
+    <subfield code="i">12</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="k">313</subfield>
+  </datafield>
+  <datafield tag="951" ind1="" ind2="">
+    <subfield code="v">2020-12-14 04:40:40 US/Eastern</subfield>
+    <subfield code="g">PressReader</subfield>
+    <subfield code="u">System</subfield>
+    <subfield code="j">lacks title-specific thresholds; target-level threshold set for latest 1 year, shortest period available (actual threshold in most cases is only a few months) --nb, 12/17</subfield>
+    <subfield code="t">2020-12-14 04:40:34 US/Eastern</subfield>
+    <subfield code="x">https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53443322620006421&amp;Force_direct=true</subfield>
+    <subfield code="s">SFX</subfield>
+    <subfield code="0">53443322620006421</subfield>
+    <subfield code="f">true</subfield>
+    <subfield code="m">61428541610006421</subfield>
+    <subfield code="n">PressReader</subfield>
+    <subfield code="b">param</subfield>
+    <subfield code="1">62428545810006421</subfield>
+    <subfield code="c">d?u.ignore_date_coverage=true&amp;rft.mms_id=99122306151806421</subfield>
+    <subfield code="a">Available</subfield>
+    <subfield code="l">611000000000002086</subfield>
+    <subfield code="e">JOURNAL</subfield>
+    <subfield code="8">53443322620006421</subfield>
+  </datafield>
+  <datafield tag="951" ind1="" ind2="">
+    <subfield code="v">2020-12-14 04:40:40 US/Eastern</subfield>
+    <subfield code="g">ProQuest</subfield>
+    <subfield code="u">System</subfield>
+    <subfield code="t">2020-12-14 04:40:34 US/Eastern</subfield>
+    <subfield code="x">https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53443322640006421&amp;Force_direct=true</subfield>
+    <subfield code="s">SFX</subfield>
+    <subfield code="0">53443322640006421</subfield>
+    <subfield code="k">Available from 01/04/1990. Most recent 1 year(s) not available.</subfield>
+    <subfield code="f">true</subfield>
+    <subfield code="m">61428538710006421</subfield>
+    <subfield code="n">SciTech Premium Collection</subfield>
+    <subfield code="b">param</subfield>
+    <subfield code="1">62428551050006421</subfield>
+    <subfield code="c">d?u.ignore_date_coverage=true&amp;rft.mms_id=99122306151806421</subfield>
+    <subfield code="a">Available</subfield>
+    <subfield code="l">613790000000000496</subfield>
+    <subfield code="e">JOURNAL</subfield>
+    <subfield code="8">53443322640006421</subfield>
+  </datafield>
+  <datafield tag="953" ind1="" ind2="">
+    <subfield code="a">53443322640006421</subfield>
+    <subfield code="b">1990</subfield>
+    <subfield code="d">1</subfield>
+    <subfield code="f">4</subfield>
+  </datafield>
+  <datafield tag="954" ind1="" ind2="">
+    <subfield code="a">53443322640006421</subfield>
+    <subfield code="b">&gt;=</subfield>
+    <subfield code="c">1</subfield>
+  </datafield>
+  <datafield tag="951" ind1="" ind2="">
+    <subfield code="v">2020-12-14 04:40:40 US/Eastern</subfield>
+    <subfield code="g">Biodiversity Heritage Library</subfield>
+    <subfield code="u">System</subfield>
+    <subfield code="j">open access</subfield>
+    <subfield code="t">2020-12-14 04:40:34 US/Eastern</subfield>
+    <subfield code="x">https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53443322570006421&amp;Force_direct=true</subfield>
+    <subfield code="s">SFX</subfield>
+    <subfield code="0">53443322570006421</subfield>
+    <subfield code="k">Available from 1869 until 1923.</subfield>
+    <subfield code="f">false</subfield>
+    <subfield code="m">61428538230006421</subfield>
+    <subfield code="n">Biodiversity Heritage Library Free</subfield>
+    <subfield code="b">param</subfield>
+    <subfield code="1">62428552660006421</subfield>
+    <subfield code="c">d?u.ignore_date_coverage=true&amp;rft.mms_id=99122306151806421</subfield>
+    <subfield code="a">Available</subfield>
+    <subfield code="l">613780000000001162</subfield>
+    <subfield code="e">JOURNAL</subfield>
+    <subfield code="8">53443322570006421</subfield>
+  </datafield>
+  <datafield tag="953" ind1="" ind2="">
+    <subfield code="a">53443322570006421</subfield>
+    <subfield code="b">1869</subfield>
+    <subfield code="c">1923</subfield>
+    <subfield code="d">1</subfield>
+    <subfield code="e">12</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="g">31</subfield>
+  </datafield>
+</record>

--- a/spec/fixtures/marc_to_solr/electronic.mrx
+++ b/spec/fixtures/marc_to_solr/electronic.mrx
@@ -1,1 +1,135 @@
-<record><leader>01231nas 2200349 a 4500</leader><controlfield tag='001'>9931252300521</controlfield><controlfield tag='005'>20150417210834.0</controlfield><controlfield tag='008'>110922c20119999hu uu p    0  0eng </controlfield><datafield ind1=' ' ind2=' ' tag='010'><subfield code='a'>2012243131</subfield></datafield><datafield ind1='7' ind2=' ' tag='016'><subfield code='a'>101569896</subfield><subfield code='2'>DNLM</subfield></datafield><datafield ind1=' ' ind2=' ' tag='022'><subfield code='a'>2062-509X</subfield><subfield code='0'>(uri) http://worldcat.org/issn/2062-509X</subfield></datafield><datafield ind1=' ' ind2=' ' tag='022'><subfield code='e'>2062-8633</subfield></datafield><datafield ind1=' ' ind2=' ' tag='035'><subfield code='a'>(OCoLC)775758673</subfield><subfield code='0'>(uri) http://www.worldcat.org/oclc/775758673</subfield></datafield><datafield ind1=' ' ind2=' ' tag='035'><subfield code='a'>(CKB)3400000000000244</subfield></datafield><datafield ind1=' ' ind2=' ' tag='035'><subfield code='a'>(CONSER) 2012243131</subfield></datafield><datafield ind1=' ' ind2=' ' tag='035'><subfield code='a'>(EXLCZ)993400000000000244</subfield></datafield><datafield ind1=' ' ind2=' ' tag='042'><subfield code='a'>pcc</subfield></datafield><datafield ind1='0' ind2='0' tag='060'><subfield code='a'>W1</subfield><subfield code='b'>EU720L</subfield></datafield><datafield ind1='1' ind2='0' tag='210'><subfield code='a'>Eur J Microbiol Immunol (Bp)</subfield><subfield code='2'>dnlm</subfield></datafield><datafield ind1=' ' ind2=' ' tag='210'><subfield code='a'>EUR J MICROBIOL IMMUNOL (BP)</subfield></datafield><datafield ind1='0' ind2='0' tag='245'><subfield code='a'>European journal of microbiology &amp; immunology.</subfield></datafield><datafield ind1=' ' ind2=' ' tag='246'><subfield code='a'>European journal of microbiology &amp; immunology</subfield></datafield><datafield ind1='1' ind2=' ' tag='246'><subfield code='a'>European journal of microbiology and immunology</subfield></datafield><datafield ind1=' ' ind2=' ' tag='260'><subfield code='a'>Budapest :</subfield><subfield code='b'>Akadémiai Kiadó</subfield></datafield><datafield ind1=' ' ind2=' ' tag='310'><subfield code='a'>Quarterly</subfield></datafield><datafield ind1='1' ind2=' ' tag='362'><subfield code='a'>Began with Vol. 1, no. 1 (Mar. 2011).</subfield></datafield><datafield ind1='0' ind2=' ' tag='510'><subfield code='a'>PubMed</subfield><subfield code='b'>Date range of indexed citations unspecified</subfield></datafield><datafield ind1=' ' ind2=' ' tag='588'><subfield code='a'>Description based on: Vol. 1, no. 1 (Mar. 2011); title from cover.</subfield></datafield><datafield ind1=' ' ind2=' ' tag='588'><subfield code='a'>Latest issue consulted: Vol. 1, no. 1 (Mar. 2011).</subfield></datafield><datafield ind1='1' ind2='2' tag='650'><subfield code='a'>Microbiological Phenomena</subfield><subfield code='v'>Periodicals.</subfield></datafield><datafield ind1='2' ind2='2' tag='650'><subfield code='a'>Immune System Phenomena</subfield><subfield code='v'>Periodicals.</subfield></datafield><datafield ind1='2' ind2=' ' tag='710'><subfield code='a'>Akadémiai Kiadó.</subfield></datafield><datafield ind1=' ' ind2=' ' tag='906'><subfield code='a'>JOURNAL</subfield></datafield><datafield ind1=' ' ind2=' ' tag='950'><subfield code='c'>2015-09-16 10:52:24 US/Eastern</subfield><subfield code='b'>2012-02-25 20:23:57 US/Eastern</subfield><subfield code='a'>false</subfield></datafield><datafield ind1=' ' ind2=' ' tag='951'><subfield code='v'>2015-09-16 10:54:27 US/Eastern</subfield><subfield code='g'>PubMed Central</subfield><subfield code='u'>System</subfield><subfield code='t'>2015-09-16 10:53:16 US/Eastern</subfield><subfield code='x'>https://sandbox02-na.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=5310503380000521&amp;Force_direct=true</subfield><subfield code='s'>System</subfield><subfield code='w'>2015-09-16 14:53:16</subfield><subfield code='k'> Available from 2011 volume: 1.</subfield><subfield code='f'>false</subfield><subfield code='m'>6110467190000521</subfield><subfield code='n'>PubMed Central (Training)</subfield><subfield code='b'>param</subfield><subfield code='1'>6210467180000521</subfield><subfield code='c'>d?u.ignore_date_coverage=true&amp;rft.mms_id=9931252300521</subfield><subfield code='a'>Available</subfield><subfield code='l'>61111058563444000</subfield><subfield code='e'>JOURNAL</subfield><subfield code='8'>5310503380000521</subfield></datafield><datafield ind1=' ' ind2=' ' tag='953'><subfield code='a'>5310503380000521</subfield><subfield code='b'>2011</subfield><subfield code='d'>1</subfield><subfield code='f'>1</subfield><subfield code='h'>1</subfield></datafield><datafield ind1='0' ind2=' ' tag='852'><subfield code='b'>BIO</subfield><subfield code='c'>biology</subfield><subfield code='8'>2280569990000521</subfield></datafield><datafield ind1=' ' ind2=' ' tag='952'><subfield code='d'>2019-03-06 16:38:52</subfield><subfield code='8'>2280569990000521</subfield><subfield code='a'>2019-03-06 16:38:52</subfield><subfield code='b'>Science Library</subfield><subfield code='c'>Science Stacks</subfield><subfield code='e'>false</subfield></datafield></record>
+<record>
+  <leader>01231nas&#194;&#160;2200349 a 4500</leader>
+  <controlfield tag='001'>9931252300521</controlfield>
+  <controlfield tag='005'>20150417210834.0</controlfield>
+  <controlfield tag='008'>110922c20119999hu uu p &#194;&#160;&#194;&#160;&#194;&#160;0&#194;&#160;&#194;&#160;0eng&#194;&#160;</controlfield>
+  <datafield ind1='' ind2='' tag='010'>
+    <subfield code='a'>2012243131</subfield>
+  </datafield>
+  <datafield ind1='7' ind2='' tag='016'>
+    <subfield code='a'>101569896</subfield>
+    <subfield code='2'>DNLM</subfield>
+  </datafield>
+  <datafield ind1='' ind2='' tag='022'>
+    <subfield code='a'>2062-509X</subfield>
+    <subfield code='0'>(uri) http://worldcat.org/issn/2062-509X</subfield>
+  </datafield>
+  <datafield ind1='' ind2='' tag='022'>
+    <subfield code='e'>2062-8633</subfield>
+  </datafield>
+  <datafield ind1='' ind2='' tag='035'>
+    <subfield code='a'>(OCoLC)775758673</subfield>
+    <subfield code='0'>(uri) http://www.worldcat.org/oclc/775758673</subfield>
+  </datafield>
+  <datafield ind1='' ind2='' tag='035'>
+    <subfield code='a'>(CKB)3400000000000244</subfield>
+  </datafield>
+  <datafield ind1='' ind2='' tag='035'>
+    <subfield code='a'>(CONSER)&#194;&#160;2012243131</subfield>
+  </datafield>
+  <datafield ind1='' ind2='' tag='035'>
+    <subfield code='a'>(EXLCZ)993400000000000244</subfield>
+  </datafield>
+  <datafield ind1='' ind2='' tag='042'>
+    <subfield code='a'>pcc</subfield>
+  </datafield>
+  <datafield ind1='0' ind2='0' tag='060'>
+    <subfield code='a'>W1</subfield>
+    <subfield code='b'>EU720L</subfield>
+  </datafield>
+  <datafield ind1='1' ind2='0' tag='210'>
+    <subfield code='a'>Eur J Microbiol Immunol (Bp)</subfield>
+    <subfield code='2'>dnlm</subfield>
+  </datafield>
+  <datafield ind1='' ind2='' tag='210'>
+    <subfield code='a'>EUR J MICROBIOL IMMUNOL (BP)</subfield>
+  </datafield>
+  <datafield ind1='0' ind2='0' tag='245'>
+    <subfield code='a'>European journal of microbiology &amp; immunology.</subfield>
+  </datafield>
+  <datafield ind1='' ind2='' tag='246'>
+    <subfield code='a'>European journal of microbiology &amp; immunology</subfield>
+  </datafield>
+  <datafield ind1='1' ind2='' tag='246'>
+    <subfield code='a'>European journal of microbiology and immunology</subfield>
+  </datafield>
+  <datafield ind1='' ind2='' tag='260'>
+    <subfield code='a'>Budapest :</subfield>
+    <subfield code='b'>Akad&#195;&#169;miai Kiad&#195;&#179;</subfield>
+  </datafield>
+  <datafield ind1='' ind2='' tag='310'>
+    <subfield code='a'>Quarterly</subfield>
+  </datafield>
+  <datafield ind1='1' ind2='' tag='362'>
+    <subfield code='a'>Began with Vol. 1, no. 1 (Mar. 2011).</subfield>
+  </datafield>
+  <datafield ind1='0' ind2='' tag='510'>
+    <subfield code='a'>PubMed</subfield>
+    <subfield code='b'>Date range of indexed citations unspecified</subfield>
+  </datafield>
+  <datafield ind1='' ind2='' tag='588'>
+    <subfield code='a'>Description based on: Vol. 1, no. 1 (Mar. 2011); title from cover.</subfield>
+  </datafield>
+  <datafield ind1='' ind2='' tag='588'>
+    <subfield code='a'>Latest issue consulted: Vol. 1, no. 1 (Mar. 2011).</subfield>
+  </datafield>
+  <datafield ind1='1' ind2='2' tag='650'>
+    <subfield code='a'>Microbiological Phenomena</subfield>
+    <subfield code='v'>Periodicals.</subfield>
+  </datafield>
+  <datafield ind1='2' ind2='2' tag='650'>
+    <subfield code='a'>Immune System Phenomena</subfield>
+    <subfield code='v'>Periodicals.</subfield>
+  </datafield>
+  <datafield ind1='2' ind2='' tag='710'>
+    <subfield code='a'>Akad&#195;&#169;miai Kiad&#195;&#179;.</subfield>
+  </datafield>
+  <datafield ind1='' ind2='' tag='906'>
+    <subfield code='a'>JOURNAL</subfield>
+  </datafield>
+  <datafield ind1='' ind2='' tag='950'>
+    <subfield code='c'>2015-09-16 10:52:24 US/Eastern</subfield>
+    <subfield code='b'>2012-02-25 20:23:57 US/Eastern</subfield>
+    <subfield code='a'>false</subfield>
+  </datafield>
+  <datafield ind1='' ind2='' tag='951'>
+    <subfield code='v'>2015-09-16 10:54:27 US/Eastern</subfield>
+    <subfield code='g'>PubMed Central</subfield>
+    <subfield code='u'>System</subfield>
+    <subfield code='t'>2015-09-16 10:53:16 US/Eastern</subfield>
+    <subfield code='x'>https://sandbox02-na.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=5310503380000521&amp;Force_direct=true</subfield>
+    <subfield code='s'>System</subfield>
+    <subfield code='w'>2015-09-16 14:53:16</subfield>
+    <subfield code='k'>Available from 2011 volume: 1.</subfield>
+    <subfield code='f'>false</subfield>
+    <subfield code='m'>6110467190000521</subfield>
+    <subfield code='n'>PubMed Central (Training)</subfield>
+    <subfield code='b'>param</subfield>
+    <subfield code='1'>6210467180000521</subfield>
+    <subfield code='c'>d?u.ignore_date_coverage=true&amp;rft.mms_id=9931252300521</subfield>
+    <subfield code='a'>Available</subfield>
+    <subfield code='l'>61111058563444000</subfield>
+    <subfield code='e'>JOURNAL</subfield>
+    <subfield code='8'>5310503380000521</subfield>
+  </datafield>
+  <datafield ind1='' ind2='' tag='953'>
+    <subfield code='a'>5310503380000521</subfield>
+    <subfield code='b'>2011</subfield>
+    <subfield code='d'>1</subfield>
+    <subfield code='f'>1</subfield>
+    <subfield code='h'>1</subfield>
+  </datafield>
+  <datafield ind1='0' ind2='' tag='852'>
+    <subfield code='b'>BIO</subfield>
+    <subfield code='c'>biology</subfield>
+    <subfield code='8'>2280569990000521</subfield>
+  </datafield>
+  <datafield ind1='' ind2='' tag='952'>
+    <subfield code='d'>2019-03-06 16:38:52</subfield>
+    <subfield code='8'>2280569990000521</subfield>
+    <subfield code='a'>2019-03-06 16:38:52</subfield>
+    <subfield code='b'>Science Library</subfield>
+    <subfield code='c'>Science Stacks</subfield>
+    <subfield code='e'>false</subfield>
+  </datafield>
+</record>

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -115,6 +115,29 @@ describe 'From traject_config.rb' do
     end
   end
 
+  describe "electronic_portfolio_s" do
+    it "returns the electronic_portfolio_s field" do
+      record = @indexer.map_record(fixture_alma_record('99122306151806421'))
+      portfolios = record['electronic_portfolio_s'].map { |p| JSON.parse(p) }
+      nature = portfolios.detect { |p| p['title'] == 'Nature' }
+      ebsco = portfolios.detect { |p| p['title'] == 'EBSCOhost Academic Search Ultimate' }
+      proquest = portfolios.detect { |p| p['title'] == 'ProQuest Central' }
+
+      expect(nature['url']).to include '&portfolio_pid=53443322610006421'
+      expect(nature['desc']).to eq 'Available from 1869 volume: 1 issue: 1.'
+
+      # Date range with explicit start and no end date
+      expect(nature['start']).to eq '1869'
+      expect(nature['end']).to eq 'latest'
+
+      # Date range with explicit start and end
+      expect(ebsco['start']).to eq '1997'
+      expect(ebsco['end']).to eq '2015'
+
+      # Date range with embargo
+      expect(proquest['end']).to eq '2020'
+    end
+  end
   describe "call_number_display field" do
     it "returns the call_number_display field with k subfield at the end" do
       record = @indexer.map_record(fixture_alma_record('9957270023506421'))


### PR DESCRIPTION
Adds `electronic_portfolio_s` field by extracting data from 951,953, and 954 fields. Accounts for date ranges and embargoes.

Closes #1054 