### PR TITLE
Add documentation to LocationDataService about Figgy using IDs.

### DIFF
--- a/app/services/location_data_service.rb
+++ b/app/services/location_data_service.rb
@@ -55,6 +55,8 @@ class LocationDataService
   end
 
   # Populate delivery locations based on the delivery_locations.json
+  # @note Do NOT remove values from here without updating Figgy appropriately.
+  #   The URIs are referenced in Figgy and removing them will break manifests.
   # These values will not change when we move to alma.
   def populate_delivery_locations
     highest_id = delivery_locations_array.sort_by { |x| x["id"] }.last["id"]


### PR DESCRIPTION
Closes #1450

I was going to put this in delivery_locations.json, but JSON doesn't have comments.