### PR TITLE
Added controller tests (request tests) for Availability endpoints

### DIFF
--- a/app/controllers/bibliographic_controller.rb
+++ b/app/controllers/bibliographic_controller.rb
@@ -320,4 +320,4 @@ class BibliographicController < ApplicationController # rubocop:disable Metrics/
         head :bad_request
       end
     end
-end
+end # rubocop:enable Metrics/ClassLength

--- a/app/controllers/bibliographic_controller.rb
+++ b/app/controllers/bibliographic_controller.rb
@@ -106,9 +106,8 @@ class BibliographicController < ApplicationController # rubocop:disable Metrics/
         render json: solr_doc
       end
     end
-  rescue Alma::PerSecondThresholdError => alma_client_error
-    Rails.logger.error "Failed to retrieve the holding records for the bib. ID: #{sanitize(params[:bib_id])}: #{alma_client_error}"
-    head(:too_many_requests)
+  rescue => e
+    handle_exception(exception: e, message: "Failed to retrieve the holding records for the bib. ID: #{sanitize(params[:bib_id])}")
   end
 
   def bib_jsonld
@@ -131,9 +130,8 @@ class BibliographicController < ApplicationController # rubocop:disable Metrics/
         end
       end
     end
-  rescue Alma::PerSecondThresholdError => alma_client_error
-    Rails.logger.error "Failed to retrieve the holding records for the bib. ID: #{sanitize(params[:bib_id])}: #{alma_client_error}"
-    head(:too_many_requests)
+  rescue => e
+    handle_exception(exception: e, message: "Failed to retrieve the holding records for the bib. ID: #{sanitize(params[:bib_id])}")
   end
 
   # bibliographic/:bib_id/items
@@ -147,6 +145,8 @@ class BibliographicController < ApplicationController # rubocop:disable Metrics/
     end
   rescue Alma::BibItemSet::ResponseError
     render_not_found(params[:bib_id])
+  rescue => e
+    handle_exception(exception: e, message: "Failed to retrieve items for bib ID: #{bib_id_param}")
   end
 
   def render_not_found(id)

--- a/app/controllers/bibliographic_controller.rb
+++ b/app/controllers/bibliographic_controller.rb
@@ -1,4 +1,4 @@
-class BibliographicController < ApplicationController
+class BibliographicController < ApplicationController # rubocop:disable Metrics/ClassLength
   include FormattingConcern
   before_action :protect, only: [:update]
   skip_before_action :verify_authenticity_token, only: [:item_discharge]
@@ -29,6 +29,8 @@ class BibliographicController < ApplicationController
     respond_to do |wants|
       wants.json { render json: availability }
     end
+  rescue => e
+    handle_exception(exception: e, message: "Failed to retrieve availability for ID: #{id}")
   end
 
   # Returns availability for a single ID
@@ -39,6 +41,8 @@ class BibliographicController < ApplicationController
     respond_to do |wants|
       wants.json { render json: availability }
     end
+  rescue => e
+    handle_exception(exception: e, message: "Failed to retrieve availability for IDs: #{ids}")
   end
 
   # Returns availability for a single holding in a bib record
@@ -52,6 +56,8 @@ class BibliographicController < ApplicationController
     else
       render plain: "Please supply a bib id and a holding id", status: 404
     end
+  rescue => e
+    handle_exception(exception: e, message: "Failed to retrieve holdings for: #{params[:bib_id]}/#{params[:holding_id]}")
   end
 
   def bib
@@ -63,12 +69,8 @@ class BibliographicController < ApplicationController
     begin
       records = adapter.get_bib_record(bib_id_param)
       records.strip_non_numeric! unless opts[:holdings]
-    rescue Alma::PerSecondThresholdError => alma_threshold_error
-      Rails.logger.error "Failed to retrieve the record using the bib. ID: #{bib_id_param}: #{alma_threshold_error}"
-      return head :too_many_requests
-    rescue StandardError => bib_request_error
-      Rails.logger.error "Failed to retrieve the record using the bib. ID: #{bib_id_param}: #{bib_request_error}"
-      return head :bad_request
+    rescue => e
+      return handle_exception(exception: e, message: "Failed to retrieve the record using the bib. ID: #{bib_id_param}")
     end
 
     if records.nil?
