### PR TITLE
Requests items sorted by enum from Alma

### DIFF
--- a/app/adapters/alma_adapter/availability_status.rb
+++ b/app/adapters/alma_adapter/availability_status.rb
@@ -114,7 +114,8 @@ class AlmaAdapter
         # This method DOES issue a separate call to the Alma API to get item information.
         # Internally this call passes "ALL" to ExLibris to get data for all the holdings
         # in the current bib record.
-        Alma::BibItem.find(bib.id).items
+        opts = { order_by: "enum_a" }
+        Alma::BibItem.find(bib.id, opts).items
       end
 
       @item_data = items.group_by do |item|
@@ -146,7 +147,7 @@ class AlmaAdapter
       options = { enable_loggable: true, timeout: 10 }
       message = "Items for bib: #{bib.id}, holding_id: #{holding_id}"
       AlmaAdapter::Execute.call(options: options, message: message) do
-        opts = { limit: Alma::BibItemSet::ITEMS_PER_PAGE, holding_id: holding_id }
+        opts = { limit: Alma::BibItemSet::ITEMS_PER_PAGE, holding_id: holding_id, order_by: "enum_a" }
         items = Alma::BibItem.find(bib.id, opts).all.map { |item| AlmaAdapter::AlmaItem.new(item) }
         data = { items: items, total_count: items.count }
       end

--- a/spec/adapters/alma_adapter_spec.rb
+++ b/spec/adapters/alma_adapter_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe AlmaAdapter do
         .with(headers: stub_alma_request_headers)
         .to_return(status: 200, body: bib_record_with_cdl, headers: { "content-Type" => "application/json" })
 
-      stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/9965126093506421/holdings/ALL/items")
+      stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/9965126093506421/holdings/ALL/items?order_by=enum_a")
         .with(headers: stub_alma_request_headers)
         .to_return(status: 200, body: bib_record_with_cdl_holding_items, headers: { "content-Type" => "application/json" })
 
@@ -413,7 +413,7 @@ RSpec.describe AlmaAdapter do
         .to_return(status: 429, body: stub_alma_per_second_threshold, headers: { "content-Type" => "application/json" })
 
       stub_alma_ids(ids: "9919392043506421", status: 200)
-      stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/9919392043506421/holdings/22105104420006421/items?limit=100")
+      stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/9919392043506421/holdings/22105104420006421/items?limit=100&order_by=enum_a")
         .to_return(status: 429, body: stub_alma_per_second_threshold, headers: { "Content-Type" => "application/json" })
     end
 

--- a/spec/requests/bib_gets_spec.rb
+++ b/spec/requests/bib_gets_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Bibliographic Gets", type: :request do
         .to_return(status: 429, headers: alma_response_headers, body: alma_response_body)
 
       stub_alma_ids(ids: "9919392043506421", status: 200)
-      stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/9919392043506421/holdings/22105104420006421/items?limit=100")
+      stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/9919392043506421/holdings/22105104420006421/items?limit=100&order_by=enum_a")
         .to_return(status: 429, headers: alma_response_headers, body: alma_response_body)
     end
 

--- a/spec/support/stub_alma.rb
+++ b/spec/support/stub_alma.rb
@@ -33,7 +33,8 @@ module AlmaStubbing
 
   def stub_alma_holding_items(mms_id:, holding_id:, filename:, query: "limit=100")
     alma_path = Pathname.new(file_fixture_path).join("alma")
-    stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/#{mms_id}/holdings/#{holding_id}/items?#{query}")
+    query_string = [query, "order_by=enum_a"].select(&:present?).join("&")
+    stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/#{mms_id}/holdings/#{holding_id}/items?#{query_string}")
       .to_return(status: 200,
                  headers: { "Content-Type" => "application/json" },
                  body: alma_path.join(filename))


### PR DESCRIPTION
Requests items sorted by enum descending (e.g. vol 10, vol 9, vol 8). There is no default value so we were getting the items in who-knows-what order.

Fixes https://github.com/pulibrary/requests/issues/987

Below is a fragment of the data that bib data returns for a holding with multiple volumes (`/bibliographic/998574693506421/holdings/22579848200006421/availability.json`):

```
[
    {
        "barcode": "32101036813440",
        "id": "23579847650006421",
        "holding_id": "22579848200006421",
        "status": "Available",
        ...
        "enum_display": "vol. 290, no. 5489-5495",
        "chron_display": "Oct.-17 Nov. 2000",
        "in_temp_library": false
    },
    {
        "barcode": "32101039383789",
        "id": "23579847660006421",
        "holding_id": "22579848200006421",
        "status": "Available",
        ...
        "enum_display": "vol. 289, no. 5483-5488",
        "chron_display": "25 Aug.-29 Sept. 2000",
        "in_temp_library": false
    },
    {
        "barcode": "32101039383771",
        "id": "23579847670006421",
        "holding_id": "22579848200006421",
        "status": "Available",
        ...
        "enum_display": "vol. 289, no. 5476-5482",
        "chron_display": "July-18 Aug. 2000",
        "in_temp_library": false
    },
    {
        "barcode": "32101039161151",
        "id": "23579847710006421",
        "holding_id": "22579848200006421",
        "status": "Available",
        ...
        "enum_display": "vol. 288, no. 5470-5475",
        "chron_display": "May 26-June 2000",
        "in_temp_library": false
    }
    ...
```