### PR TITLE
Alma timeout issues

### DIFF
--- a/app/adapters/alma_adapter.rb
+++ b/app/adapters/alma_adapter.rb
@@ -58,7 +58,7 @@ class AlmaAdapter
 
   # Returns availability for a list of bib ids
   def get_availability_many(ids:)
-    options = { timeout: 1 }
+    options = { timeout: 20 }
     AlmaAdapter::Execute.call(options: options, message: "Find bibs #{ids.join(',')}") do
       bibs = Alma::Bib.find(Array.wrap(ids), expand: ["p_avail", "e_avail", "d_avail", "requests"].join(",")).each
       return nil if bibs.count == 0

--- a/app/adapters/alma_adapter.rb
+++ b/app/adapters/alma_adapter.rb
@@ -58,12 +58,15 @@ class AlmaAdapter
 
   # Returns availability for a list of bib ids
   def get_availability_many(ids:)
-    bibs = Alma::Bib.find(Array.wrap(ids), expand: ["p_avail", "e_avail", "d_avail", "requests"].join(",")).each
-    return nil if bibs.count == 0
-    availability = bibs.each_with_object({}) do |bib, acc|
-      acc[bib.id] = AvailabilityStatus.new(bib: bib).bib_availability
+    options = { timeout: 1 }
+    AlmaAdapter::Execute.call(options: options, message: "Find bibs #{ids.join(',')}") do
+      bibs = Alma::Bib.find(Array.wrap(ids), expand: ["p_avail", "e_avail", "d_avail", "requests"].join(",")).each
+      return nil if bibs.count == 0
+      availability = bibs.each_with_object({}) do |bib, acc|
+        acc[bib.id] = AvailabilityStatus.new(bib: bib).bib_availability
+      end
+      availability
     end
-    availability
   rescue Alma::StandardError => e
     handle_alma_error(client_error: e)
   end
@@ -152,7 +155,8 @@ class AlmaAdapter
   end
 
   def find_user(patron_id)
-    alma_preserve_exception do
+    options = { enable_loggable: true }
+    AlmaAdapter::Execute.call(options: options, message: "Find user #{patron_id}") do
       return Alma::User.find(patron_id)
     rescue Alma::StandardError => e
       # The Alma gem throws "not found" for all errors but only error code 401861
@@ -206,23 +210,5 @@ class AlmaAdapter
       errors = build_alma_errors(from: client_error)
       raise errors.first if errors.first.is_a?(Alma::PerSecondThresholdError)
       raise client_error
-    end
-
-    # In some instances the Alma gem hides the original exception and returns a string
-    # (rather than a hash) with the error information. This beheavior prevents us from
-    # handling PER_SECOND_THRESHOLD errors. In those instances we use this method to
-    # force the Alma gem to preserve the original exception.
-    #
-    # Notice that this method is duplicated in availability_status.rb. At some point
-    # we might want to refactor this and have all calls to the Alma gem come through
-    # alma_adapter.rb and remove the duplicate.
-    def alma_preserve_exception
-      cached_value = Alma.configuration.enable_loggable
-      begin
-        Alma.configure { |config| config.enable_loggable = true }
-        yield
-      ensure
-        Alma.configure { |config| config.enable_loggable = cached_value }
-      end
     end
 end

--- a/app/adapters/alma_adapter/availability_status.rb
+++ b/app/adapters/alma_adapter/availability_status.rb
@@ -104,7 +104,7 @@ class AlmaAdapter
 
       options = { timeout: 10 }
       message = "All items for #{bib.id}"
-      items = alma_with_options(options: options, message: message) do
+      items = AlmaAdapter::Execute.call(options: options, message: message) do
         # This method DOES issue a separate call to the Alma API to get item information.
         # Internally this call passes "ALL" to ExLibris to get data for all the holdings
         # in the current bib record.
@@ -139,7 +139,7 @@ class AlmaAdapter
       data = nil
       options = { enable_loggable: true, timeout: 10 }
       message = "Items for bib: #{bib.id}, holding_id: #{holding_id}"
-      alma_with_options(options: options, message: message) do
+      AlmaAdapter::Execute.call(options: options, message: message) do
         opts = { limit: Alma::BibItemSet::ITEMS_PER_PAGE, holding_id: holding_id }
         items = Alma::BibItem.find(bib.id, opts).all.map { |item| AlmaAdapter::AlmaItem.new(item) }
         data = { items: items, total_count: items.count }
@@ -158,51 +158,6 @@ class AlmaAdapter
           end
         end
         cdl
