### PR TITLE
Adds guard to prevent sending an empty array

### DIFF
--- a/app/services/index_functions.rb
+++ b/app/services/index_functions.rb
@@ -68,7 +68,7 @@ module IndexFunctions
         system "traject -c marc_to_solr/lib/traject_config.rb #{df.path} -u #{solr_url}; true"
         df.zip
       end
-      solr.delete_by_id(dump.delete_ids) if dump.delete_ids
+      solr.delete_by_id(dump.delete_ids) unless dump.delete_ids.blank?
     end
     solr.commit
   end


### PR DESCRIPTION
This is an attempt at addressing the delete error reported in #1411 

Notice that although the error in #1411 says `404 not found` but we suspect that an invalid delete command with zero ids is triggering the problem and this is in fact an HTTP `400` error in disguise. But this is a guess that we hope to prove with this change.
