### PR TITLE
Timeout values for deletes

### DIFF
--- a/marc_to_solr/lib/solr_deleter.rb
+++ b/marc_to_solr/lib/solr_deleter.rb
@@ -26,7 +26,7 @@ class SolrDeleter
     def request_deletion(uri:, body:, content_type: 'text/xml')
       @logger&.info "Deleting #{body}"
       Faraday.post(uri) do |req|
-        req.headers = {"Content-Type" => content_type}
+        req.headers = { "Content-Type" => content_type }
         req.body = body
         req.options.open_timeout = 10
         req.options.read_timeout = 10

--- a/marc_to_solr/lib/solr_deleter.rb
+++ b/marc_to_solr/lib/solr_deleter.rb
@@ -25,8 +25,13 @@ class SolrDeleter
     # request payload is XML (even if the response is in JSON via the wt=json param)
     def request_deletion(uri:, body:, content_type: 'text/xml')
       @logger&.info "Deleting #{body}"
-
-      Faraday.post(uri, body, "Content-Type" => content_type)
+      Faraday.post(uri) do |req|
+        req.headers = {"Content-Type" => content_type}
+        req.body = body
+        req.options.open_timeout = 10
+        req.options.read_timeout = 10
+        req.options.write_timeout = 10
+      end
     rescue Net::ReadTimeout => net_read_timeout
       Rails.logger.warn("Failed to transmit the POST request to #{uri}: #{body}")
     end


### PR DESCRIPTION
Sets a longer timeout for deletes since we are getting `Net::ReadTimeout` exceptions.

Fixes #1389 

We might still need to tweak these values, but I am hoping that the new longer value of 10 seconds allows at least some of the deletes to succeed. 

For what is worth, I am able to replicate the `Net::ReadTimeout` error if I set the timeout values to 1.