### PR TITLE
Update rsolr to get recent fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,7 +380,7 @@ GEM
     retriable (3.1.2)
     reverse_markdown (1.4.0)
       nokogiri
-    rsolr (2.1.0)
+    rsolr (2.3.0)
       builder (>= 2.1.2)
       faraday (>= 0.9.0)
     rspec-core (3.9.3)


### PR DESCRIPTION
resolves #1391 and should stop us from getting the Uninitialized
Constant error on Faraday