### PR TITLE
Removes unused property from AlmaAdapter::Status class

### DIFF
--- a/app/adapters/alma_adapter/availability_status.rb
+++ b/app/adapters/alma_adapter/availability_status.rb
@@ -43,7 +43,7 @@ class AlmaAdapter
       return nil if holding["inventory_type"] != "physical"
 
       location_info = location_record(holding)
-      status_label = Status.new(bib: bib, holding: holding, holding_item_data: nil, aeon: aeon?(location_info)).to_s
+      status_label = Status.new(bib: bib, holding: holding, aeon: aeon?(location_info)).to_s
       status = {
         on_reserve: AlmaItem.reserve_location?(holding["library_code"], holding["location_code"]) ? "Y" : "N",
         location: holding_location_code(holding),
@@ -95,7 +95,7 @@ class AlmaAdapter
     def holding_summary(holding)
       holding_item_data = item_data[holding["holding_id"]]
       location_info = location_record(holding)
-      status = Status.new(bib: bib, holding_item_data: holding_item_data, holding: holding, aeon: aeon?(location_info))
+      status = Status.new(bib: bib, holding: holding, aeon: aeon?(location_info))
       {
         item_id: holding_item_data&.first&.item_data&.fetch("pid", nil),
         location: "#{holding['library_code']}-#{holding['location_code']}",

--- a/app/adapters/alma_adapter/status.rb
+++ b/app/adapters/alma_adapter/status.rb
@@ -3,13 +3,12 @@
 # @TODO Add support for all the statuses in
 #   https://github.com/pulibrary/marc_liberation/issues/937
 class AlmaAdapter::Status
-  attr_reader :bib, :holding_item_data, :holding, :aeon
+  attr_reader :bib, :holding, :aeon
   # @param bib [Alma::Bib]
-  # @param holding_item_data [Alma::BibItem]
   # @param holding [Hash] Holding data pulled from Alma::AvailabilityResponse
-  def initialize(bib:, holding_item_data:, holding:, aeon: false)
+  # @param aeon [Bool] Is Aeon location?
+  def initialize(bib:, holding:, aeon: false)
     @bib = bib
-    @holding_item_data = holding_item_data
     @holding = holding
     @aeon = aeon
   end


### PR DESCRIPTION
This is a small refactoring on the `AlmaAdapter::Status` class: I removed the unused property `holding_item_data` from the class.

I made this change while prototyping how to address an Orangelight issue with Marquand items (https://github.com/pulibrary/orangelight/issues/2659). In the end I ended up making the changes for the Marquand items directly in Orangelight, but the refactor in this PR will simplify the code a little bit, even if it has nothing to do with the original issue.