### PR TITLE
Implements PER_SECOND_TRESHOLD check for patron endpoint.

### DIFF
--- a/app/controllers/patron_controller.rb
+++ b/app/controllers/patron_controller.rb
@@ -14,8 +14,8 @@ class PatronController < ApplicationController
     respond_to do |wants|
       wants.json  { render json: MultiJson.dump(info) }
     end
-  rescue Alma::User::ResponseError
-    render json: {}, status: 404
+  rescue => e
+    handle_alma_exception(exception: e, message: "Error fetching patron: #{@patron_id}")
   end
 
   private
@@ -44,7 +44,7 @@ class PatronController < ApplicationController
     end
 
     def data
-      @data ||= Alma::User.find(patron_id)
+      @data ||= AlmaAdapter.new.find_user(patron_id)
     end
 
     def identifiers

--- a/spec/controllers/patron_controller_spec.rb
+++ b/spec/controllers/patron_controller_spec.rb
@@ -158,6 +158,21 @@ RSpec.describe PatronController, type: :controller do
       expect(response).to have_http_status(404)
     end
   end
+
+  context "When Alma returns PER_THRESHOLD errors" do
+    it "returns HTTP 429" do
+      stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/users/bbird?expand=fees,requests,loans")
+        .to_return(status: 429,
+                   headers: { "Content-Type" => "application/json" },
+                   body: stub_alma_per_second_threshold)
+      user = double('user')
+      allow(request.env['warden']).to receive(:authenticate!) { user }
+      allow(controller).to receive(:current_user) { user }
+
+      get :patron_info, params: { patron_id: 'bbird', format: :json }
+      expect(response).to have_http_status(429)
+    end
+  end
 end
 
 def stub_patron(netid = "bbird", status = 200)


### PR DESCRIPTION
Implements PER_SECOND_TRESHOLD check for patron endpoint.

Moved some of the logic for the Alma code to the adapter to hide the logic to deal with Alma errors since the gem sometimes hides the errors, sometimes lets them bubble up, and some other times buries the real error alongside a generic error. 

Notice that method `alma_preserve_exception` that is now duplicated in both AlmaAdapter and AvailabilityStatus. We could refactor this to a single method in a helper class or update the AvailabilityStatus to funnel all calls to the Alma gem through the adapter but that would couple both classes both ways or remove the Alma calls from AvailabilityStatus. My suggestion would be to refactor AvailabilityStatus so that it does not need to call the Alma gem and instead it receives the data that it needs, but that should be handled via a separate issue.

Part of #1094 