### PR TITLE
Revert "Turn off scsb crons for downtime"

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -72,33 +72,33 @@ every 1.day, at: ["1:00am", "11:30am", "3:30pm"], roles: [:cron_production] do
   )
 end
 
-# # Daily racap / partner jobs
-# every 1.day, at: "3:00pm", roles: [:cron_production] do
-#   rake "marc_liberation:recap_dump", output: "/tmp/cron_log.log"
-# end
-#
-# # Daily recap shared collection update to Solr
-# every 1.day, at: "6:30am", roles: [:cron_production] do
-#   liberate_latest_production(
-#     "scsb:latest",
-#     set_url: ENV["SOLR_URL"],
-#     update_locations: "true",
-#     output: "/tmp/daily_updates.log"
-#   )
-# end
-#
-# # Daily recap shared collection update to Solr staging cluster
-# every 1.day, at: "7:00am", roles: [:cron_production] do
-#   liberate_latest_production(
-#     "scsb:latest",
-#     set_url: ENV["SOLR_REINDEX_URL"],
-#     update_locations: "true",
-#     output: "/tmp/daily_updates.log"
-#   )
-# end
-# every 1.day, at: "6:00am", roles: [:cron_production] do
-#   rake "marc_liberation:partner_update", output: "/tmp/cron_log.log"
-# end
+# Daily racap / partner jobs
+every 1.day, at: "3:00pm", roles: [:cron_production] do
+  rake "marc_liberation:recap_dump", output: "/tmp/cron_log.log"
+end
+
+# Daily recap shared collection update to Solr
+every 1.day, at: "6:30am", roles: [:cron_production] do
+  liberate_latest_production(
+    "scsb:latest",
+    set_url: ENV["SOLR_URL"],
+    update_locations: "true",
+    output: "/tmp/daily_updates.log"
+  )
+end
+
+# Daily recap shared collection update to Solr staging cluster
+every 1.day, at: "7:00am", roles: [:cron_production] do
+  liberate_latest_production(
+    "scsb:latest",
+    set_url: ENV["SOLR_REINDEX_URL"],
+    update_locations: "true",
+    output: "/tmp/daily_updates.log"
+  )
+end
+every 1.day, at: "6:00am", roles: [:cron_production] do
+  rake "marc_liberation:partner_update", output: "/tmp/cron_log.log"
+end
 
 # process the access file daily at 10:30am Eastern (the machine is in Z time, which is why this is 2pm)
 every 1.day, at: "2:30pm", roles: [:hr_cron] do


### PR DESCRIPTION
This reverts commit bfabab8c28d6f7b46eb31d4e9b129f2263598680.

I left this commit on the new `voyager` branch, and the `alma` branch has an
equivalent commit added in https://github.com/pulibrary/bibdata/pull/1536

Merging this PR will allow us to sensibly rebase the alma branch one last time
and then merge it to main.
