### PR TITLE
Handles HTTP 429 in get_availability_holding

### DIFF
--- a/app/adapters/alma_adapter.rb
+++ b/app/adapters/alma_adapter.rb
@@ -39,8 +39,8 @@ class AlmaAdapter
     bibs = Alma::Bib.find(Array.wrap(id), expand: ["p_avail", "e_avail", "d_avail", "requests"].join(",")).each
     return nil if bibs.count == 0
     { bibs.first.id => AvailabilityStatus.new(bib: bibs.first).bib_availability }
-  rescue Alma::StandardError => client_error
-    handle_alma_error(client_error: client_error)
+  rescue Alma::StandardError => e
+    handle_alma_error(client_error: e)
   end
 
   # Returns availability for a list of bib ids
@@ -51,8 +51,8 @@ class AlmaAdapter
       acc[bib.id] = AvailabilityStatus.new(bib: bib).bib_availability
     end
     availability
-  rescue Alma::StandardError => client_error
-    handle_alma_error(client_error: client_error)
+  rescue Alma::StandardError => e
+    handle_alma_error(client_error: e)
   end
 
   def get_availability_holding(id:, holding_id:)
@@ -70,8 +70,8 @@ class AlmaAdapter
     holding_items[:items].map do |item|
       item.availability_summary(marc_holding: marc_holding)
     end
-  rescue Alma::StandardError => client_error
-    handle_alma_error(client_error: client_error)
+  rescue Alma::StandardError => e
+    handle_alma_error(client_error: e)
   end
 
   # Returns list of holding records for a given MMS

--- a/spec/adapters/alma_adapter_spec.rb
+++ b/spec/adapters/alma_adapter_spec.rb
@@ -431,6 +431,10 @@ RSpec.describe AlmaAdapter do
           }
         )
         .to_return(status: 429, body: http_429_response, headers: { "content-Type" => "application/json" })
+
+      stub_alma_ids(ids: "9919392043506421", status: 200)
+      stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/9919392043506421/holdings/22105104420006421/items?limit=100")
+        .to_return(status: 429, body: http_429_response, headers: { "Content-Type" => "application/json" } )
     end
 
     it "handles per second threshold exception in single bib availability" do
@@ -439,6 +443,10 @@ RSpec.describe AlmaAdapter do
 
     it "handles per second threshold exception in multi-bib availability" do
       expect { adapter.get_availability_many(ids: ["9922486553506421", "99122426947506421"]) }.to raise_error(Alma::PerSecondThresholdError)
+    end
+
+    it "handles per second threshold exception in holding availability" do
+      expect { adapter.get_availability_holding(id: "9919392043506421", holding_id: "22105104420006421") }.to raise_error(Alma::PerSecondThresholdError)
     end
   end
 end

--- a/spec/adapters/alma_adapter_spec.rb
+++ b/spec/adapters/alma_adapter_spec.rb
@@ -434,7 +434,7 @@ RSpec.describe AlmaAdapter do
 
       stub_alma_ids(ids: "9919392043506421", status: 200)
       stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/9919392043506421/holdings/22105104420006421/items?limit=100")
-        .to_return(status: 429, body: http_429_response, headers: { "Content-Type" => "application/json" } )
+        .to_return(status: 429, body: http_429_response, headers: { "Content-Type" => "application/json" })
     end
 
     it "handles per second threshold exception in single bib availability" do


### PR DESCRIPTION
This is part of issue #1094 and it adds an extra check to handle HTTP 409 errors in `get_availability_holding`

Notice that I had to use a slightly different configuration when calling `Alma::BibItem.find()` because the Alma gem by default [swallows the real exception for this call](https://github.com/tulibraries/alma_rb/blob/main/lib/alma/bib_item_set.rb#L36-L39) and prevents us from handling the HTTP 429 error. By forcing `config.enable_loggable = true` before making the call `Alma::BibItem.find()` we get the real exception and can live happily ever after. 