### PR TITLE
Issue 1557 ark v2

### DIFF
--- a/marc_to_solr/lib/electronic_access_link.rb
+++ b/marc_to_solr/lib/electronic_access_link.rb
@@ -44,14 +44,12 @@ class ElectronicAccessLink
       if !@url_key&.match?(URI.regexp)
         @logger.error "#{@bib_id} - invalid URL for 856$u value: #{@url_key}"
         @url_key = nil
+      elsif @url_key.start_with?(/http:\/[A-Za-z]/)
+        # Misleading URL "http:/" instead of "http://"
+        @logger.error "#{@bib_id} - invalid URL for 856$u value (http:/): #{@url_key}"
+        @url_key = nil
       else
-        if @url_key.start_with?(/http:\/[A-Za-z]/)
-          # Misleading URL "http:/" instead of "http://"
-          @logger.error "#{@bib_id} - invalid URL for 856$u value (http:/): #{@url_key}"
-          @url_key = nil
-        else
-          @url = URI.parse(@url_key)
-        end
+        @url = URI.parse(@url_key)
       end
     end
   rescue URI::InvalidURIError

--- a/marc_to_solr/lib/electronic_access_link.rb
+++ b/marc_to_solr/lib/electronic_access_link.rb
@@ -45,7 +45,13 @@ class ElectronicAccessLink
         @logger.error "#{@bib_id} - invalid URL for 856$u value: #{@url_key}"
         @url_key = nil
       else
-        @url = URI.parse(@url_key)
+        if @url_key.start_with?(/http:\/[A-Za-z]/)
+          # Misleading URL "http:/" instead of "http://"
+          @logger.error "#{@bib_id} - invalid URL for 856$u value (http:/): #{@url_key}"
+          @url_key = nil
+        else
+          @url = URI.parse(@url_key)
+        end
       end
     end
   rescue URI::InvalidURIError

--- a/marc_to_solr/lib/uri_ark.rb
+++ b/marc_to_solr/lib/uri_ark.rb
@@ -3,8 +3,8 @@
 class URI::ARK < URI::Generic
   attr_reader :nmah, :naan, :name
 
-  ARK_REGEX = /\:\/\/(.+)\/ark\:\/(.+)\/(.+)\/?/
-  PRINCETON_ARK_REGEX = /[\/?]ark\:\/88435\/(.+)\/?/
+  ARK_REGEX = /\:\/\/(.+)\/ark\:\/(.+)\/(.+)\/?/.freeze
+  PRINCETON_ARK_REGEX = /[\/?]ark\:\/88435\/(.+)\/?/.freeze
 
   # Constructs an ARK from a URL
   # @param url [URI::Generic] the URL for the ARK resource

--- a/marc_to_solr/lib/uri_ark.rb
+++ b/marc_to_solr/lib/uri_ark.rb
@@ -3,6 +3,9 @@
 class URI::ARK < URI::Generic
   attr_reader :nmah, :naan, :name
 
+  ARK_REGEX = /\:\/\/(.+)\/ark\:\/(.+)\/(.+)\/?/
+  PRINCETON_ARK_REGEX = /[\/?]ark\:\/88435\/(.+)\/?/
+
   # Constructs an ARK from a URL
   # @param url [URI::Generic] the URL for the ARK resource
   # @return [URI::ARK] the ARK
@@ -26,8 +29,9 @@ class URI::ARK < URI::Generic
   # @return [TrueClass, FalseClass]
   def self.princeton_ark?(url:)
     return false if url.to_s.start_with?('http:http:')
-    m = /[\/?]ark\:\/88435\/(.+)\/?/.match(url.to_s)
-    !!m
+    return false unless PRINCETON_ARK_REGEX.match(url.to_s)
+    return false unless ARK_REGEX.match(url.to_s)
+    true
   end
 
   # Constructor
@@ -41,7 +45,7 @@ class URI::ARK < URI::Generic
     # Extract the components from the ARK URL into member variables
     def extract_components!
       raise StandardError, "Invalid ARK URL using: #{self.to_s}" unless self.class.princeton_ark?(url: self)
-      m = /[\/]?(.+)\/ark\:\/(.+)\/(.+)\/?/.match(self.to_s)
+      m = ARK_REGEX.match(self.to_s)
 
       @nmah = m[1]
       @naan = m[2]

--- a/spec/marc_to_solr/lib/princeton_marc_spec.rb
+++ b/spec/marc_to_solr/lib/princeton_marc_spec.rb
@@ -172,6 +172,19 @@ describe 'From princeton_marc.rb' do
       end
     end
 
