### PR TITLE
Require rubygems/package to fix cache_file rake task

### DIFF
--- a/app/services/publishing_job_file_service.rb
+++ b/app/services/publishing_job_file_service.rb
@@ -1,3 +1,4 @@
+require 'rubygems/package'
 class PublishingJobFileService
   attr_reader :path
   def initialize(path:)


### PR DESCRIPTION
This is needed to run the service in a rake task.