### PR TITLE
Alma HTTP 429 (PER_SECOND_THRESHOLD)

### DIFF
--- a/app/adapters/alma_adapter.rb
+++ b/app/adapters/alma_adapter.rb
@@ -39,6 +39,8 @@ class AlmaAdapter
     bibs = Alma::Bib.find(Array.wrap(id), expand: ["p_avail", "e_avail", "d_avail", "requests"].join(",")).each
     return nil if bibs.count == 0
     { bibs.first.id => AvailabilityStatus.new(bib: bibs.first).bib_availability }
+  rescue Alma::StandardError => client_error
+    handle_alma_error(client_error: client_error)
   end
 
   # Returns availability for a list of bib ids
@@ -49,6 +51,8 @@ class AlmaAdapter
       acc[bib.id] = AvailabilityStatus.new(bib: bib).bib_availability
     end
     availability
+  rescue Alma::StandardError => client_error
+    handle_alma_error(client_error: client_error)
   end
 
   def get_availability_holding(id:, holding_id:)
@@ -66,6 +70,8 @@ class AlmaAdapter
     holding_items[:items].map do |item|
       item.availability_summary(marc_holding: marc_holding)
     end
+  rescue Alma::StandardError => client_error
+    handle_alma_error(client_error: client_error)
   end
 
   # Returns list of holding records for a given MMS
@@ -152,5 +158,11 @@ class AlmaAdapter
       return true if errors.empty?
 
       raise(errors.first)
+    end
+
+    def handle_alma_error(client_error:)
+      errors = build_alma_errors(from: client_error)
+      raise errors.first if errors.first.is_a?(Alma::PerSecondThresholdError)
+      raise client_error
     end
 end

--- a/spec/adapters/alma_adapter_spec.rb
+++ b/spec/adapters/alma_adapter_spec.rb
@@ -381,4 +381,60 @@ RSpec.describe AlmaAdapter do
       expect(item).to eq item_test
     end
   end
+
+  describe "ExLibris rate limit" do
+    let(:http_429_response) do
+      # Sources: https://developers.exlibrisgroup.com/alma/apis/#error
+      #          and https://developers.exlibrisgroup.com/alma/apis/#threshold
+      <<-HTTP_RESPONSE
+        {
+          "errorsExist": true,
+          "errorList": {
+            "error": [
+              {
+                "errorCode": "PER_SECOND_THRESHOLD",
+                "errorMessage": "HTTP requests are more than allowed per second",
+                "trackingId": "E01-0101190932-VOBYO-AWAE1554214409"
+              }
+            ]
+          },
+          "result": null
+        }
+      HTTP_RESPONSE
+    end
+
+    before do
+      stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs?expand=p_avail,e_avail,d_avail,requests&mms_id=9922486553506421")
+        .with(
+          headers: {
+            'Accept' => 'application/json',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => 'apikey TESTME',
+            'Content-Type' => 'application/json',
+            'User-Agent' => 'Ruby'
+          }
+        )
+        .to_return(status: 429, body: http_429_response, headers: { "content-Type" => "application/json" })
+
+      stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs?expand=p_avail,e_avail,d_avail,requests&mms_id=9922486553506421,99122426947506421")
+        .with(
+          headers: {
+            'Accept' => 'application/json',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => 'apikey TESTME',
+            'Content-Type' => 'application/json',
+            'User-Agent' => 'Ruby'
+          }
+        )
+        .to_return(status: 429, body: http_429_response, headers: { "content-Type" => "application/json" })
+    end
+
+    it "handles per second threshold exception in single bib availability" do
+      expect { adapter.get_availability_one(id: "9922486553506421") }.to raise_error(Alma::PerSecondThresholdError)
+    end
+
+    it "handles per second threshold exception in multi-bib availability" do
+      expect { adapter.get_availability_many(ids: ["9922486553506421", "99122426947506421"]) }.to raise_error(Alma::PerSecondThresholdError)
+    end
+  end
 end


### PR DESCRIPTION
Handles Alma HTTP 429 response code (PER_SECOND_THRESHOLD) in the `get_availability_one` and `get_availability_many`

I am using the methods that @jrgriffiniii added to detect the Alma exception but added a helper method `handle_alma_error` to keep the `raise x if y` logic to a single place. 

Another difference with the initial implementation that James did is that in this case we are detecting the exception in API calls performed by the Alma gem (the initial code that James did detected the exception in an Alma API call embedded in our AlmaAdapter).

Part of the changes to address issue #1094