### PR TITLE
Supports the persistence of the index status on Dumps for IncrementalIndexJobs (and the requeuing of the job when a previous worker is running)

### DIFF
--- a/app/jobs/alma_dump_transfer_job.rb
+++ b/app/jobs/alma_dump_transfer_job.rb
@@ -122,26 +122,11 @@ class AlmaDumpTransferJob < ActiveJob::Base
 
   private
 
-    def find_message(dump:)
+    def event_message(dump:)
       event = dump.event
-      return if event.nil?
+      return {} if event.nil?
 
-      event.message_body
-    end
-
-    def parse_event_message(dump:)
-      event_message_body = find_message(dump: dump)
-      JSON.parse(event_message_body)
-    end
-
-    def find_job_instance(dump:)
-      parsed = parse_event_message(dump: dump)
-      parsed["job_instance"] || {}
-    end
-
-    def find_job_name(dump:)
-      job_instance = find_job_instance(dump: dump)
-      job_instance["name"]
+      JSON.parse(event.message_body)
     end
 
     def jobs_configuration
@@ -149,7 +134,8 @@ class AlmaDumpTransferJob < ActiveJob::Base
     end
 
     def find_job_configuration(dump:)
-      job_name = find_job_name(dump: dump)
+      job_name = event_message(dump: dump).dig("job_instance", "name")
+
       jobs_configuration[job_name] || {}
     end
 end

--- a/app/jobs/incremental_index_job.rb
+++ b/app/jobs/incremental_index_job.rb
@@ -1,9 +1,42 @@
 class IncrementalIndexJob < ActiveJob::Base
+  class IndexQueueLocked < StandardError; end
+
   queue_as :default
+  retry_on IndexQueueLocked
 
   def perform(dump)
-    solr_config = Rails.application.config.solr
-    indexer = Alma::Indexer.new(solr_url: solr_config['url'])
+    dump.index_status = Dump::ENQUEUED
+    dump.save!
+
+    raise IndexQueueLocked unless running_jobs.empty?
+
+    dump.index_status = Dump::STARTED
+    dump.save!
+
     indexer.incremental_index!(dump)
+
+    dump.index_status = Dump::DONE
+    dump.save!
+  rescue StandardError => indexer_error
+    Rails.logger.error("Failed to incrementally index Dump #{dump.id}: indexer_error")
+    raise(indexer_error)
   end
+
+  private
+
+    def solr_config
+      Rails.application.config.solr
+    end
+
+    def indexer
+      @indexer ||= Alma::Indexer.new(solr_url: solr_config['url'])
+    end
+
+    def current_time
+      DateTime.now
+    end
+
+    def running_jobs
+      @running_jobs ||= Dump.all.select { |d| d.started? && d.updated_at <= current_time }
+    end
 end

--- a/app/jobs/scsb_import_full_job.rb
+++ b/app/jobs/scsb_import_full_job.rb
@@ -1,9 +1,20 @@
 class ScsbImportFullJob < ActiveJob::Base
   def perform
     Event.record do |event|
-      event.dump = Dump.create(dump_type: DumpType.find_by(constant: 'PARTNER_RECAP_FULL'))
-      event.save
+      event.dump = created_dump
+      event.save!
+
       Scsb::PartnerUpdates.full(dump: event.dump)
     end
   end
+
+  private
+
+    def dump_type
+      @dump_type ||= DumpType.find_or_create_by!(constant: DumpType::PARTNER_RECAP_FULL)
+    end
+
+    def created_dump
+      Dump.create!(dump_type: dump_type)
+    end
 end

--- a/app/models/dump.rb
+++ b/app/models/dump.rb
@@ -4,6 +4,10 @@ require 'net/sftp'
 require 'date'
 
 class Dump < ActiveRecord::Base
+  ENQUEUED = 'enqueued'.freeze
+  STARTED = 'started'.freeze
+  DONE = 'done'.freeze
+
   belongs_to :event
   belongs_to :dump_type
   has_many :dump_files
@@ -59,4 +63,16 @@ class Dump < ActiveRecord::Base
         dump_type = DumpType.where(constant: 'PARTNER_RECAP_FULL')
       end
   end # class << self
+
+  def enqueued?
+    index_status == ENQUEUED
+  end
+
+  def started?
+    index_status == STARTED
+  end
+
+  def done?
+    index_status == DONE
+  end
 end

--- a/app/models/dump_type.rb
+++ b/app/models/dump_type.rb
@@ -1,3 +1,5 @@
 class DumpType < ActiveRecord::Base
+  PARTNER_RECAP_FULL = 'PARTNER_RECAP_FULL'.freeze
+
   has_many :dumps
 end

