### PR TITLE
Refactor s3_bucket initializer params

### DIFF
--- a/app/models/scsb/s3_bucket.rb
+++ b/app/models/scsb/s3_bucket.rb
@@ -15,14 +15,22 @@ module Scsb
     end
 
     def self.recap_transfer_client
-      new
+      new(
+        s3_client:
+        Aws::S3::Client.new(
+          region: 'us-east-2',
+          credentials: Aws::Credentials.new(
+            ENV['SCSB_S3_ACCESS_KEY'],
+            ENV['SCSB_S3_SECRET_ACCESS_KEY']
+          )
+        ),
+        s3_bucket_name: ENV['SCSB_S3_BUCKET_NAME']
+      )
     end
 
     attr_reader :s3_client, :s3_bucket_name
 
-    def initialize(s3_client: Aws::S3::Client.new(region: 'us-east-2',
-                                                  credentials: Aws::Credentials.new(ENV['SCSB_S3_ACCESS_KEY'], ENV['SCSB_S3_SECRET_ACCESS_KEY'])),
-                   s3_bucket_name: ENV['SCSB_S3_BUCKET_NAME'])
+    def initialize(s3_client:, s3_bucket_name:)
       @s3_client = s3_client
       @s3_bucket_name = s3_bucket_name
     end


### PR DESCRIPTION
Just let them be required since they're only used through the factories;
this makes the 2 factories more symmetrical and easier to parse the
params

refs #1449 - the issue itself was resolved by provisioning, but this
refactor helped when investigating the issue