### PR TITLE
Attach each SCSB DumpFile as it's processed

### DIFF
--- a/app/models/scsb/partner_updates.rb
+++ b/app/models/scsb/partner_updates.rb
@@ -96,7 +96,6 @@ module Scsb
           end
           File.unlink(file)
         end
-        filepaths = []
         xml_files.each do |file|
           filename = File.basename(file)
           reader = MARC::XMLReader.new(file.to_s, external_encoding: 'UTF-8')
@@ -104,10 +103,9 @@ module Scsb
           writer = MARC::XMLWriter.new(filepath)
           reader.each { |record| writer.write(process_record(record)) }
           writer.close
-          filepaths << filepath
           File.unlink(file)
+          attach_dump_file(filepath)
         end
-        filepaths.sort.each { |f| attach_dump_file(f) }
       end
 
       def process_partner_deletes(files:)


### PR DESCRIPTION
2 reasons:

1. It will hit the database more often, hopefully keeping our connection
   alive
2. Linking the files as we get them will make it easier to clean up a
   failed run -- deleting the Event will clean out the files on disk.

refs #1531