### PR TITLE
IndexManager to manage control of indexing into separate Solr URLs.

### DIFF
--- a/app/jobs/alma_dump_transfer_job.rb
+++ b/app/jobs/alma_dump_transfer_job.rb
@@ -16,7 +16,8 @@ class AlmaDumpTransferJob < ActiveJob::Base
     dump.save
 
     if incremental_dump?(type_constant)
-      IndexManager.for(Rails.application.config.solr["url"]).index_remaining!
+      # IndexManager.for(Rails.application.config.solr["url"]).index_remaining!
+      IncrementalIndexJob.perform_later(dump)
     elsif recap_incremental_dump?(type_constant)
       # RecapBoundwithsProcessingJob will not include all records. Re-enable
       # when this issue is resolved: https://github.com/pulibrary/bibdata/issues/1463

--- a/app/jobs/alma_dump_transfer_job.rb
+++ b/app/jobs/alma_dump_transfer_job.rb
@@ -16,7 +16,7 @@ class AlmaDumpTransferJob < ActiveJob::Base
     dump.save
 
     if incremental_dump?(type_constant)
-      IncrementalIndexJob.perform_later(dump)
+      IndexManager.for(Rails.application.config.solr["url"]).index_remaining!
     elsif recap_incremental_dump?(type_constant)
       # RecapBoundwithsProcessingJob will not include all records. Re-enable
       # when this issue is resolved: https://github.com/pulibrary/bibdata/issues/1463

--- a/app/jobs/index_remaining_dumps_job.rb
+++ b/app/jobs/index_remaining_dumps_job.rb
@@ -1,0 +1,10 @@
+class IndexRemainingDumpsJob
+  include Sidekiq::Worker
+  def perform(index_manager_id)
+    index_manager = IndexManager.find(index_manager_id)
+    return unless index_manager.next_dump
+    batch.jobs do
+      index_manager.index_next_dump!
+    end
+  end
+end

--- a/app/models/dump.rb
+++ b/app/models/dump.rb
@@ -25,6 +25,7 @@ class Dump < ActiveRecord::Base
   scope :partner_recap_full, -> { where(dump_type: partner_recap_full_dump_type) }
   scope :partner_recap, -> { where(dump_type: DumpType.where(constant: 'PARTNER_RECAP')) }
   scope :changed_records, -> { where(dump_type: DumpType.where(constant: 'CHANGED_RECORDS')) }
+  scope :full_dumps, -> { where(dump_type: DumpType.where(constant: 'ALL_RECORDS')) }
 
   class << self
     ##

--- a/app/models/dump.rb
+++ b/app/models/dump.rb
@@ -68,6 +68,10 @@ class Dump < ActiveRecord::Base
       end
   end # class << self
 
+  def full_dump?
+    dump_type.constant == 'ALL_RECORDS'
+  end
+
   def subsequent_partner_incrementals
     Dump.partner_recap.where(generated_date: generated_date..Float::INFINITY)
   end

