### PR TITLE
Availability by mfhd and on_reserve

### DIFF
--- a/app/adapters/alma_adapter/alma_item.rb
+++ b/app/adapters/alma_adapter/alma_item.rb
@@ -205,7 +205,7 @@ class AlmaAdapter
         id: item_data["pid"],
         copy_number: holding_data["copy_id"],
         status: nil,                                # ?? "Not Charged"
-        on_reserve: nil,                            # ??
+        on_reserve: "N",
         item_type: policy["value"],                 # Gen
         pickup_location_id: holding_location,      # stacks
         pickup_location_code: holding_location,    # stacks

--- a/spec/adapters/alma_adapter_spec.rb
+++ b/spec/adapters/alma_adapter_spec.rb
@@ -362,6 +362,10 @@ RSpec.describe AlmaAdapter do
       expect(item[:in_temp_library]).to eq false
       expect(item[:temp_library_code]).to eq nil
 
+      # We are hard-coding this value to "N" to preserve the property in the response
+      # but we are not really using this value anymore.
+      expect(item[:on_reserve]).to eq "N"
+
       # Make sure temp locations are handled and the permanent location is preserved.
       availability = adapter.get_availability_holding(id: "9919392043506421", holding_id: "22105104420006421")
       item = availability.first
@@ -373,7 +377,7 @@ RSpec.describe AlmaAdapter do
       # Test an actual response. These values are not particularly meaningful, but to make sure we don't
       # inadvertently change them when refactoring.
       item_test = { barcode: "32101080920208", id: "23105104390006421", copy_number: "1", status: nil,
-                    on_reserve: nil, item_type: "Gen", pickup_location_id: "pa", pickup_location_code: "pa",
+                    on_reserve: "N", item_type: "Gen", pickup_location_id: "pa", pickup_location_code: "pa",
                     location: "online$etasrcp", label: "ReCAP", in_temp_library: true, status_label: "Item in place",
                     description: "g. 4, br. 7/8", enum_display: "g. 4, br. 7/8", chron_display: "",
                     temp_library_code: "online", temp_library_label: "Electronic Access",


### PR DESCRIPTION
Hard codes `on_reserve` to "N" to preserve compatibility with what the client apps (Orangelight and Request) expect.

Addresses a property that I left out when closing #1179