### PR TITLE
PER_SECOND_THRESHOLD validation for barcode endpoint

### DIFF
--- a/app/adapters/alma_adapter.rb
+++ b/app/adapters/alma_adapter.rb
@@ -125,7 +125,7 @@ class AlmaAdapter
     item = Alma::BibItem.find_by_barcode(barcode)
     if item["errorsExist"]
       # In this case although `item` is an object of type Alma::BibItem, its
-      # content is really an HTTPartyResponse with the error information. ¯\_(ツ)_/¯
+      # content is really an HTTPartyResponse with the error information. :shrug:
       message = item.item.parsed_response.to_s
       error = message.include?("No items found") ? Alma::NotFoundError.new(message) : Alma::StandardError.new(message)
       handle_alma_error(client_error: error)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,4 +8,20 @@ class ApplicationController < ActionController::Base
   def after_sign_out_path_for(_resource_or_scope)
     request.referrer
   end
+
+  def handle_alma_exception(exception:, message:)
+    if exception.is_a?(Alma::PerSecondThresholdError)
+      Rails.logger.error "HTTP 429. #{message} #{exception}"
+      head :too_many_requests
+    elsif exception.is_a?(Alma::NotFoundError)
+      Rails.logger.error "HTTP 404. #{message} #{exception}"
+      head :not_found
+    elsif exception.is_a?(Alma::StandardError)
+      Rails.logger.error "HTTP 400. #{message} #{exception}"
+      head :bad_request
+    else
+      Rails.logger.error "HTTP 500. #{message} #{exception}"
+      head :internal_server_error
+    end
+  end
 end

--- a/app/controllers/barcode_controller.rb
+++ b/app/controllers/barcode_controller.rb
@@ -14,13 +14,10 @@ class BarcodeController < ApplicationController
     if !valid_barcode?(barcode)
       render plain: "Barcode #{barcode} not valid.", status: 404
     else
-      item = Alma::BibItem.find_by_barcode(barcode)
-      if item["errorsExist"]
-        render plain: item["errorList"]["error"].map { |e| e["errorMessage"] }, status: 404
-        return
-      end
-      mms_id = item.item["bib_data"]["mms_id"]
-      record = AlmaAdapter.new.get_bib_record(mms_id)
+      adapter = AlmaAdapter.new
+      item = adapter.item_by_barcode(barcode)
+      mms_id = item["bib_data"]["mms_id"]
+      record = adapter.get_bib_record(mms_id)
 
       # If the bib record is supressed, the returned record will be nil and the controller should return with a 404 status
       if record.nil?
@@ -29,7 +26,7 @@ class BarcodeController < ApplicationController
       end
       holding = Alma::BibHolding.find(mms_id: mms_id, holding_id: item.holding_data["holding_id"])
       records = if record.linked_record_ids.present?
-                  AlmaAdapter.new.get_bib_records(record.linked_record_ids)
+                  adapter.get_bib_records(record.linked_record_ids)
                 else
                   [record]
                 end
@@ -54,5 +51,7 @@ class BarcodeController < ApplicationController
         end
       end
     end
+  rescue => e
+    handle_alma_exception(exception: e, message: "Error for barcode: #{barcode}")
   end
 end

--- a/spec/controllers/barcode_controller_spec.rb
+++ b/spec/controllers/barcode_controller_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe BarcodeController, type: :controller do
           .with(query: { item_barcode: barcode })
           .to_return(status: 429,
                      headers: { "Content-Type" => "application/json" },
-                     body: stub_alma_per_second_threshold())
+                     body: stub_alma_per_second_threshold)
         get :scsb, params: { barcode: "32101076720316" }, format: :xml
         expect(response.status).to eq(429)
       end

--- a/spec/controllers/barcode_controller_spec.rb
+++ b/spec/controllers/barcode_controller_spec.rb
@@ -106,6 +106,23 @@ RSpec.describe BarcodeController, type: :controller do
         expect(response.status).to eq(404)
       end
     end
+
+    context "When Alma returns PER_THRESHOLD errors" do
+      it "handles error on items API call" do
+        barcode = "32101076720316"
+        stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/items.*/)
+          .with(query: { item_barcode: barcode })
+          .to_return(status: 429,
+                     headers: { "Content-Type" => "application/json" },
+                     body: stub_alma_per_second_threshold())
+        get :scsb, params: { barcode: "32101076720316" }, format: :xml
+        expect(response.status).to eq(429)
+      end
+
+      # TODO: implement this test
+      # it "handles error on holdings API call" do
+      # end
+    end
   end
 
   describe '#valid_barcode' do

--- a/spec/support/stub_alma.rb
+++ b/spec/support/stub_alma.rb
@@ -50,6 +50,26 @@ module AlmaStubbing
                  headers: { "Content-Type" => "application/json" },
                  body: alma_path.join("barcode_#{barcode}.json"))
   end
+
+  def stub_alma_per_second_threshold()
+    # Sources: https://developers.exlibrisgroup.com/alma/apis/#error
+    #          and https://developers.exlibrisgroup.com/alma/apis/#threshold
+    <<-HTTP_RESPONSE
+      {
+        "errorsExist": true,
+        "errorList": {
+          "error": [
+            {
+              "errorCode": "PER_SECOND_THRESHOLD",
+              "errorMessage": "HTTP requests are more than allowed per second",
+              "trackingId": "E01-0101190932-VOBYO-AWAE1554214409"
+            }
+          ]
+        },
+        "result": null
+      }
+    HTTP_RESPONSE
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/stub_alma.rb
+++ b/spec/support/stub_alma.rb
@@ -51,7 +51,7 @@ module AlmaStubbing
                  body: alma_path.join("barcode_#{barcode}.json"))
   end
 
-  def stub_alma_per_second_threshold()
+  def stub_alma_per_second_threshold
     # Sources: https://developers.exlibrisgroup.com/alma/apis/#error
     #          and https://developers.exlibrisgroup.com/alma/apis/#threshold
     <<-HTTP_RESPONSE


### PR DESCRIPTION
First pass at adding validation for PER_SECOND_THRESHOLD to the barcode endpoint.

I added some helper methods to the ApplicationController that, if the approach looks
good to the team, we can refactor the code in the BibliographicController to use them
as well and make that controller a bit skinnier.

Notice that I also moved some of the code in the BarcodeController to the AlmaAdapter
so that the logic for "Alma stuff" is consolidated in a single place. This also masks
the issue that Alma handles error reporting different from case to case: sometimes it
raises an exception while other times (like in this case) it overloads the return object
with the error information.

Part of #1094