--- a/app/models/index_manager.rb
+++ b/app/models/index_manager.rb
@@ -1,0 +1,59 @@
+class IndexManager < ActiveRecord::Base
+  # @param solr_url Solr URL to get the index manager for (or initialize a new
+  #   one)
+  # @returns [IndexManager]
+  def self.for(solr_url)
+    IndexManager.find_or_initialize_by(solr_collection: solr_url)
+  end
+  belongs_to :dump_in_progress, class_name: "Dump"
+  belongs_to :last_dump_completed, class_name: "Dump"
+
+  def index_next_dump!
+    return unless next_dump
+    self.dump_in_progress = next_dump
+    save
+    generate_batch do
+      next_dump.dump_files.each do |dump_file|
+        DumpFileIndexJob.perform_async(dump_file.id, solr_collection)
+      end
+    end
+  end
+
+  def generate_batch
+    batch = Sidekiq::Batch.new
+    batch.on(:success, IndexManager::Workflow, 'dump_id' => next_dump.id, 'index_manager_id' => id)
+    batch.jobs do
+      yield
+    end
+  end
+
+  def next_dump
+    @next_dump ||=
+      begin
+        if last_dump_completed
+          next_incremental
+        else
+          recent_full_dump
+        end
+      end
+  end
+
+  def recent_full_dump
+    Dump.full_dumps.joins(:event).order("events.start" => "DESC").first
+  end
+
+  def next_incremental
+    Dump.changed_records.joins(:event).where("events.start > ?", last_dump_completed.event.start.iso8601).order("events.start" => "ASC").first
+  end
+
+  class Workflow
+    # Callback for when the batch of DumpFiles is done indexing.
+    def on_success(_status, options)
+      index_manager = IndexManager.find(options['index_manager_id'])
+      dump = Dump.find(options['dump_id'])
+      index_manager.last_dump_completed = dump
+      index_manager.dump_in_progress = nil
+      index_manager.save
+    end
+  end
+end

--- a/app/models/index_manager.rb
+++ b/app/models/index_manager.rb
@@ -28,7 +28,7 @@ class IndexManager < ActiveRecord::Base
     # Create an overall catchup batch.
     batch = Sidekiq::Batch.new
     batch.on(:success, "IndexManager::Workflow#indexed_remaining", 'index_manager_id' => id)
-    batch.description = "Index remaining dumps to catch up."
+    batch.description = "Performing catch-up index into #{solr_collection}"
     batch.jobs do
       IndexRemainingDumpsJob.perform_async(id)
     end
@@ -37,6 +37,7 @@ class IndexManager < ActiveRecord::Base
   def generate_batch
     batch = Sidekiq::Batch.new
     batch.on(:success, IndexManager::Workflow, 'dump_id' => next_dump.id, 'index_manager_id' => id)
+    batch.description = "Indexing Dump #{next_dump.id} into #{solr_collection}"
     batch.jobs do
       yield
     end

--- a/app/services/alma/indexer.rb
+++ b/app/services/alma/indexer.rb
@@ -11,11 +11,6 @@ class Alma::Indexer
     end
   end
 
-  def update_index!
-    manager = IndexManager.for(solr_url)
-    manager.index_next_dump!
-  end
-
   def incremental_index!(dump)
     raise "received a dump with type other than CHANGED_RECORDS" unless dump.dump_type.constant == "CHANGED_RECORDS"
     dump.update!(index_status: Dump::STARTED)

--- a/app/services/alma/indexer.rb
+++ b/app/services/alma/indexer.rb
@@ -11,6 +11,11 @@ class Alma::Indexer
     end
   end
 
+  def update_index!
+    manager = IndexManager.for(solr_url)
+    manager.index_next_dump!
+  end
+
   def incremental_index!(dump)
     raise "received a dump with type other than CHANGED_RECORDS" unless dump.dump_type.constant == "CHANGED_RECORDS"
     dump.update!(index_status: Dump::STARTED)

--- a/db/migrate/20210810161840_create_index_managers.rb
+++ b/db/migrate/20210810161840_create_index_managers.rb
@@ -1,0 +1,11 @@
+class CreateIndexManagers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :index_managers do |t|
+      t.string :solr_collection, index: { unique: true }
+      t.references :dump_in_progress, foreign_key: { to_table: 'dumps' }
+      t.references :last_dump_completed, foreign_key: { to_table: 'dumps' }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210810204449_add_in_progress_to_index_manager.rb
+++ b/db/migrate/20210810204449_add_in_progress_to_index_manager.rb
@@ -1,0 +1,5 @@
+class AddInProgressToIndexManager < ActiveRecord::Migration[5.2]
+  def change
+    add_column :index_managers, :in_progress, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_06_182740) do
+ActiveRecord::Schema.define(version: 2021_08_10_161840) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,6 +107,17 @@ ActiveRecord::Schema.define(version: 2021_07_06_182740) do
     t.index ["status"], name: "index_hathi_accesses_on_status"
   end
 
