### PR TITLE
Add more accurate tests for host and constituent records

### DIFF
--- a/app/adapters/alma_adapter/scsb_dump_record.rb
+++ b/app/adapters/alma_adapter/scsb_dump_record.rb
@@ -35,8 +35,11 @@ class AlmaAdapter
     # Tests if the record is a constituent record in a boundwith
     # @return [Boolean]
     def constituent?
-      return true if marc_record["773"]
-      false
+      if marc_record["773"] && marc_record["773"]["w"]
+        true
+      else
+        false
+      end
     end
 
     # Gets ids of a host record's constituent records from the 774 field.
@@ -59,8 +62,11 @@ class AlmaAdapter
     # Tests if the record is a host record in a boundwith
     # @return [Boolean]
     def host?
-      return true if marc_record["774"]
-      false
+      if marc_record["774"] && marc_record["774"]["w"]
+        true
+      else
+        false
+      end
     end
 
     # Gets id of a constituent record's host record from the 773 field.

--- a/spec/adapters/alma_adapter/scsb_dump_record_spec.rb
+++ b/spec/adapters/alma_adapter/scsb_dump_record_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe AlmaAdapter::ScsbDumpRecord do
     MARC::XMLReader.new(file, external_encoding: 'UTF-8').first
   end
 
+  let(:bad_host_record) do
+    file = file_fixture("alma/scsb_dump_fixtures/bad-host.xml").to_s
+    MARC::XMLReader.new(file, external_encoding: 'UTF-8').first
+  end
+
   let(:host_record_uncached) do
     file = file_fixture("alma/scsb_dump_fixtures/host-id-not-in-cache.xml").to_s
     MARC::XMLReader.new(file, external_encoding: 'UTF-8').first
@@ -13,6 +18,11 @@ RSpec.describe AlmaAdapter::ScsbDumpRecord do
 
   let(:constituent_record) do
     file = file_fixture("alma/scsb_dump_fixtures/constituent.xml").to_s
+    MARC::XMLReader.new(file, external_encoding: 'UTF-8').first
+  end
+
+  let(:bad_constituent_record) do
+    file = file_fixture("alma/scsb_dump_fixtures/bad-constituent.xml").to_s
     MARC::XMLReader.new(file, external_encoding: 'UTF-8').first
   end
 
@@ -58,12 +68,24 @@ RSpec.describe AlmaAdapter::ScsbDumpRecord do
         expect(described_class.new(marc_record: constituent_record).constituent?).to be true
       end
     end
+
+    context "with a malformed constituent record" do
+      it "returns false" do
+        expect(described_class.new(marc_record: bad_constituent_record).constituent?).to be false
+      end
+    end
   end
 
   describe "#host?" do
     context "with a host record" do
       it "returns true" do
         expect(described_class.new(marc_record: host_record).host?).to be true
+      end
+    end
+
+    context "with a malformed host record" do
+      it "returns false" do
+        expect(described_class.new(marc_record: bad_host_record).host?).to be false
       end
     end
 

