### PR TITLE
Index DumpFiles in parallel

### DIFF
--- a/app/jobs/dump_file_index_job.rb
+++ b/app/jobs/dump_file_index_job.rb
@@ -1,0 +1,5 @@
+class DumpFileIndexJob < ActiveJob::Base
+  def perform(dump_file, solr_url:)
+    Alma::Indexer::DumpFileIndexer.new(dump_file, solr_url: solr_url).index!
+  end
+end

--- a/app/jobs/incremental_index_job.rb
+++ b/app/jobs/incremental_index_job.rb
@@ -37,6 +37,6 @@ class IncrementalIndexJob < ActiveJob::Base
     end
 
     def running_jobs
-      @running_jobs ||= Dump.all.select { |d| d.started? && d.updated_at <= current_time }
+      @running_jobs ||= Dump.all.select { |d| d.started? && d.updated_at <= current_time } + DumpFile.started
     end
 end

--- a/app/jobs/incremental_index_job.rb
+++ b/app/jobs/incremental_index_job.rb
@@ -12,6 +12,7 @@ class IncrementalIndexJob < ActiveJob::Base
 
     dump.index_status = Dump::STARTED
     dump.save!
+    dump.dump_files.update(index_status: :started)
 
     indexer.incremental_index!(dump)
 

--- a/app/models/dump_file.rb
+++ b/app/models/dump_file.rb
@@ -4,47 +4,46 @@ require 'digest'
 class DumpFile < ActiveRecord::Base
   belongs_to :dump
   belongs_to :dump_file_type
+  enum index_status: [:enqueued, :started, :done]
 
   after_create do
-    self.path = generate_fp if self.path.nil?
-    self.save
+    self.path = generate_fp if path.nil?
+    save
   end
 
   before_save do
-    unless self.path.nil? || !File.exist?(self.path)
-      self.md5 = File.open(self.path, 'rb') do |io|
+    unless path.nil? || !File.exist?(path)
+      self.md5 = File.open(path, 'rb') do |io|
         digest = Digest::MD5.new
         buf = ''
-        while io.read(4096, buf)
-          digest.update(buf)
-        end
+        digest.update(buf) while io.read(4096, buf)
         digest
       end
     end
   end
 
   before_destroy do
-    File.delete(self.path) if File.exist?(self.path)
+    File.delete(path) if File.exist?(path)
   end
 
   def recap_record_type?
     [
       DumpFileType.find_by(constant: 'RECAP_RECORDS'),
       DumpFileType.find_by(constant: 'RECAP_RECORDS_FULL')
-    ].include? self.dump_file_type
+    ].include? dump_file_type
   end
 
   def zipped?
-    self.path.ends_with?('.gz')
+    path.ends_with?('.gz')
   end
 
   def zip
-    unless self.zipped?
-      gz_path = "#{self.path}.gz"
-      uncompressed_path = self.path
+    unless zipped?
+      gz_path = "#{path}.gz"
+      uncompressed_path = path
       Zlib::GzipWriter.open(gz_path) do |gz|
         File.open(uncompressed_path) do |fp|
-          while chunk = fp.read(16 * 1024) do
+          while chunk = fp.read(16 * 1024)
             gz.write chunk
           end
         end
@@ -52,19 +51,19 @@ class DumpFile < ActiveRecord::Base
       end
       self.path = gz_path
       File.delete(uncompressed_path)
-      self.save
+      save
     end
     self
   end
 
   def unzip
-    if self.zipped?
-      uncompressed_path = self.path.sub(/\.gz$/, '')
-      gz_path = self.path
+    if zipped?
+      uncompressed_path = path.sub(/\.gz$/, '')
+      gz_path = path
 
       Zlib::GzipReader.open(gz_path) do |gz|
         File.open(uncompressed_path, 'wb') do |fp|
-          while chunk = gz.read(16 * 1024) do
+          while chunk = gz.read(16 * 1024)
             fp.write chunk
           end
         end
@@ -73,7 +72,7 @@ class DumpFile < ActiveRecord::Base
 
       self.path = uncompressed_path
       File.delete(gz_path)
-      self.save
+      save
     end
     self
   end

--- a/app/services/alma/indexer.rb
+++ b/app/services/alma/indexer.rb
@@ -7,13 +7,13 @@ class Alma::Indexer
 
   def full_reindex!
     full_reindex_files.each do |dump_file|
