### PR TITLE
Adds check for PER_SECOND_THRESHOLD to item_discharge endpoint

### DIFF
--- a/app/controllers/bibliographic_controller.rb
+++ b/app/controllers/bibliographic_controller.rb
@@ -182,34 +182,21 @@ class BibliographicController < ApplicationController
     holding_id = params[:holding_id]
     item_pid = params[:item_pid]
     options = { op: "scan", library: "recap", circ_desk: "DEFAULT_CIRC_DESK", done: "true" }
-
-    use_discharge_key do
-      item = Alma::BibItem.scan(mms_id: mms_id, holding_id: holding_id, item_pid: item_pid, options: options)
-      respond_to do |wants|
-        wants.json do
-          json = item
-          return render json: json, status: :bad_request if item["errorsExist"] && item["errorList"]["error"].first["errorMessage"].start_with?("The parameter item_pid is invalid")
-          return render json: json, status: :internal_server_error if item["errorsExist"]
-          render json: json
-        end
+    adapter = AlmaAdapter.new
+    item = adapter.item_discharge(mms_id: mms_id, holding_id: holding_id, item_pid: item_pid, options: options)
+    respond_to do |wants|
+      wants.json do
+        render json: item
       end
     end
+  rescue => e
+    handle_alma_exception(exception: e, message: "Error discharging item: #{mms_id}/#{holding_id}/#{item_pid}")
   end
 
   private
 
     def render_not_found(id)
       render plain: "Record #{id} not found or suppressed", status: 404
-    end
-
-    def use_discharge_key
-      cached_key = Alma.configuration.apikey
-      begin
-        Alma.configure { |config| config.apikey = Rails.configuration.alma[:item_discharge_apikey] }
-        yield
-      ensure
-        Alma.configure { |config| config.apikey = cached_key }
-      end
     end
 
     # Construct or access the indexing service

--- a/spec/controllers/bibliographic_controller_spec.rb
+++ b/spec/controllers/bibliographic_controller_spec.rb
@@ -386,7 +386,20 @@ RSpec.describe BibliographicController, type: :controller do
                      body: Rails.root.join('spec', 'fixtures', 'files', 'alma', 'scan_error_23258767460006421.json'))
 
         post :item_discharge, params: { mms_id: "9968643943506421", holding_id: "22258767470006421", item_pid: "23258767460006421", auth_token: "hard_coded_secret" }, format: :json
-        expect(response).to have_http_status(:internal_server_error)
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
+    context "alma API returns PER_SECOND_THRESHOLD" do
+      it "returns a 429" do
+        stub_request(:post, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/.*\/holdings\/.*\/items\/.*/)
+          .with(headers: { 'Authorization' => 'apikey TEST_WR_KEY' })
+          .to_return(status: 429,
+                     headers: { "Content-Type" => "application/json" },
+                     body: stub_alma_per_second_threshold)
+
+        post :item_discharge, params: { mms_id: "9968643943506421", holding_id: "22258767470006421", item_pid: "23258767460006421", auth_token: "hard_coded_secret" }, format: :json
+        expect(response).to have_http_status(:too_many_requests)
       end
     end
 


### PR DESCRIPTION
Moves the calls to Alma to the adapter and adds a check for PER_SECOND_THRESHOLD errors.

Related to #1094 