### PR TITLE
Re-namespace locations routes to the same routes they were before.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,11 +6,13 @@ Rails.application.routes.draw do
   resources :dumps, only: [:show]
   resources :campus_access_exceptions, only: [:new, :create]
 
-  resources :hours_locations
-  resources :holding_locations
-  resources :libraries
-  resources :delivery_locations
-  get 'digital_locations', to: 'delivery_locations#digital_locations'
+  scope :locations do
+    resources :hours_locations
+    resources :holding_locations
+    resources :libraries
+    resources :delivery_locations
+    get 'digital_locations', to: 'delivery_locations#digital_locations'
+  end
 
   get '/bibliographic', to: 'bibliographic#index', defaults: { format: :txt }
   get '/bibliographic/:bib_id/availability', to: 'bibliographic#availability'

--- a/spec/controllers/delivery_locations_controller_spec.rb
+++ b/spec/controllers/delivery_locations_controller_spec.rb
@@ -17,7 +17,7 @@ describe DeliveryLocationsController, type: :controller do
 
     it 'delivery_locations is active in navbar' do
       get :index
-      expect(response.body.include?('<li class="active"><a href="/delivery_locations')).to eq true
+      expect(response.body.include?('<li class="active"><a href="/locations/delivery_locations')).to eq true
     end
   end
 

--- a/spec/controllers/holding_locations_controller_spec.rb
+++ b/spec/controllers/holding_locations_controller_spec.rb
@@ -17,7 +17,7 @@ describe HoldingLocationsController, type: :controller do
 
     it 'holding_locations is active in navbar' do
       get :index
-      expect(response.body.include?('<li class="active"><a href="/holding_locations')).to eq true
+      expect(response.body.include?('<li class="active"><a href="/locations/holding_locations')).to eq true
     end
   end
 

--- a/spec/controllers/hours_locations_controller_spec.rb
+++ b/spec/controllers/hours_locations_controller_spec.rb
@@ -19,7 +19,7 @@ describe HoursLocationsController, type: :controller do
 
     it 'hours_locations is active in navbar' do
       get :index
-      expect(response.body.include?('<li class="active"><a href="/hours_locations')).to eq true
+      expect(response.body.include?('<li class="active"><a href="/locations/hours_locations')).to eq true
     end
   end
 

--- a/spec/controllers/libraries_controller_spec.rb
+++ b/spec/controllers/libraries_controller_spec.rb
@@ -16,7 +16,7 @@ describe LibrariesController, type: :controller do
 
     it 'libraries is active in navbar' do
       get :index
-      expect(response.body.include?('<li class="active"><a href="/libraries')).to eq true
+      expect(response.body.include?('<li class="active"><a href="/locations/libraries')).to eq true
     end
   end
 

--- a/spec/system/devise_spec.rb
+++ b/spec/system/devise_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Devise restricts features for unauthenticated users', type: :sys
   ["libraries", "holding_locations", "delivery_locations",
    "hours_locations"].each_with_index do |data_type, _i|
     scenario "anyone can retrieve JSON feeds for #{data_type}" do
-      visit "/#{data_type}.json"
+      visit "/locations/#{data_type}.json"
     end
   end
 


### PR DESCRIPTION
Fixes a bug in Figgy and Requests caused by the new URL.