### PR TITLE
Sort of fixes the issue with invalid ARKs. 

### DIFF
--- a/marc_to_solr/lib/uri_ark.rb
+++ b/marc_to_solr/lib/uri_ark.rb
@@ -41,7 +41,7 @@ class URI::ARK < URI::Generic
     # Extract the components from the ARK URL into member variables
     def extract_components!
       raise StandardError, "Invalid ARK URL using: #{self.to_s}" unless self.class.princeton_ark?(url: self)
-      m = /\:\/\/(.+)\/ark\:\/(.+)\/(.+)\/?/.match(self.to_s)
+      m = /\/(.+)\/ark\:\/(.+)\/(.+)\/?/.match(self.to_s)
 
       @nmah = m[1]
       @naan = m[2]

--- a/spec/marc_to_solr/lib/uri_ark_spec.rb
+++ b/spec/marc_to_solr/lib/uri_ark_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe URI::ARK do
     let(:princeton_ark) { 'http://arks.princeton.edu/ark:/88435/9k41zd556' }
     let(:invalid_princeton_ark) { 'http:http://arks.princeton.edu/ark:/88435/9k41zd556' }
     let(:non_princeton_ark) { 'https://nls.ldls.org.uk/welcome.html?ark:/81055/vdc_100052020059.0x000001' }
+    let(:single_slash_ark) { 'http:/arks.princeton.edu/ark:/88435/ff365d62r/pdf' }
     it 'Princeton arks return true' do
       expect(described_class.princeton_ark?(url: princeton_ark)).to eq true
     end
@@ -13,6 +14,10 @@ RSpec.describe URI::ARK do
     end
     it 'arks that include http twice the url return false ' do
       expect(described_class.princeton_ark?(url: invalid_princeton_ark)).to eq false
+    end
+    it 'handles single forward slash gracefully' do
+      ark = described_class.parse(url: single_slash_ark)
+      expect(ark.to_s).to eq "http::80/arks.princeton.edu/ark:/88435/ff365d62r/pdf"
     end
   end
 end


### PR DESCRIPTION
Notice that this version let's the ARK to be parsed but the resulting URL is not quite valid, yet, it prevents Trajects from crashing and stop processing the MARC file which is what we are after for now.

Fixes #1557 