@@ -307,5 +309,15 @@ class BibliographicController < ApplicationController
       parts[1] = parts[1].rjust(4, '0')
       dot_parts[0] = parts.join('.')
       dot_parts.join('.')
+    end
+
+    def handle_exception(exception:, message:)
+      if exception.is_a?(Alma::PerSecondThresholdError)
+        Rails.logger.error "HTTP 429. #{message} #{exception}"
+        head :too_many_requests
+      else
+        Rails.logger.error "HTTP 400. #{message} #{exception}"
+        head :bad_request
+      end
     end
 end

--- a/spec/controllers/bibliographic_controller_spec.rb
+++ b/spec/controllers/bibliographic_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe BibliographicController, type: :controller do
         get :bib, params: { bib_id: bib_id }
 
         expect(response.status).to be 400
-        expect(Rails.logger).to have_received(:error).with("Failed to retrieve the record using the bib. ID: 1234567: it's broken")
+        expect(Rails.logger).to have_received(:error).with("HTTP 400. Failed to retrieve the record using the bib. ID: 1234567 it's broken")
       end
     end
   end

--- a/spec/requests/bib_gets_spec.rb
+++ b/spec/requests/bib_gets_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Bibliographic Gets", type: :request do
       alma_api_response.to_json
     end
     let(:alma_response_headers) do
-      {}
+      { "Content-Type" => "application/json" }
     end
 
     before do
@@ -42,6 +42,19 @@ RSpec.describe "Bibliographic Gets", type: :request do
         headers: alma_response_headers,
         body: alma_response_body
       )
+
+      stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs?expand=p_avail,e_avail,d_avail,requests&mms_id=9922486553506421")
+        .to_return(status: 429, headers: alma_response_headers, body: alma_response_body)
+
+      stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs?expand=p_avail,e_avail,d_avail,requests&mms_id=9922486553506421,99122426947506421")
+        .to_return(status: 429, headers: alma_response_headers, body: alma_response_body)
+
+      stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs?expand=p_avail,e_avail,d_avail,requests&mms_id=9922486553506421,99122426947506421")
+        .to_return(status: 429, headers: alma_response_headers, body: alma_response_body)
+
+      stub_alma_ids(ids: "9919392043506421", status: 200)
+      stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/9919392043506421/holdings/22105104420006421/items?limit=100")
+        .to_return(status: 429, headers: alma_response_headers, body: alma_response_body)
     end
 
     describe "GET /bibliographic?bib_id=430472" do
@@ -140,6 +153,27 @@ RSpec.describe "Bibliographic Gets", type: :request do
       it "responds with an error message to the client" do
         get "/bibliographic/430472/holdings.json"
 
+        expect(response.status).to eq(429)
+      end
+    end
+
+    describe "GET /bibliographic/9922486553506421/availability.json" do
+      it "responds with an error message to the client" do
+        get "/bibliographic/9922486553506421/availability.json"
+        expect(response.status).to eq(429)
+      end
+    end
+
+    describe "GET /bibliographic/availability.json?bib_ids=9922486553506421,99122426947506421" do
+      it "responds with an error message to the client" do
+        get "/bibliographic/availability.json?bib_ids=9922486553506421,99122426947506421"
+        expect(response.status).to eq(429)
+      end
+    end
+
+    describe "GET /bibliographic/9919392043506421/holdings/22105104420006421/availability" do
+      it "responds with an error message to the client" do
+        get "/bibliographic/9919392043506421/holdings/22105104420006421/availability.json"
         expect(response.status).to eq(429)
       end
     end


### PR DESCRIPTION
New tests are to make sure we handle Alma's PER_SECOND_THRESHOLD errors. 
This is part of #1094. 

Notice that I disabled a Rubocop warning and created a separate issue (#1256) to address it. It is possible that the code to add this same validation to other controllers will make me move some of the new code that pushed the class over the limit to a shared location (e.g. ApplicationController) and will address the issue.
