### PR TITLE
Remove extraneous "via FTP" from job names

### DIFF
--- a/config/alma.yml
+++ b/config/alma.yml
@@ -8,10 +8,10 @@ default: &default
   sftp_host: <%= ENV['SFTP_HOST'] %>
   sqs_queue_url: <%= ENV['SQS_QUEUE_URL'] %>
   jobs:
-    "Publishing Platform Job General Publishing via FTP":
+    "Publishing Platform Job General Publishing":
       dump_type: "ALL_RECORDS"
       dump_file_type: "BIB_RECORDS"
-    "Publishing Platform Job Incremental Publishing via FTP":
+    "Publishing Platform Job Incremental Publishing":
       dump_type: "CHANGED_RECORDS"
       dump_file_type: "UPDATED_RECORDS"
     "Publishing Platform Job Incremental ReCAP Records":

--- a/spec/fixtures/aws/sqs_full_dump.json
+++ b/spec/fixtures/aws/sqs_full_dump.json
@@ -10,7 +10,7 @@
   "job_instance": {
     "id": "1434818870006421",
     "external_id": "1434818880006421",
-    "name": "Publishing Platform Job General Publishing via FTP",
+    "name": "Publishing Platform Job General Publishing",
     "submitted_by": {
       "value": "AlmaAdmin",
       "desc": "Administrator, Alma"
@@ -90,7 +90,7 @@
     ],
     "job_info": {
       "id": "S1434512240006421",
-      "name": "Publishing Platform Job General Publishing via FTP",
+      "name": "Publishing Platform Job General Publishing",
       "description": "Publishing Platform Job",
       "type": {
         "value": "SCHEDULED",

--- a/spec/fixtures/aws/sqs_incremental_dump.json
+++ b/spec/fixtures/aws/sqs_incremental_dump.json
@@ -10,7 +10,7 @@
   "job_instance": {
     "id": "6587815790006421",
     "external_id": "6587815800006421",
-    "name": "Publishing Platform Job Incremental Publishing via FTP",
+    "name": "Publishing Platform Job Incremental Publishing",
     "submitted_by": {
       "value": "940000258",
       "desc": "Zelesky, Mark"
@@ -83,7 +83,7 @@
     ],
     "job_info": {
       "id": "S6423194610006421",
-      "name": "Publishing Platform Job Incremental Publishing via FTP",
+      "name": "Publishing Platform Job Incremental Publishing",
       "description": "Publishing Platform Job",
       "type": {
         "value": "SCHEDULED",

--- a/spec/jobs/alma_dump_transfer_job_spec.rb
+++ b/spec/jobs/alma_dump_transfer_job_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe AlmaDumpTransferJob, type: :job do
 
       let(:dump) do
         FactoryBot.create(:empty_dump).tap do |d|
-          d.event.message_body = "{\"job_instance\": {\"name\":\"Publishing Platform Job General Publishing via FTP\"}}"
+          d.event.message_body = "{\"job_instance\": {\"name\":\"Publishing Platform Job General Publishing\"}}"
           d.event.save
         end
       end
@@ -87,7 +87,7 @@ RSpec.describe AlmaDumpTransferJob, type: :job do
       let(:local_path) { File.join(MARC_LIBERATION_CONFIG['data_dir'], filename) }
       let(:dump) do
         FactoryBot.create(:empty_incremental_dump).tap do |d|
-          d.event.message_body = "{\"job_instance\": {\"name\":\"Publishing Platform Job Incremental Publishing via FTP\"}}"
+          d.event.message_body = "{\"job_instance\": {\"name\":\"Publishing Platform Job Incremental Publishing\"}}"
           d.event.save
         end
       end


### PR DESCRIPTION
fixes #1155

The change has been made in the Alma publishing profile configuration