### PR TITLE
Bump time out values for deletes

### DIFF
--- a/spec/marc_to_solr/lib/solr_deleter_spec.rb
+++ b/spec/marc_to_solr/lib/solr_deleter_spec.rb
@@ -44,22 +44,21 @@ describe SolrDeleter do
       end
     end
 
-    context 'when the HTTP request to the Solr endpoint' do
+    context 'when the HTTP request to Solr times out' do
       let(:logger) do
         instance_double(ActiveSupport::Logger)
       end
 
       before do
-        allow(Faraday).to receive(:post).and_raise(Net::ReadTimeout)
+        allow(Faraday).to receive(:post).and_raise(Faraday::TimeoutError)
         allow(logger).to receive(:info)
         allow(logger).to receive(:warn)
-        allow(Rails).to receive(:logger).and_return(logger)
 
         solr_deleter.delete(ids, batch_size)
       end
 
       it 'logs a warning' do
-        expect(logger).to have_received(:warn).exactly(2).times.with("Failed to transmit the POST request to #{url}: <delete><id>#{ids.first}</id><id>#{ids.last}</id></delete>")
+        expect(logger).to have_received(:warn).exactly(2).times
       end
     end
 

--- a/spec/marc_to_solr/lib/solr_deleter_spec.rb
+++ b/spec/marc_to_solr/lib/solr_deleter_spec.rb
@@ -58,7 +58,7 @@ describe SolrDeleter do
       end
 
       it 'logs a warning' do
-        expect(logger).to have_received(:warn).exactly(2).times
+        expect(logger).to have_received(:warn).exactly(2).times.with(/^Delete timed out /)
       end
     end
 


### PR DESCRIPTION
Bump time out values for deletes.

I also updated the code to log the time it took complete or timeout the delete operation. This should help us tune the parameters if the error happens again. I also updated the code to use the proper logger and catch a Faraday exception since Faraday wraps the standard Ruby Net HTTP Timeout exception.

Fixes #1440 

Log example after a successful execution:

```
2021-06-23T14:16:53-04:00  INFO Deleting <delete><id>SCSB-2146180</id><id>SCSB-2440575</id></delete>
2021-06-23T14:16:54-04:00  INFO Delete completed in 1.962307 seconds. URL: http://localhost:8983/solr/puldata/update?commit=true&wt=json
2021-06-23T14:16:54-04:00  INFO finished Indexer#process: 115 records in 3.044 seconds; 37.8 records/second overall.
```

Log example after a timeout exception (I forced the timeout value to 1 second to produce this log, hence the short timeout value reported)

```
2021-06-23T14:15:41-04:00  INFO Deleting <delete><id>SCSB-2146180</id><id>SCSB-2440575</id></delete>
2021-06-23T14:15:42-04:00  WARN Delete timed out after 1.019411 seconds. URL: http://localhost:8983/solr/puldata/update?commit=true&wt=json : <delete><id>SCSB-2146180</id><id>SCSB-2440575</id></delete>
2021-06-23T14:15:42-04:00  INFO Deleting <delete><id>SCSB-2146180</id><id>SCSB-2440575</id></delete>
2021-06-23T14:15:43-04:00  WARN Delete timed out after 1.005086 seconds. URL: http://localhost:8983/solr/puldata/update?commit=true&wt=json : <delete><id>SCSB-2146180</id><id>SCSB-2440575</id></delete>
2021-06-23T14:15:43-04:00  INFO finished Indexer#process: 115 records in 3.157 seconds; 36.4 records/second overall.
```