+  create_table "index_managers", force: :cascade do |t|
+    t.string "solr_collection"
+    t.bigint "dump_in_progress_id"
+    t.bigint "last_dump_completed_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dump_in_progress_id"], name: "index_index_managers_on_dump_in_progress_id"
+    t.index ["last_dump_completed_id"], name: "index_index_managers_on_last_dump_completed_id"
+    t.index ["solr_collection"], name: "index_index_managers_on_solr_collection", unique: true
+  end
+
   create_table "locations_delivery_locations", id: :serial, force: :cascade do |t|
     t.string "label"
     t.text "address"
@@ -183,6 +194,8 @@ ActiveRecord::Schema.define(version: 2021_07_06_182740) do
     t.index ["username"], name: "index_users_on_username"
   end
 
+  add_foreign_key "index_managers", "dumps", column: "dump_in_progress_id"
+  add_foreign_key "index_managers", "dumps", column: "last_dump_completed_id"
   add_foreign_key "locations_delivery_locations", "locations_libraries"
   add_foreign_key "locations_holding_locations", "locations_hours_locations"
   add_foreign_key "locations_holding_locations", "locations_libraries"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_10_161840) do
+ActiveRecord::Schema.define(version: 2021_08_10_204449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 2021_08_10_161840) do
     t.bigint "last_dump_completed_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "in_progress"
     t.index ["dump_in_progress_id"], name: "index_index_managers_on_dump_in_progress_id"
     t.index ["last_dump_completed_id"], name: "index_index_managers_on_last_dump_completed_id"
     t.index ["solr_collection"], name: "index_index_managers_on_solr_collection", unique: true

--- a/lib/tasks/index_manager.rake
+++ b/lib/tasks/index_manager.rake
@@ -1,0 +1,11 @@
+namespace :index_manager do
+  desc "Initialize index manager for the current production Solr URL with the latest dump"
+  task initialize: :environment do
+    solr_url = Rails.application.config.solr["url"]
+    most_recent_dump = Dump.changed_records.joins(:events).order('events.started' => 'DESC').first
+    manager = IndexManager.for(solr_url)
+    manager.last_dump_completed = most_recent_dump
+    manager.save!
+    puts "Created IndexManager for #{solr_url} pointed to Dump ID #{solr_url}"
+  end
+end

--- a/lib/tasks/orangeindex.rake
+++ b/lib/tasks/orangeindex.rake
@@ -110,7 +110,11 @@ namespace :liberate do
   desc "Index remaining incrementals against SET_URL"
   task incremental: :environment do
     solr_url = ENV['SET_URL'] || default_solr_url
-    IndexManager.for(solr_url).index_remaining!
+    solr = IndexFunctions.rsolr_connection(solr_url)
+    dump = Dump.changed_records.last
+    Alma::Indexer.new(solr_url: solr_url).incremental_index!(dump)
+    solr.commit
+    # IndexManager.for(solr_url).index_remaining!
   end
 
   desc "Index a single MARC XML file against SET_URL"

--- a/lib/tasks/orangeindex.rake
+++ b/lib/tasks/orangeindex.rake
@@ -107,13 +107,10 @@ namespace :liberate do
     solr.commit
   end
 
-  desc "Index latest incremental record dump against SET_URL"
+  desc "Index remaining incrementals against SET_URL"
   task incremental: :environment do
     solr_url = ENV['SET_URL'] || default_solr_url
-    solr = IndexFunctions.rsolr_connection(solr_url)
-    dump = Dump.changed_records.last
-    Alma::Indexer.new(solr_url: solr_url).incremental_index!(dump)
-    solr.commit
+    IndexManager.for(solr_url).index_remaining!
   end
 
   desc "Index a single MARC XML file against SET_URL"

