### PR TITLE
Makes the CDL check only when client request a deep availability check

### DIFF
--- a/app/adapters/alma_adapter.rb
+++ b/app/adapters/alma_adapter.rb
@@ -40,7 +40,7 @@ class AlmaAdapter
     bibs = Alma::Bib.find(Array.wrap(id), expand: ["p_avail", "e_avail", "d_avail", "requests"].join(",")).each
     return nil if bibs.count == 0
 
-    av_info = AvailabilityStatus.new(bib: bibs.first).bib_availability
+    av_info = AvailabilityStatus.new(bib: bibs.first, deep_check: deep_check).bib_availability
 
     temp_locations = av_info.any? { |_key, value| value[:temp_location] }
     if temp_locations && deep_check

--- a/app/adapters/alma_adapter/availability_status.rb
+++ b/app/adapters/alma_adapter/availability_status.rb
@@ -155,7 +155,7 @@ class AlmaAdapter
 
       def cdl_holding?(holding_id)
         cdl = false
-        item_data[holding_id].each do |bib_item|
+        (item_data[holding_id] || []).each do |bib_item|
           if AlmaItem.new(bib_item).cdl?
             cdl = true
             break

--- a/app/adapters/alma_adapter/availability_status.rb
+++ b/app/adapters/alma_adapter/availability_status.rb
@@ -6,8 +6,9 @@ class AlmaAdapter
     end
 
     attr_reader :bib
-    def initialize(bib:)
+    def initialize(bib:, deep_check: false)
       @bib = bib
+      @deep_check = deep_check
     end
 
     # Returns availability information for each of the holdings in the Bib record.
@@ -60,7 +61,7 @@ class AlmaAdapter
         # condition.
         status[:id] = "fake_id_#{sequence}"
         status[:temp_location] = true
-      elsif status[:status_label] == "Unavailable"
+      elsif status[:status_label] == "Unavailable" && @deep_check
         # Notice that we only check if a holding is available via CDL when necessary
         # because it requires an extra (slow-ish) API call.
         status[:cdl] = cdl_holding?(holding["holding_id"])

--- a/spec/adapters/alma_adapter_spec.rb
+++ b/spec/adapters/alma_adapter_spec.rb
@@ -230,9 +230,18 @@ RSpec.describe AlmaAdapter do
       expect(holding[:cdl]).to eq false
     end
 
-    it "reports CDL when available" do
+    it "by default does not report CDL availability for unavailable records" do
       FactoryBot.create(:holding_location, code: 'firestone$stacks', label: 'Stacks')
       availability = adapter.get_availability_one(id: "9965126093506421")
+      holding = availability["9965126093506421"]["22202918790006421"]
+      expect(holding[:status_label]).to eq "Unavailable"
+      expect(holding[:cdl]).to eq false
+      expect(holding[:label]).to eq 'Firestone Library - Stacks'
+    end
+
+    it "reports CDL availability for unavailable records when requesting deep check" do
+      FactoryBot.create(:holding_location, code: 'firestone$stacks', label: 'Stacks')
+      availability = adapter.get_availability_one(id: "9965126093506421", deep_check: true)
       holding = availability["9965126093506421"]["22202918790006421"]
       expect(holding[:status_label]).to eq "Unavailable"
       expect(holding[:cdl]).to eq true


### PR DESCRIPTION
Address the slowness in the calls for availability (issue #1564)

Since the biggest performance offender seems to be the extra calls that we make to `/bibs/.../holdings/ALL/items` this PR stops making that extra call automatically for all Unavailable records. Instead, we only make the call for Unavailable records _if the client requests it_ (via the deep parameter). 

For now we are not making any changes to Orangelight. OL will just get "Unavailable" for records that Alma report as Unavailable and no indication whether they are available through CDL.

See also https://github.com/pulibrary/orangelight/pull/2597 for changes to Orangelight to preserve the CDL flag *on the show page*.