### PR TITLE
Added missing test for ExLibris HTTP 429

### DIFF
--- a/app/adapters/alma_adapter.rb
+++ b/app/adapters/alma_adapter.rb
@@ -133,6 +133,17 @@ class AlmaAdapter
     item
   end
 
+  def holding_by_id(mms_id:, holding_id:)
+    holding = Alma::BibHolding.find(mms_id: mms_id, holding_id: holding_id)
+    if holding["errorsExist"]
+      # In this case although `holding` is an object of type Alma::BibHolding, its
+      # content is really an HTTPartyResponse with the error information. :shrug:
+      error = Alma::StandardError.new(holding.holding.parsed_response.to_s)
+      handle_alma_error(client_error: error)
+    end
+    holding
+  end
+
   private
 
     def apikey

--- a/app/controllers/barcode_controller.rb
+++ b/app/controllers/barcode_controller.rb
@@ -26,7 +26,7 @@ class BarcodeController < ApplicationController
         render plain: "Record #{mms_id} not found or suppressed", status: 404
         return
       end
-      holdings = adapter.holding_by_id(mms_id: mms_id, holding_id: item.holding_data["holding_id"])
+      holding = adapter.holding_by_id(mms_id: mms_id, holding_id: item.holding_data["holding_id"])
       records = if record.linked_record_ids.present?
                   adapter.get_bib_records(record.linked_record_ids)
                 else

--- a/app/controllers/barcode_controller.rb
+++ b/app/controllers/barcode_controller.rb
@@ -26,7 +26,7 @@ class BarcodeController < ApplicationController
         render plain: "Record #{mms_id} not found or suppressed", status: 404
         return
       end
-      holding = Alma::BibHolding.find(mms_id: mms_id, holding_id: item.holding_data["holding_id"])
+      holdings = adapter.holding_by_id(mms_id: mms_id, holding_id: item.holding_data["holding_id"])
       records = if record.linked_record_ids.present?
                   adapter.get_bib_records(record.linked_record_ids)
                 else

--- a/spec/controllers/barcode_controller_spec.rb
+++ b/spec/controllers/barcode_controller_spec.rb
@@ -119,9 +119,16 @@ RSpec.describe BarcodeController, type: :controller do
         expect(response.status).to eq(429)
       end
 
-      # TODO: implement this test
-      # it "handles error on holdings API call" do
-      # end
+      it "handles error on holdings API call" do
+        stub_alma_item_barcode(mms_id: "9972625743506421", item_id: "2340957190006421", holding_id: "2240957220006421", barcode: "32101069559514")
+        stub_alma_ids(ids: "9972625743506421", status: 200, fixture: "9972625743506421")
+        stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/9972625743506421/holdings/2240957220006421")
+          .to_return(status: 429,
+                     headers: { "Content-Type" => "application/json" },
+                     body: stub_alma_per_second_threshold)
+        get :scsb, params: { barcode: "32101069559514" }, format: :xml
+        expect(response.status).to eq(429)
+      end
     end
   end
 


### PR DESCRIPTION
Added test for PER_SECOND_THRESHOLD errors in holding API call. 

Moved some code from the Controller to the Adapter to encapsulate error handling logic.

Part of #1094 