-      DumpFileIndexer.new(dump_file, solr_url: solr_url).index!
+      DumpFileIndexJob.perform_later(dump_file, solr_url: solr_url)
     end
   end
 
   def incremental_index!(dump)
     dump.dump_files.each do |dump_file|
-      DumpFileIndexer.new(dump_file, solr_url: solr_url).index!
+      DumpFileIndexJob.perform_later(dump_file, solr_url: solr_url)
     end
   end
 

--- a/app/services/alma/indexer.rb
+++ b/app/services/alma/indexer.rb
@@ -1,24 +1,19 @@
 require 'rubygems/package'
 class Alma::Indexer
-  include Rails.application.routes.url_helpers
   attr_reader :solr_url
   def initialize(solr_url:)
     @solr_url = solr_url
   end
 
   def full_reindex!
-    full_reindex_file_paths.each do |path|
-      decompress_file(path) do |file|
-        index_file(file.path)
-      end
+    full_reindex_files.each do |dump_file|
+      DumpFileIndexer.new(dump_file, solr_url: solr_url).index!
     end
   end
 
   def incremental_index!(dump)
     dump.dump_files.each do |dump_file|
-      decompress_file(dump_file.path) do |file|
-        index_file(file.path)
-      end
+      DumpFileIndexer.new(dump_file, solr_url: solr_url).index!
     end
   end
 
@@ -27,39 +22,7 @@ class Alma::Indexer
     `traject #{debug_flag} -c marc_to_solr/lib/traject_config.rb #{file_name} -u #{solr_url}; true`
   end
 
-  def default_url_options
-    Rails.configuration.action_mailer.default_url_options
-  end
-
   private
-
-    def decompress_file(file_path)
-      tar_reader(file_path).each.map do |entry|
-        Tempfile.create(decompressed_filename(entry), binmode: true) do |decompressed_tmp|
-          decompressed_file = write_chunks(entry, decompressed_tmp)
-          entry.close
-          yield(decompressed_file)
-        end
-      end
-    end
-
-    def tar_reader(path)
-      tar_extract = Gem::Package::TarReader.new(Zlib::GzipReader.open(path))
-      tar_extract.tap(&:rewind)
-    end
-
-    def write_chunks(entry, temp_file)
-      while (chunk = entry.read(16 * 1024))
-        temp_file.write chunk
-      end
-      temp_file.tap(&:rewind)
-    end
-
-    def decompressed_filename(entry)
-      file_name, decompress_extension = entry.full_name.split(".")
-      decompress_extension ||= "xml"
-      ["full_reindex_file_unzip_#{file_name}", "." + decompress_extension]
-    end
 
     def full_reindex_event
       Event.joins(dump: :dump_type).where(success: true, 'dump_types.constant': "ALL_RECORDS").order(finish: 'DESC').first!

--- a/app/services/alma/indexer/dump_file_indexer.rb
+++ b/app/services/alma/indexer/dump_file_indexer.rb
@@ -1,0 +1,51 @@
+class Alma::Indexer
+  class DumpFileIndexer
+    attr_reader :dump_file, :solr_url
+    delegate :path, to: :dump_file
+    delegate :index_file, to: :indexer
+    def initialize(dump_file, solr_url:)
+      @dump_file = dump_file
+      @solr_url = solr_url
+    end
+
+    def index!
+      dump_file.update(index_status: :started)
+      decompress_file do |file|
+        index_file(file.path)
+      end
+      dump_file.update(index_status: :done)
+    end
+
+    def indexer
+      @indexer ||= Alma::Indexer.new(solr_url: solr_url)
+    end
+
+    def decompress_file
+      tar_reader.each.map do |entry|
+        Tempfile.create(decompressed_filename(entry), binmode: true) do |decompressed_tmp|
+          decompressed_file = write_chunks(entry, decompressed_tmp)
+          entry.close
+          yield(decompressed_file)
+        end
+      end
+    end
+
+    def tar_reader
+      tar_extract = Gem::Package::TarReader.new(Zlib::GzipReader.open(path))
+      tar_extract.tap(&:rewind)
+    end
+
+    def write_chunks(entry, temp_file)
+      while (chunk = entry.read(16 * 1024))
+        temp_file.write chunk
+      end
+      temp_file.tap(&:rewind)
+    end
+
+    def decompressed_filename(entry)
+      file_name, decompress_extension = entry.full_name.split(".")
+      decompress_extension ||= "xml"
+      ["full_reindex_file_unzip_#{file_name}", "." + decompress_extension]
+    end
+  end
+end