--- a/spec/factories/index_managers.rb
+++ b/spec/factories/index_managers.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :index_manager do
+    solr_collection "MyString"
+    dump_in_progress nil
+    last_dump_completed nil
+  end
+end

--- a/spec/jobs/alma_dump_transfer_job_spec.rb
+++ b/spec/jobs/alma_dump_transfer_job_spec.rb
@@ -77,7 +77,8 @@ RSpec.describe AlmaDumpTransferJob, type: :job do
         expect(dump.dump_files.map(&:dump_file_type).map(&:constant).uniq).to eq ["BIB_RECORDS"]
         expect(dump.dump_files.first.path).to eq File.join(MARC_LIBERATION_CONFIG['data_dir'], filename1)
 
-        expect(IndexRemainingDumpsJob).not_to have_received(:perform_async)
+        expect(IncrementalIndexJob).not_to have_been_enqueued
+        # expect(IndexRemainingDumpsJob).not_to have_received(:perform_async)
       end
     end
 
@@ -121,7 +122,8 @@ RSpec.describe AlmaDumpTransferJob, type: :job do
         expect(Dump.first.dump_files.count).to eq 1
         expect(Dump.first.dump_files.map(&:dump_file_type).map(&:constant).uniq).to eq ["UPDATED_RECORDS"]
         expect(Dump.first.dump_files.first.path).to eq File.join(MARC_LIBERATION_CONFIG['data_dir'], filename)
-        expect(IndexRemainingDumpsJob).to have_received(:perform_async).once
+        # expect(IndexRemainingDumpsJob).to have_received(:perform_async).once
+        expect(IncrementalIndexJob).to have_been_enqueued.once
       end
     end
     context "with a recap incremental dump" do

--- a/spec/jobs/alma_dump_transfer_job_spec.rb
+++ b/spec/jobs/alma_dump_transfer_job_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe AlmaDumpTransferJob, type: :job do
   let(:attrs) { Net::SFTP::Protocol::V01::Attributes.new({}) }
 
   describe 'perform' do
+    before do
+      allow(IndexRemainingDumpsJob).to receive(:perform_async)
+    end
     after do
       ActiveJob::Base.queue_adapter.enqueued_jobs = []
     end
@@ -74,7 +77,7 @@ RSpec.describe AlmaDumpTransferJob, type: :job do
         expect(dump.dump_files.map(&:dump_file_type).map(&:constant).uniq).to eq ["BIB_RECORDS"]
         expect(dump.dump_files.first.path).to eq File.join(MARC_LIBERATION_CONFIG['data_dir'], filename1)
 
-        expect(IncrementalIndexJob).not_to have_been_enqueued
+        expect(IndexRemainingDumpsJob).not_to have_received(:perform_async)
       end
     end
 
@@ -118,7 +121,7 @@ RSpec.describe AlmaDumpTransferJob, type: :job do
         expect(Dump.first.dump_files.count).to eq 1
         expect(Dump.first.dump_files.map(&:dump_file_type).map(&:constant).uniq).to eq ["UPDATED_RECORDS"]
         expect(Dump.first.dump_files.first.path).to eq File.join(MARC_LIBERATION_CONFIG['data_dir'], filename)
-        expect(IncrementalIndexJob).to have_been_enqueued.once
+        expect(IndexRemainingDumpsJob).to have_received(:perform_async).once
       end
     end
     context "with a recap incremental dump" do

--- a/spec/models/index_manager_spec.rb
+++ b/spec/models/index_manager_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe IndexManager, type: :model do
       end
       # Have to manually call batch callbacks
       run_callback(Sidekiq::BatchSet.new.to_a.last)
-      # IncrementalIndexJob.new.on_success(Sidekiq::BatchSet.new.to_a.last, "dump_id" => dump.id)
       solr.commit
 
       response = solr.get("select", params: { q: "*:*" })