--- a/spec/fixtures/files/alma/scsb_dump_fixtures/bad-constituent.xml
+++ b/spec/fixtures/files/alma/scsb_dump_fixtures/bad-constituent.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<record>
+  <leader>01037ctmaa22002172a 4500</leader>
+  <controlfield tag="005">20200927194847.0</controlfield>
+  <controlfield tag="008">851121q16001699xx            000 0 ara d</controlfield>
+  <controlfield tag="001">9962646063506421</controlfield>
+<datafield tag="035" ind1=" " ind2=" ">
+  <subfield code="a">6264606</subfield>
+</datafield>
+<datafield tag="035" ind1=" " ind2=" ">
+  <subfield code="a">(NjP)6264606-princetondb</subfield>
+</datafield>
+<datafield tag="040" ind1=" " ind2=" ">
+  <subfield code="a">PUL</subfield>
+  <subfield code="c">PUL</subfield>
+</datafield>
+<datafield tag="066" ind1=" " ind2=" ">
+  <subfield code="c">(3</subfield>
+</datafield>
+<datafield tag="100" ind1="0" ind2=" ">
+  <subfield code="a">Ghazzālī,</subfield>
+  <subfield code="d">1058-1111.</subfield>
+  <subfield code="0">http://id.loc.gov/authorities/names/n82097778</subfield>
+</datafield>
+<datafield tag="245" ind1="1" ind2="0">
+  <subfield code="a">Minhāj al-ʻābidīn.</subfield>
+</datafield>
+<datafield tag="500" ind1=" " ind2=" ">
+  <subfield code="a">fol. 21b-110b. 192 x 135: 168 x 90 mm. 21 lin. Jumādá I, 1087.</subfield>
+</datafield>
+<datafield tag="500" ind1=" " ind2=" ">
+  <subfield code="a">Brockelmann, GAL, I, 542 (no. 38); S I, 751; Bouyges, Essai de chronologie des œuvres de al-Ghazali, no. 64.</subfield>
+</datafield>
+<datafield tag="500" ind1=" " ind2=" ">
+  <subfield code="a">Incip.: ... الحمد لله الملك الحکىم</subfield>
+</datafield>
+<datafield tag="650" ind1=" " ind2="0">
+  <subfield code="a">Sufism</subfield>
+  <subfield code="v">Early works to 1800.</subfield>
+  <subfield code="0">http://id.loc.gov/authorities/subjects/sh2008112367</subfield>
+</datafield>
+<datafield tag="650" ind1=" " ind2="0">
+  <subfield code="a">Religious life</subfield>
+  <subfield code="x">Islam</subfield>
+  <subfield code="v">Early works to 1800.</subfield>
+  <subfield code="0">http://id.loc.gov/authorities/subjects/sh86008165</subfield>
+</datafield>
+<datafield tag="650" ind1=" " ind2="0">
+  <subfield code="a">Faith (Islam)</subfield>
+  <subfield code="v">Early works to 1800.</subfield>
+  <subfield code="0">http://id.loc.gov/authorities/subjects/sh87000153</subfield>
+</datafield>
+<datafield tag="655" ind1=" " ind2="7">
+  <subfield code="a">Manuscripts, Arabic</subfield>
+  <subfield code="y">17th century.</subfield>
+  <subfield code="2">lcsh</subfield>
+</datafield>
+<datafield tag="773" ind1="0" ind2=" ">
+  <subfield code="t">[Bidāyat al-hīdāyah ... etc.]</subfield>
+  <subfield code="x">99116515383506421</subfield>
+</datafield>
+<datafield tag="950" ind1=" " ind2=" ">
+  <subfield code="b">2020-12-02 06:12:49 US/Eastern</subfield>
+  <subfield code="a">false</subfield>
+</datafield>
+<datafield tag="852" ind1="8" ind2="0">
+  <subfield code="b">rare</subfield>
+  <subfield code="c">hsvm</subfield>
+  <subfield code="h">Islamic Manuscripts, Garrett no. 5931Y</subfield>
+  <subfield code="8">2264711800006421</subfield>
+</datafield>
+<datafield tag="952" ind1=" " ind2=" ">
+  <subfield code="a">2020-12-02 11:12:49</subfield>
+  <subfield code="8">2264711800006421</subfield>
+  <subfield code="b">Special Collections</subfield>
+  <subfield code="c">hsvm: Manuscripts South East</subfield>
+  <subfield code="e">false</subfield>
+</datafield>
+</record>

--- a/spec/fixtures/files/alma/scsb_dump_fixtures/bad-host.xml
+++ b/spec/fixtures/files/alma/scsb_dump_fixtures/bad-host.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<record>
+  <leader>00428nam a2200109 i 4500</leader>
+  <controlfield tag="005">20210423111453.0</controlfield>
+  <controlfield tag="008">201202s2013    xx      r     000 0 eng d</controlfield>
+  <controlfield tag="001">99121886293506421</controlfield>
+  <datafield tag="245" ind1="0" ind2="0">
+    <subfield code="a">Host bibliographic record for boundwith item barcode 32101066958685 :</subfield>
+    <subfield code="b">updated 4-23-21 11:14 AM</subfield>
+  </datafield>
+  <datafield tag="774" ind1="1" ind2=" ">
+    <subfield code="t">Suchende seelen;</subfield>
+    <subfield code="x">9929455783506421</subfield>
+  </datafield>
+  <datafield tag="774" ind1="1" ind2=" ">
+    <subfield code="t">Zwischenakt; sittenroman,</subfield>
+    <subfield code="x">9929455793506421</subfield>
+  </datafield>
+  <datafield tag="774" ind1="1" ind2=" ">
+    <subfield code="t">Das ewige rätsel; roman,</subfield>
+    <subfield code="x">9929455773506421</subfield>
+  </datafield>
+  <datafield tag="950" ind1=" " ind2=" ">
+    <subfield code="c">2021-04-23 11:14:53 US/Eastern</subfield>
+    <subfield code="b">2020-12-02 21:30:29 US/Eastern</subfield>
+    <subfield code="a">false</subfield>
+  </datafield>
+  <datafield tag="852" ind1="8" ind2="0">
+    <subfield code="b">recap</subfield>
+    <subfield code="c">pa</subfield>
+    <subfield code="h">3488.93344.333</subfield>
+    <subfield code="8">22269289940006421</subfield>
+  </datafield>
+  <datafield tag="952" ind1=" " ind2=" ">
+    <subfield code="a">2020-12-03 02:30:29</subfield>
+    <subfield code="8">22269289940006421</subfield>
+    <subfield code="b">ReCAP</subfield>
+    <subfield code="c">rcppa: RECAP</subfield>
+    <subfield code="e">false</subfield>
+  </datafield>
+  <datafield tag="876" ind1=" " ind2=" ">
+    <subfield code="0">22269289940006421</subfield>
+    <subfield code="a">23269289930006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="d">2020-12-03 02:30:29</subfield>
+    <subfield code="p">32101066958685</subfield>
+    <subfield code="t">1</subfield>
+  </datafield>
+</record>


### PR DESCRIPTION
Fixes issue where records with malformed 773 and 774 fields (they use subfield "x' rather than subfield "w") cause boundwiths indexing to fail.

Closes #1329 