### PR TITLE
Ensure the DumpFileIndexJob errors when Traject errors.

### DIFF
--- a/app/services/alma/indexer.rb
+++ b/app/services/alma/indexer.rb
@@ -25,7 +25,7 @@ class Alma::Indexer
 
   def index_file(file_name, debug_mode = false)
     debug_flag = debug_mode ? "--debug-mode" : ""
-    `traject #{debug_flag} -c marc_to_solr/lib/traject_config.rb #{file_name} -u #{solr_url}; true`
+    `traject #{debug_flag} -c marc_to_solr/lib/traject_config.rb #{file_name} -u #{solr_url} 2>&1`
   end
 
   private

--- a/app/services/alma/indexer/dump_file_indexer.rb
+++ b/app/services/alma/indexer/dump_file_indexer.rb
@@ -10,7 +10,8 @@ class Alma::Indexer
 
     def index!
       decompress_file do |file|
-        index_file(file.path)
+        result = index_file(file.path)
+        raise "Traject indexing failed for #{file.path}" unless $CHILD_STATUS.success? && !result.include?("FATAL")
       end
     end
 

--- a/spec/jobs/dump_file_index_job_spec.rb
+++ b/spec/jobs/dump_file_index_job_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe DumpFileIndexJob do
+  describe "#perform" do
+    it "raises an error when traject errors" do
+      dump = FactoryBot.create(:incremental_dump)
+
+      expect { described_class.new.perform(dump.dump_files.first.id, "http://localhost:8983/solr/badcollection") }.to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Traject's CLI is just silently erroring when something goes wrong,
making the jobs get lost. This tests to make sure the log doesn't
include FATAL, which indicates a crash, as well as checks the exit code.