### PR TITLE
Returns not available when an item is in Acquisitions.

### DIFF
--- a/app/adapters/alma_adapter/alma_item.rb
+++ b/app/adapters/alma_adapter/alma_item.rb
@@ -265,7 +265,7 @@ class AlmaAdapter
 
       # Source for values: https://developers.exlibrisgroup.com/alma/apis/docs/xsd/rest_item.xsd/
       # and https://api-na.hosted.exlibrisgroup.com/almaws/v1/conf/departments?apikey=YOUR-KEY&format=json
-      code = if value == "Bind" || value == "Pres" || value == "CDL"
+      code = if value == "Bind" || value == "Pres" || value == "CDL" || value == "AcqWorkOrder"
                "Not Available"
              else
                # "COURSE" or "PHYSICAL_TO_DIGITIZATION"
@@ -275,19 +275,13 @@ class AlmaAdapter
     end
 
     def status_from_process_type
+      # For now we return "Not Available" for any item that has a process_type.
+      # You can see a list of all the possible values here:
+      #   https://developers.exlibrisgroup.com/alma/apis/docs/xsd/rest_item.xsd/
       value = item_data.dig("process_type", "value")
       desc = item_data.dig("process_type", "desc")
 
-      # Source for values: https://developers.exlibrisgroup.com/alma/apis/docs/xsd/rest_item.xsd/
-      code = if value == "ACQ"
-               "Available"
-             else
-               # "CLAIM_RETURNED_LOAN", "HOLDSHELF", "ILL", "MISSING", "REQUESTED", "TECHNICAL",
-               # "LOAN", "LOST_ILL", "LOST_LOAN", "LOST_LOAN_AND_PAID",
-               # "TRANSIT", "TRANSIT_TO_REMOTE_STORAGE"
-               "Not Available"
-             end
-      { code: code, label: desc, source: "process_type", process_type: value }
+      { code: "Not Available", label: desc, source: "process_type", process_type: value }
     end
 
     def status_from_base_status

--- a/spec/adapters/alma_adapter/alma_item_spec.rb
+++ b/spec/adapters/alma_adapter/alma_item_spec.rb
@@ -122,4 +122,70 @@ RSpec.describe AlmaAdapter::AlmaItem do
       end
     end
   end
+
+  describe "status" do
+    let(:item_work_order_acq) do
+      Alma::BibItem.new(
+        "bib_data" => { "mms_id" => "99122455086806421" },
+        "holding_data" => { "holding_id" => "22477860740006421" },
+        "item_data" => {
+          "pid" => "23477860730006421",
+          "base_status" => { "value" => "0", "desc" => "Item not in place" },
+          "process_type" => { "value" => "WORK_ORDER_DEPARTMENT", "desc" => "In Process" },
+          "work_order_type" => { "value" => "AcqWorkOrder", "desc" => "Acquisitions and Cataloging" },
+          "work_order_at" => { "value" => "AcqDepttechserv", "desc" => "Acquisitions and Cataloging" }
+        }
+      )
+    end
+
+    let(:item_process_type_acq) do
+      Alma::BibItem.new(
+        "bib_data" => { "mms_id" => "9939075533506421" },
+        "holding_data" => { "holding_id" => "22194161030006421" },
+        "item_data" => {
+          "pid" => "23194161020006421",
+          "base_status" => { "value" => "0", "desc" => "Item not in place" },
+          "process_type" => { "value" => "ACQ", "desc" => "Acquisition" }
+        }
+      )
+    end
+
+    let(:item_base_status_in_place) do
+      Alma::BibItem.new(
+        "bib_data" => { "mms_id" => "9939075533506421" },
+        "holding_data" => { "holding_id" => "22194161030006421" },
+        "item_data" => { "pid" => "23194161020006421", "base_status" => { "value" => "1", "desc" => "Item in place" } }
+      )
+    end
+
+    let(:item_base_status_not_in_place) do
+      Alma::BibItem.new(
+        "bib_data" => { "mms_id" => "9939075533506421" },
+        "holding_data" => { "holding_id" => "22194161030006421" },
+        "item_data" => { "pid" => "23194161020006421", "base_status" => { "value" => "0", "desc" => "Item not in place" } }
+      )
+    end
+
+    it "handles items with work order in acquisitions" do
+      item = described_class.new(item_work_order_acq)
+      status = item.calculate_status
+      expect(status[:code]).to eq "Not Available"
+    end
+
+    it "handles items with process type in acquisitions" do
+      item = described_class.new(item_process_type_acq)
+      status = item.calculate_status
+      expect(status[:code]).to eq "Not Available"
+    end
+
+    it "handles items with base status (in place)" do
+      item = described_class.new(item_base_status_in_place)
+      expect(item.calculate_status[:code]).to eq "Available"
+    end
+
+    it "handles items with base status (not in place)" do
+      item = described_class.new(item_base_status_not_in_place)
+      expect(item.calculate_status[:code]).to eq "Not Available"
+    end
+  end
 end


### PR DESCRIPTION
Returns not available when an item is in Acquisitions. Notice that we handle two different scenarios: when the item has a process_type and when it has a work order.

Fixes #1381 