--- a/spec/models/index_manager_spec.rb
+++ b/spec/models/index_manager_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe IndexManager, type: :model do
+  let(:solr_url) { ENV["SOLR_URL"] || "http://#{ENV['lando_marc_liberation_test_solr_conn_host']}:#{ENV['lando_marc_liberation_test_solr_conn_port']}/solr/marc-liberation-core-test" }
+  describe "index_next_dump!" do
+    let(:solr) { RSolr.connect(url: solr_url) }
+    before do
+      Sidekiq::BatchSet.new.to_a.each(&:delete)
+      solr.delete_by_query("*:*")
+      solr.commit
+    end
+    it "indexes a full dump if there's been nothing indexed yet" do
+      full_event = FactoryBot.create(:full_dump_event)
+      incremental_event = FactoryBot.create(:incremental_dump_event)
+
+      index_manager = described_class.for(solr_url)
+      Sidekiq::Testing.inline! do
+        index_manager.index_next_dump!
+      end
+      # Have to manually call batch callbacks
+      run_callback(Sidekiq::BatchSet.new.to_a.last)
+      # IncrementalIndexJob.new.on_success(Sidekiq::BatchSet.new.to_a.last, "dump_id" => dump.id)
+      solr.commit
+
+      response = solr.get("select", params: { q: "*:*" })
+      # There's one record in 1.xml, and one record in 2.xml
+      expect(response['response']['numFound']).to eq 2
+      index_manager.reload
+      expect(index_manager.last_dump_completed).to eq full_event.dump
+      expect(index_manager.dump_in_progress).to be_nil
+    end
+    it "indexes the next incremental if the most recent full dump has been done" do
+      allow(DumpFileIndexJob).to receive(:perform_async).and_call_original
+      # This incremental is before the full dump, don't run it
+      pre_incremental_event = FactoryBot.create(:incremental_dump_event, start: Time.current - 2.days, finish: Time.current - 2.days + 100)
+      full_event = FactoryBot.create(:full_dump_event, start: Time.current - 1.day, finish: Time.current - 1.day + 100)
+      # This should get run on the second call
+      incremental_event = FactoryBot.create(:incremental_dump_event, start: Time.current - 4.hours, finish: Time.current - 3.hours)
+      # Incremental that isn't run yet, but would eventually.
+      final_incremental_event = FactoryBot.create(:incremental_dump_event, start: Time.current - 2.hours, finish: Time.current - 1.hour)
+
+      index_manager = described_class.for(solr_url)
+      Sidekiq::Testing.inline! do
+        # Index full dump
+        index_manager.index_next_dump!
+        run_callback(Sidekiq::BatchSet.new.to_a.last)
+        # Index incremental
+        index_manager = described_class.find(index_manager.id)
+        index_manager.index_next_dump!
+        run_callback(Sidekiq::BatchSet.new.to_a.last)
+      end
+      solr.commit
+
+      expect(DumpFileIndexJob).not_to have_received(:perform_async).with(pre_incremental_event.dump.dump_files.first.id, anything)
+      expect(DumpFileIndexJob).to have_received(:perform_async).with(incremental_event.dump.dump_files.first.id, anything)
+      expect(DumpFileIndexJob).not_to have_received(:perform_async).with(final_incremental_event.dump.dump_files.first.id, anything)
+      response = solr.get("select", params: { q: "*:*" })
+      expect(response['response']['numFound']).to eq 9
+      index_manager.reload
+      expect(index_manager.last_dump_completed).to eq incremental_event.dump
+      expect(index_manager.dump_in_progress).to be_nil
+    end
+  end
+
+  def run_callback(batch_set)
+    callback = batch_set.callbacks["success"][0]
+    callback.each do |class_name, args|
+      class_name.constantize.new.on_success(batch_set, args)
+    end
+  end
+end