--- a/db/migrate/20210706182740_add_index_status_to_dump_files.rb
+++ b/db/migrate/20210706182740_add_index_status_to_dump_files.rb
@@ -1,0 +1,5 @@
+class AddIndexStatusToDumpFiles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :dump_files, :index_status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_30_201908) do
+ActiveRecord::Schema.define(version: 2021_07_06_182740) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2021_06_30_201908) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "dump_file_type_id"
+    t.integer "index_status", default: 0
     t.index ["dump_file_type_id"], name: "index_dump_files_on_dump_file_type_id"
     t.index ["dump_id"], name: "index_dump_files_on_dump_id"
   end

--- a/spec/jobs/incremental_index_job_spec.rb
+++ b/spec/jobs/incremental_index_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe IncrementalIndexJob, type: :job do
 
   describe '.perform' do
     context 'with existing Dump objects' do
-      let(:dump1) { Dump.create(index_status: Dump::STARTED) }
+      let(:dump1) { Dump.create(dump_files: [DumpFile.create(index_status: :started)]) }
       let(:dump2) { Dump.create }
 
       it 'enqueues the new Dump object for a retry if an existing Dump objects is already being indexed' do

--- a/spec/jobs/incremental_index_job_spec.rb
+++ b/spec/jobs/incremental_index_job_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe IncrementalIndexJob, type: :job do
         expect(dump2).to be_enqueued
       end
     end
+    context 'with enqueued Dump objects' do
+      let(:dump1) { Dump.create(dump_files: [DumpFile.create]) }
+      let(:dump2) { Dump.create }
+
+      it 'enqueues the new Dump object for a retry if an existing Dump objects is already being indexed' do
+        described_class.perform_now(dump1)
+        described_class.perform_now(dump2)
+
+        expect(dump2).to be_enqueued
+      end
+    end
 
     context 'when an error occurs trying to index a Dump objects' do
       let(:dump1) { Dump.create }

--- a/spec/services/alma/indexer_spec.rb
+++ b/spec/services/alma/indexer_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Alma::Indexer do
+  include ActiveJob::TestHelper
   describe "#full_reindex!" do
     it "gets the latest full dump tar files, unzips it, and indexes all the contained files" do
       event = FactoryBot.create(:full_dump_event)
@@ -13,7 +14,9 @@ RSpec.describe Alma::Indexer do
       solr.delete_by_query("*:*")
 
       indexer = described_class.new(solr_url: solr_url)
-      indexer.full_reindex!
+      perform_enqueued_jobs do
+        indexer.full_reindex!
+      end
 
       solr.commit
       response = solr.get("select", params: { q: "*:*" })
@@ -31,7 +34,9 @@ RSpec.describe Alma::Indexer do
       solr.delete_by_query("*:*")
 
       indexer = described_class.new(solr_url: solr_url)
-      indexer.full_reindex!
+      perform_enqueued_jobs do
+        indexer.full_reindex!
+      end
 
       solr.commit
       response = solr.get("select", params: { q: "*:*" })
@@ -48,7 +53,9 @@ RSpec.describe Alma::Indexer do
 
       indexer = described_class.new(solr_url: solr_url)
       file_name = file_fixture("alma/full_dump/2.xml")
-      indexer.index_file(file_name)
+      perform_enqueued_jobs do
+        indexer.index_file(file_name)
+      end
 
       solr.commit
       response = solr.get("select", params: { q: "*:*" })
@@ -96,7 +103,9 @@ RSpec.describe Alma::Indexer do
 
       dump = FactoryBot.create(:incremental_dump)
       indexer = described_class.new(solr_url: solr_url)
-      indexer.incremental_index!(dump)
+      perform_enqueued_jobs do
+        indexer.incremental_index!(dump)
+      end
       solr.commit
 
       # expect solr to have stuff

--- a/spec/services/alma/indexer_spec.rb
+++ b/spec/services/alma/indexer_spec.rb
@@ -102,6 +102,8 @@ RSpec.describe Alma::Indexer do
       # expect solr to have stuff
       response = solr.get("select", params: { q: "*:*" })
       expect(response['response']['numFound']).to eq 7
+
+      expect(DumpFile.done.size).to eq 2
     end
   end
 end


### PR DESCRIPTION
Closes #1469 

Notes:

* It takes approximately 1hr/dump file when a worker is running 5 threads.
* The box does not max out CPU, we may be able to add more threads, but I'm not sure and this may vary depending on how we change Traject in the future.
* With three boxes we should theoretically be able to run the full index in 7.5 hours (down from 21)