### PR TITLE
Add rake task to index a dump by id

### DIFF
--- a/app/services/alma/indexer.rb
+++ b/app/services/alma/indexer.rb
@@ -12,6 +12,7 @@ class Alma::Indexer
   end
 
   def incremental_index!(dump)
+    raise "received a dump with type other than CHANGED_RECORDS" unless dump.dump_type.constant == "CHANGED_RECORDS"
     dump.update!(index_status: Dump::STARTED)
     dump.dump_files.update(index_status: :started)
     batch = Sidekiq::Batch.new

--- a/lib/tasks/orangeindex.rake
+++ b/lib/tasks/orangeindex.rake
@@ -127,6 +127,17 @@ namespace :liberate do
     solr.commit
   end
 
+  desc "Index an incremental alma dump by ID"
+  task index_dump: :environment do
+    solr_url = ENV['SET_URL'] || default_solr_url
+    dump_id = ENV['DUMP_ID']
+    abort "usage: SOLR_URL=[solr_url] DUMP_ID=[dump_id] liberate:index_dump" unless solr_url && dump_id
+    solr = IndexFunctions.rsolr_connection(solr_url)
+    dump = Dump.find(dump_id)
+    Alma::Indexer.new(solr_url: solr_url).incremental_index!(dump)
+    solr.commit
+  end
+
   desc "Logs the deleted and updated IDs in the MARC files associated with a Dump"
   task dump_log_ids: :environment do
     dump_id = ENV['DUMP_ID'].to_i


### PR DESCRIPTION
This will make it easier to index one incremental alma dump at a time if
needed, until #1518 is resolved.