-      end
-
-      # Makes a call to the Alma gem using custom configuration options.
-      #
-      # @param options [Hash] custom configuration options to use for the Alma API call. Some
-      # of the possible options are:
-      #
-      #   enable_loggable (boolean): True to request Alma to preserve the original exception
-      #     to that we can handle PER_SECOND_THRESHOLD errors (otherwise we cannnot distinguish
-      #     threshold errors from any other).
-      #
-      #   timeout (seconds): Used to allow longer requests than the default (5 seconds).
-      #
-      #   For a full list of options see https://github.com/tulibraries/alma_rb/blob/main/lib/alma/config.rb
-      #
-      # @param message [String] Message to include when logging the call.
-      def alma_with_options(options:, message:)
-        # Saves the current values of the options to customize
-        original = {}
-        options.keys.each do |key|
-          original[key] = Alma.configuration.send(key.to_s)
-        end
-        start = Time.now
-        begin
-          # Sets the new configuration values
-          options.keys.each do |key|
-            Alma.configure { |config| config.send(key.to_s + "=", options[key]) }
-          end
-          yield
-        ensure
-          # Restore the options to their original values
-          options.keys.each do |key|
-            Alma.configure { |config| config.send(key.to_s + "=", original[key]) }
-          end
-          log_elapsed(start, message)
-        end
-      end
-
-      def log_elapsed(start, msg)
-        elapsed_ms = ((Time.now - start) * 1000).to_i
-        if elapsed_ms > 3000
-          Rails.logger.warn("ELAPSED: #{msg} took #{elapsed_ms} ms")
-        else
-          Rails.logger.info("ELAPSED: #{msg} took #{elapsed_ms} ms")
-        end
       end
   end
 end

--- a/app/adapters/alma_adapter/execute.rb
+++ b/app/adapters/alma_adapter/execute.rb
@@ -1,0 +1,46 @@
+class AlmaAdapter::Execute
+  # Makes a call to the Alma gem using custom configuration options.
+  #
+  # @param options [Hash] custom configuration options to use for the Alma API call. Some
+  # of the possible options are:
+  #
+  #   enable_loggable (boolean): True to request Alma to preserve the original exception
+  #     to that we can handle PER_SECOND_THRESHOLD errors (otherwise we cannnot distinguish
+  #     threshold errors from any other).
+  #
+  #   timeout (seconds): Used to allow longer requests than the default (5 seconds).
+  #
+  #   For a full list of options see https://github.com/tulibraries/alma_rb/blob/main/lib/alma/config.rb
+  #
+  # @param message [String] Message to include when logging the call.
+  def self.call(options:, message:)
+    # Saves the current values of the options to customize
+    original = {}
+    options.keys.each do |key|
+      original[key] = Alma.configuration.send(key.to_s)
+    end
+    start = Time.now
+    begin
+      # Sets the new configuration values
+      options.keys.each do |key|
+        Alma.configure { |config| config.send(key.to_s + "=", options[key]) }
+      end
+      yield
+    ensure
+      # Restore the options to their original values
+      options.keys.each do |key|
+        Alma.configure { |config| config.send(key.to_s + "=", original[key]) }
+      end
+      log_elapsed(start, message)
+    end
+  end
+
+  def self.log_elapsed(start, msg)
+    elapsed_ms = ((Time.now - start) * 1000).to_i
+    if elapsed_ms > 3000
+      Rails.logger.warn("ELAPSED: #{msg} took #{elapsed_ms} ms")
+    else
+      Rails.logger.info("ELAPSED: #{msg} took #{elapsed_ms} ms")
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,9 @@ class ApplicationController < ActionController::Base
     elsif exception.is_a?(Alma::StandardError)
       Rails.logger.error "HTTP 400. #{message} #{exception}"
       head :bad_request
+    elsif exception.is_a?(Net::ReadTimeout)
+      Rails.logger.error "HTTP 504. #{message} #{exception}"
+      head :gateway_timeout
     else
       Rails.logger.error "HTTP 500. #{message} #{exception}"
       head :internal_server_error

--- a/spec/requests/bib_gets_spec.rb
+++ b/spec/requests/bib_gets_spec.rb
@@ -179,6 +179,18 @@ RSpec.describe "Bibliographic Gets", type: :request do
     end
   end
 
+  context "when an API call times out" do
+    let(:adapter) { AlmaAdapter.new }
+    before do
+      allow(AlmaAdapter).to receive(:new).and_return(adapter)
+      allow(adapter).to receive(:get_availability_many).and_raise(Net::ReadTimeout)
+    end
+    it "Returns proper status code" do
+      get "/bibliographic/availability.json?bib_ids=9918888023506421,9929723813506421,998968313506421"
+      expect(response.status).to be(504)
+    end
+  end
+
   describe "GET /bibliographic/430472/items" do
     it "Properly encoded item records" do
       pending "Replace with Alma"


### PR DESCRIPTION
Uses a longer timeout value for `get_availability_many()` and uses proper HTTP status code for `Net::ReadTimeout` exceptions.

Notice that I moved the code to call Alma with custom parameters (`timeout` and `enable_loggable`) to its own class so that we can share this functionality between `alma_adapter.rb` and `alma_adapter/availability_status.rb`

Addresses #1265 