--- a/db/migrate/20210608192520_add_index_status_to_dumps.rb
+++ b/db/migrate/20210608192520_add_index_status_to_dumps.rb
@@ -1,0 +1,5 @@
+class AddIndexStatusToDumps < ActiveRecord::Migration[5.2]
+  def change
+    add_column :dumps, :index_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_06_143119) do
+ActiveRecord::Schema.define(version: 2021_06_08_192520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,6 +66,7 @@ ActiveRecord::Schema.define(version: 2021_05_06_143119) do
     t.datetime "updated_at", null: false
     t.text "update_ids"
     t.text "create_ids"
+    t.string "index_status"
     t.index ["dump_type_id"], name: "index_dumps_on_dump_type_id"
     t.index ["event_id"], name: "index_dumps_on_event_id"
   end

--- a/spec/jobs/alma_dump_transfer_job_spec.rb
+++ b/spec/jobs/alma_dump_transfer_job_spec.rb
@@ -48,18 +48,10 @@ RSpec.describe AlmaDumpTransferJob, type: :job do
           d.event.save
         end
       end
-      let(:session_stub) do
-        instance_double(Net::SFTP::Session)
-      end
-      let(:dir_stub) do
-        instance_double(Net::SFTP::Operations::Dir)
-      end
-      let(:download_stub) do
-        instance_double(Net::SFTP::Operations::Download)
-      end
-      let(:event) do
-        FactoryBot.create(:full_dump_file_type)
-      end
+      let(:session_stub) { instance_double(Net::SFTP::Session) }
+      let(:dir_stub) { instance_double(Net::SFTP::Operations::Dir) }
+      let(:download_stub) { instance_double(Net::SFTP::Operations::Download) }
+      let(:event) { FactoryBot.create(:full_dump_file_type) }
 
       before do
         event

--- a/spec/jobs/incremental_index_job_spec.rb
+++ b/spec/jobs/incremental_index_job_spec.rb
@@ -17,13 +17,10 @@ RSpec.describe IncrementalIndexJob, type: :job do
       let(:dump1) { Dump.create(index_status: Dump::STARTED) }
       let(:dump2) { Dump.create }
 
-      before do
-        dump1
-
-        described_class.perform_now(dump2)
-      end
-
       it 'enqueues the new Dump object for a retry if an existing Dump objects is already being indexed' do
+        dump1
+        described_class.perform_now(dump2)
+
         expect(dump2).to be_enqueued
       end
     end

--- a/spec/jobs/incremental_index_job_spec.rb
+++ b/spec/jobs/incremental_index_job_spec.rb
@@ -3,18 +3,59 @@ require 'rails_helper'
 RSpec.describe IncrementalIndexJob, type: :job do
   subject(:index_job) { described_class.new }
 
+  let(:dump1) { Dump.create }
+  let(:indexer) { instance_double(Alma::Indexer) }
+  let(:solr_url) { Rails.application.config.solr["url"] }
+
+  before do
+    allow(Alma::Indexer).to receive(:new).with(solr_url: solr_url).and_return(indexer)
+    allow(indexer).to receive(:incremental_index!)
+  end
+
   describe '.perform' do
+    context 'with existing Dump objects' do
+      let(:dump1) { Dump.create(index_status: Dump::STARTED) }
+      let(:dump2) { Dump.create }
+
+      before do
+        dump1
+
+        described_class.perform_now(dump2)
+      end
+
+      it 'enqueues the new Dump object for a retry if an existing Dump objects is already being indexed' do
+        expect(dump2).to be_enqueued
+      end
+    end
+
+    context 'when an error occurs trying to index a Dump objects' do
+      let(:dump1) { Dump.create }
+
+      let(:indexer) { instance_double(Alma::Indexer) }
+      let(:solr_url) { Rails.application.config.solr["url"] }
+      let(:logger) { instance_double(ActiveSupport::Logger) }
+
+      before do
+        dump1
+
+        allow(logger).to receive(:error)
+        allow(Rails).to receive(:logger).and_return(logger)
+        allow(Alma::Indexer).to receive(:new).with(solr_url: solr_url).and_return(indexer)
+        allow(indexer).to receive(:incremental_index!).and_raise(StandardError)
+      end
+
+      it 'sets the index status for the Dump object as incomplete' do
+        expect { described_class.perform_now(dump1) }.to raise_error(StandardError)
+        expect(dump1).to be_started
+        expect(logger).to have_received(:error).with("Failed to incrementally index Dump #{dump1.id}: indexer_error")
+      end
+    end
+
     it 'sends the dump to the Alma Indexer' do
-      dump = Dump.new
+      described_class.perform_now(dump1)
 
-      indexer = instance_double(Alma::Indexer)
-      solr_url = Rails.application.config.solr["url"]
-      allow(Alma::Indexer).to receive(:new).with(solr_url: solr_url).and_return(indexer)
-      allow(indexer).to receive(:incremental_index!)
-
-      described_class.perform_now(dump)
-
-      expect(indexer).to have_received(:incremental_index!).with(dump)
+      expect(indexer).to have_received(:incremental_index!).with(dump1)
+      expect(dump1).to be_done
     end
   end
 end

--- a/spec/jobs/scsb_import_full_job_spec.rb
+++ b/spec/jobs/scsb_import_full_job_spec.rb
@@ -1,13 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe ScsbImportFullJob do
-  it 'creates an event' do
+  let(:event) do
+    Event.last
+  end
+
+  before do
     allow(Scsb::PartnerUpdates).to receive(:full)
+  end
+
+  it 'creates an event' do
     expect { described_class.perform_now }.to change { Event.count }.by(1)
-    event = Event.last
+
     expect(event.start).not_to be nil
     expect(event.finish).not_to be nil
-    expect(Event.last.dump.dump_type.constant).to eq 'PARTNER_RECAP_FULL'
+    expect(event.dump).to be_a(Dump)
+    expect(event.dump.dump_type).to be_a(DumpType)
+    expect(event.dump.dump_type.constant).to eq 'PARTNER_RECAP_FULL'
     expect(Scsb::PartnerUpdates).to have_received(:full)
   end
 end

--- a/spec/jobs/scsb_import_full_job_spec.rb
+++ b/spec/jobs/scsb_import_full_job_spec.rb
@@ -1,16 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe ScsbImportFullJob do
-  let(:event) do
-    Event.last
-  end
-
-  before do
-    allow(Scsb::PartnerUpdates).to receive(:full)
-  end
-
   it 'creates an event' do
+    allow(Scsb::PartnerUpdates).to receive(:full)
+
     expect { described_class.perform_now }.to change { Event.count }.by(1)
+    event = Event.last
 
     expect(event.start).not_to be nil
     expect(event.finish).not_to be nil


### PR DESCRIPTION
Resolves #1348 