--- a/spec/models/index_manager_spec.rb
+++ b/spec/models/index_manager_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe IndexManager, type: :model do
       index_manager.reload
       expect(index_manager.last_dump_completed).to eq full_event.dump
       expect(index_manager.dump_in_progress).to be_nil
+      expect(index_manager).not_to be_in_progress
     end
     it "doesn't index anything if it's caught up" do
       allow(DumpFileIndexJob).to receive(:perform_async).and_call_original
@@ -45,6 +46,7 @@ RSpec.describe IndexManager, type: :model do
       expect(index_manager.index_next_dump!).to be_nil
       expect(index_manager.reload.dump_in_progress).to be_nil
       expect(DumpFileIndexJob).to have_received(:perform_async).exactly(2).times
+      expect(index_manager).not_to be_in_progress
     end
     it "indexes the next incremental if the most recent full dump has been done" do
       allow(DumpFileIndexJob).to receive(:perform_async).and_call_original
@@ -76,6 +78,7 @@ RSpec.describe IndexManager, type: :model do
       index_manager.reload
       expect(index_manager.last_dump_completed).to eq incremental_event.dump
       expect(index_manager.dump_in_progress).to be_nil
+      expect(index_manager).not_to be_in_progress
     end
   end
 
@@ -89,6 +92,7 @@ RSpec.describe IndexManager, type: :model do
       final_incremental_event = FactoryBot.create(:incremental_dump_event, start: Time.current - 2.hours, finish: Time.current - 1.hour)
 
       index_manager = described_class.for(solr_url)
+      expect(index_manager).not_to be_in_progress
       Sidekiq::Testing.inline! do
         # Index full dump
         index_manager.index_remaining!
@@ -110,6 +114,7 @@ RSpec.describe IndexManager, type: :model do
       index_manager.reload
       expect(index_manager.last_dump_completed).to eq final_incremental_event.dump
       expect(index_manager.dump_in_progress).to be_nil
+      expect(index_manager).not_to be_in_progress
     end
   end
 

--- a/spec/models/index_manager_spec.rb
+++ b/spec/models/index_manager_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe IndexManager, type: :model do
   let(:solr_url) { ENV["SOLR_URL"] || "http://#{ENV['lando_marc_liberation_test_solr_conn_host']}:#{ENV['lando_marc_liberation_test_solr_conn_port']}/solr/marc-liberation-core-test" }
+  let(:solr) { RSolr.connect(url: solr_url) }
+  before do
+    Sidekiq::BatchSet.new.to_a.each(&:delete)
+    solr.delete_by_query("*:*")
+    solr.commit
+  end
   describe "index_next_dump!" do
-    let(:solr) { RSolr.connect(url: solr_url) }
-    before do
-      Sidekiq::BatchSet.new.to_a.each(&:delete)
-      solr.delete_by_query("*:*")
-      solr.commit
-    end
     it "indexes a full dump if there's been nothing indexed yet" do
       full_event = FactoryBot.create(:full_dump_event)
       incremental_event = FactoryBot.create(:incremental_dump_event)
@@ -28,6 +28,24 @@ RSpec.describe IndexManager, type: :model do
       index_manager.reload
       expect(index_manager.last_dump_completed).to eq full_event.dump
       expect(index_manager.dump_in_progress).to be_nil
+    end
+    it "doesn't index anything if it's caught up" do
+      allow(DumpFileIndexJob).to receive(:perform_async).and_call_original
+      # This incremental is before the full dump, don't run it
+      full_event = FactoryBot.create(:full_dump_event, start: Time.current - 1.day, finish: Time.current - 1.day + 100)
+
+      index_manager = described_class.for(solr_url)
+      Sidekiq::Testing.inline! do
+        # Index full dump
+        index_manager.index_next_dump!
+        run_callback(Sidekiq::BatchSet.new.to_a.last)
+        # Index incremental
+      end
+
+      index_manager = described_class.find(index_manager.id)
+      expect(index_manager.index_next_dump!).to be_nil
+      expect(index_manager.reload.dump_in_progress).to be_nil
+      expect(DumpFileIndexJob).to have_received(:perform_async).exactly(2).times
     end
     it "indexes the next incremental if the most recent full dump has been done" do
       allow(DumpFileIndexJob).to receive(:perform_async).and_call_original