+    context 'with a tricky URL (single slash)' do
+      let(:url) { 'http:/badurl.com' }
+
+      it 'retrieves no URLs' do
+        expect(links).to be_empty
+      end
+
+      it 'logs an error' do
+        ElectronicAccessLink.new(bib_id: 9_947_652_213_506_421, holding_id: nil, z_label: nil, anchor_text: nil, url_key: url, logger: logger)
+        expect(logger).to have_received(:error).with("9947652213506421 - invalid URL for 856$u value (http:/): #{url}")
+      end
+    end
+
     context 'with an invalid URL which still manages to be match the valid uri regexp' do
       let(:url) { 'http://www.strategicstudiesinstitute.army.mil/pdffiles/PUB949[1].pdf' }
 

--- a/spec/marc_to_solr/lib/princeton_marc_spec.rb
+++ b/spec/marc_to_solr/lib/princeton_marc_spec.rb
@@ -185,6 +185,19 @@ describe 'From princeton_marc.rb' do
       end
     end
 
+    context 'no HTTP url' do
+      let(:url) { 'arks.princeton.edu/ark:/88435/ff365d62r/pdf' }
+
+      it 'retrieves URLs' do
+        expect(links).not_to be_empty
+      end
+
+      it 'produces a URL' do
+        link = ElectronicAccessLink.new(bib_id: 9_947_652_213_506_421, holding_id: nil, z_label: nil, anchor_text: nil, url_key: url, logger: logger)
+        expect(links.key?(url)).to eq true
+      end
+    end
+
     context 'with an invalid URL which still manages to be match the valid uri regexp' do
       let(:url) { 'http://www.strategicstudiesinstitute.army.mil/pdffiles/PUB949[1].pdf' }
 

--- a/spec/marc_to_solr/lib/uri_ark_spec.rb
+++ b/spec/marc_to_solr/lib/uri_ark_spec.rb
@@ -16,9 +16,8 @@ RSpec.describe URI::ARK do
     it 'arks that include http twice the url return false ' do
       expect(described_class.princeton_ark?(url: invalid_princeton_ark)).to eq false
     end
-    it 'handles single forward slash gracefully' do
-      ark = described_class.parse(url: single_slash_ark)
-      expect(ark.to_s).to eq "http::80/arks.princeton.edu/ark:/88435/ff365d62r/pdf"
+    it 'Invalid Princeton arks return false' do
+      expect(described_class.princeton_ark?(url: single_slash_ark)).to eq false
     end
     it 'handles no http' do
       ark = described_class.parse(url: no_http)

--- a/spec/marc_to_solr/lib/uri_ark_spec.rb
+++ b/spec/marc_to_solr/lib/uri_ark_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe URI::ARK do
     let(:invalid_princeton_ark) { 'http:http://arks.princeton.edu/ark:/88435/9k41zd556' }
     let(:non_princeton_ark) { 'https://nls.ldls.org.uk/welcome.html?ark:/81055/vdc_100052020059.0x000001' }
     let(:single_slash_ark) { 'http:/arks.princeton.edu/ark:/88435/ff365d62r/pdf' }
-    let(:no_http) { 'arks.princeton.edu/ark:/88435/ff365d62r/pdf' }
     it 'Princeton arks return true' do
       expect(described_class.princeton_ark?(url: princeton_ark)).to eq true
     end
@@ -18,10 +17,6 @@ RSpec.describe URI::ARK do
     end
     it 'Invalid Princeton arks return false' do
       expect(described_class.princeton_ark?(url: single_slash_ark)).to eq false
-    end
-    it 'handles no http' do
-      ark = described_class.parse(url: no_http)
-      expect(ark.to_s).to eq "arks.princeton.edu/ark:/88435/ff365d62r/pdf"
     end
   end
 end


### PR DESCRIPTION
This is a slight enhancement to the work in PR #1559. Now the code detects the invalid URL with a single forward slash (e.g. http:/something), logs the error, and does not produce the invalid link for the `electronic_access_1display` field in Solr. And it does not crash Traject.

Notice that I moved some of the tests that were under `spec/marc_to_solr/lib/uri_ark_spec.rb` to be under `spec/marc_to_solr/lib/princeton_marc_spec.rb` since when a MARC file is being processed these checks happen before the ARK code, i.e. the ARK class will not get the bad URLs.