@@ -62,10 +80,50 @@ RSpec.describe IndexManager, type: :model do
     end
   end
 
-  def run_callback(batch_set)
-    callback = batch_set.callbacks["success"][0]
+  describe "#index_remaining" do
+    it "indexes everything that's left to be indexed" do
+      allow(DumpFileIndexJob).to receive(:perform_async).and_call_original
+      # This incremental is before the full dump, don't run it
+      pre_incremental_event = FactoryBot.create(:incremental_dump_event, start: Time.current - 2.days, finish: Time.current - 2.days + 100)
+      full_event = FactoryBot.create(:full_dump_event, start: Time.current - 1.day, finish: Time.current - 1.day + 100)
+      incremental_event = FactoryBot.create(:incremental_dump_event, start: Time.current - 4.hours, finish: Time.current - 3.hours)
+      final_incremental_event = FactoryBot.create(:incremental_dump_event, start: Time.current - 2.hours, finish: Time.current - 1.hour)
+
+      index_manager = described_class.for(solr_url)
+      Sidekiq::Testing.inline! do
+        # Index full dump
+        index_manager.index_remaining!
+        old_batch = nil
+        while (batch = Sidekiq::BatchSet.new.to_a.last).bid != old_batch&.bid
+          old_batch = batch
+          run_callback(batch)
+        end
+        # Run callback for the parent batch.
+        run_callback(Sidekiq::BatchSet.new.to_a.first)
+      end
+      solr.commit
+
+      expect(DumpFileIndexJob).not_to have_received(:perform_async).with(pre_incremental_event.dump.dump_files.first.id, anything)
+      expect(DumpFileIndexJob).to have_received(:perform_async).with(incremental_event.dump.dump_files.first.id, anything)
+      expect(DumpFileIndexJob).to have_received(:perform_async).with(final_incremental_event.dump.dump_files.first.id, anything)
+      response = solr.get("select", params: { q: "*:*" })
+      expect(response['response']['numFound']).to eq 9
+      index_manager.reload
+      expect(index_manager.last_dump_completed).to eq final_incremental_event.dump
+      expect(index_manager.dump_in_progress).to be_nil
+    end
+  end
+
+  def run_callback(batch)
+    callback = batch.callbacks["success"][0]
     callback.each do |class_name, args|
-      class_name.constantize.new.on_success(batch_set, args)
+      if class_name.include?("#")
+        class_name, method_name = class_name.split("#")
+        workflow = class_name.constantize.new
+        workflow.send(method_name, batch, args)
+      else
+        class_name.constantize.new.on_success(batch, args)
+      end
     end
   end
 end

--- a/spec/services/alma/indexer_spec.rb
+++ b/spec/services/alma/indexer_spec.rb
@@ -93,11 +93,13 @@ RSpec.describe Alma::Indexer do
   end
 
   describe "incremental_index!" do
-    it "indexes a dump's files" do
-      solr = RSolr.connect(url: solr_url)
+    let(:solr) { RSolr.connect(url: solr_url) }
+    before do
+      Sidekiq::BatchSet.new.to_a.each(&:delete)
       solr.delete_by_query("*:*")
       solr.commit
-
+    end
+    it "indexes a dump's files" do
       dump = FactoryBot.create(:incremental_dump)
       indexer = described_class.new(solr_url: solr_url)
       Sidekiq::Testing.inline! do


### PR DESCRIPTION
Work towards #1518 

- [x] Rake task to create an IndexManager on first deploy which has the solr URL and the most recently created dump.
- [x] Rake task/class method to do a full reindex.