### PR TITLE
Handles invalid UTF-8 characters in MARC records

### DIFF
--- a/app/services/alma/indexer.rb
+++ b/app/services/alma/indexer.rb
@@ -7,6 +7,6 @@ class Alma::Indexer
 
   def index_file(file_name, debug_mode = false)
     debug_flag = debug_mode ? "--debug-mode" : ""
-    `traject #{debug_flag} -c marc_to_solr/lib/traject_config.rb #{file_name} -u #{solr_url} 2>&1`
+    `traject #{debug_flag} -c marc_to_solr/lib/traject_config.rb #{file_name} -u #{solr_url} -w Traject::PulSolrJsonWriter 2>&1`
   end
 end

--- a/marc_to_solr/lib/pul_solr_json_writer.rb
+++ b/marc_to_solr/lib/pul_solr_json_writer.rb
@@ -1,0 +1,284 @@
+require 'yell'
+
+require 'traject/util'
+require 'traject/qualified_const_get'
+require 'traject/thread_pool'
+
+require 'json'
+require 'httpclient'
+
+require 'uri'
+require 'thread'     # for Mutex/Queue
+require 'concurrent' # for atomic_fixnum
+
+# ==========================
+# This class is a copy of Traject's SolrJsonWriter
+# (https://github.com/traject/traject/blob/master/lib/traject/solr_json_writer.rb)
+# but it has been updated to skip records with Unicode values that Ruby cannot
+# handle in JSON.parse() - see https://github.com/pulibrary/bibdata/issues/1677
+# ==========================
+
+
+# Write to Solr using the JSON interface; only works for Solr >= 3.2
+#
+# This should work under both MRI and JRuby, with JRuby getting much
+# better performance due to the threading model.
+#
+# Relevant settings
+#
+# * solr.url (optional if solr.update_url is set) The URL to the solr core to index into
+#
+# * solr.update_url: The actual update url. If unset, we'll first see if
+#   "#{solr.url}/update/json" exists, and if not use "#{solr.url}/update"
+#
+# * solr_writer.batch_size: How big a batch to send to solr. Default is 100.
+#   My tests indicate that this setting doesn't change overall index speed by a ton.
+#
+# * solr_writer.thread_pool: How many threads to use for the writer. Default is 1.
+#   Likely useful even under MRI since thread will be waiting on Solr for some time.
+#
+# * solr_writer.max_skipped: How many records skipped due to errors before we
+#   bail out with a fatal error? Set to -1 for unlimited skips. Default 0,
+#   raise and abort on a single record that could not be added to Solr.
+#
+# * solr_writer.commit_on_close: Set to true (or "true") if you want to commit at the
+#   end of the indexing run. (Old "solrj_writer.commit_on_close" supported for backwards
+#   compat only.)
+#
+# * solr_writer.commit_timeout: If commit_on_close, how long to wait for Solr before
+#   giving up as a timeout. Default 10 minutes. Solr can be slow.
+#
+# * solr_json_writer.http_client Mainly intended for testing, set your own HTTPClient
+#   or mock object to be used for HTTP.
+
+
+class Traject::PulSolrJsonWriter
+  include Traject::QualifiedConstGet
+
+  DEFAULT_MAX_SKIPPED = 0
+  DEFAULT_BATCH_SIZE  = 100
+
+  # The passed-in settings
+  attr_reader :settings, :thread_pool_size
+
+  # A queue to hold documents before sending to solr
+  attr_reader :batched_queue
+
+  def initialize(argSettings)
+    @settings = Traject::Indexer::Settings.new(argSettings)
+
+    # Set max errors
+    @max_skipped = (@settings['solr_writer.max_skipped'] || DEFAULT_MAX_SKIPPED).to_i
+    if @max_skipped < 0
+      @max_skipped = nil
+    end
+
+    @http_client = @settings["solr_json_writer.http_client"] || HTTPClient.new
+
+    @batch_size = (settings["solr_writer.batch_size"] || DEFAULT_BATCH_SIZE).to_i
+    @batch_size = 1 if @batch_size < 1
+
+    # Store error count in an AtomicInteger, so multi threads can increment
+    # it safely, if we're threaded.
+    @skipped_record_incrementer = Concurrent::AtomicFixnum.new(0)
+
+
+    # How many threads to use for the writer?
+    # if our thread pool settings are 0, it'll just create a null threadpool that
+    # executes in calling context.
+    @thread_pool_size = (@settings["solr_writer.thread_pool"] || 1).to_i
+
+    @batched_queue         = Queue.new
+    @thread_pool = Traject::ThreadPool.new(@thread_pool_size)
+
+    # old setting solrj_writer supported for backwards compat, as we make
+    # this the new default writer.
+    @commit_on_close = (settings["solr_writer.commit_on_close"] || settings["solrj_writer.commit_on_close"]).to_s == "true"
+
+    # Figure out where to send updates
+    @solr_update_url = self.determine_solr_update_url
+
+    logger.info("   #{self.class.name} writing to '#{@solr_update_url}' in batches of #{@batch_size} with #{@thread_pool_size} bg threads")
+  end
+
+
+  # Add a single context to the queue, ready to be sent to solr
+  def put(context)
+    @thread_pool.raise_collected_exception!
+
+    @batched_queue << context
+    if @batched_queue.size >= @batch_size
+      batch = Traject::Util.drain_queue(@batched_queue)
+      @thread_pool.maybe_in_thread_pool(batch) {|batch_arg| send_batch(batch_arg) }
+    end
+  end
+
+  # Send the given batch of contexts. If something goes wrong, send
+  # them one at a time.
+  # @param [Array<Traject::Indexer::Context>] an array of contexts
+  def send_batch(batch)
+    return if batch.empty?
+    json_package = JSON.generate(batch.map { |c| c.output_hash })
+    begin
+      resp = @http_client.post @solr_update_url, json_package, "Content-type" => "application/json"
+    rescue StandardError => exception
+    end
+
+    if exception || resp.status != 200
+      error_message = exception ?
+        Traject::Util.exception_to_log_message(exception) :
+        "Solr response: #{resp.status}: #{resp.body}"
+
+      logger.error "Error in Solr batch add. Will retry documents individually at performance penalty: #{error_message}"
+
+      batch.each do |c|
+        send_single(c)
+      end
+    end
+  # This rescue clause is not in the original Traject::SolrJsonWriter
+  # Special handling for batch of records with Unicode characters that JSON.parse() cannot handle.
+  rescue JSON::GeneratorError => ex
+    logger.error "JSON error in Solr batch add. Will retry documents individually at performance penalty: #{ex}"
+    batch.each do |c|
+      send_single(c)
+    end
+  end
+
+
+  # Send a single context to Solr, logging an error if need be
+  # @param [Traject::Indexer::Context] c The context whose document you want to send
+  def send_single(c)
+    json_package = JSON.generate([c.output_hash])
+    begin
+      resp = @http_client.post @solr_update_url, json_package, "Content-type" => "application/json"
+      # Catch Timeouts and network errors as skipped records, but otherwise
+      # allow unexpected errors to propagate up.
+    rescue HTTPClient::TimeoutError, SocketError, Errno::ECONNREFUSED => exception
+    end
+
+    if exception || resp.status != 200
+      if exception
+        msg = Traject::Util.exception_to_log_message(exception)
+      else
+        msg = "Solr error response: #{resp.status}: #{resp.body}"
+      end
+      logger.error "Could not add record #{c.source_record_id} at source file position #{c.position}: #{msg}"
+      logger.debug(c.source_record.to_s)
+
+      @skipped_record_incrementer.increment
+      if @max_skipped and skipped_record_count > @max_skipped
+        raise RuntimeError.new("#{self.class.name}: Exceeded maximum number of skipped records (#{@max_skipped}): aborting")
+      end
+
+    end
+  # This rescue clause is not in the original Traject::SolrJsonWriter
+  # Special handling for single record with Unicode characters that JSON.parse() cannot handle.
+  rescue JSON::GeneratorError => ex
+    logger.error "Could not add record #{c.source_record_id}: #{ex}"
+  end
+
+
+  # Get the logger from the settings, or default to an effectively null logger
+  def logger
+    settings["logger"] ||= Yell.new(STDERR, :level => "gt.fatal") # null logger
+  end
+
+  # On close, we need to (a) raise any exceptions we might have, (b) send off
+  # the last (possibly empty) batch, and (c) commit if instructed to do so
+  # via the solr_writer.commit_on_close setting.
+  def close
+    @thread_pool.raise_collected_exception!
+
+    # Finish off whatever's left. Do it in the thread pool for
+    # consistency, and to ensure expected order of operations, so
+    # it goes to the end of the queue behind any other work.
+    batch = Traject::Util.drain_queue(@batched_queue)
+    if batch.length > 0
+      @thread_pool.maybe_in_thread_pool { send_batch(batch) }
+    end
+
+    # Wait for shutdown, and time it.
+    logger.debug "#{self.class.name}: Shutting down thread pool, waiting if needed..."
+    elapsed = @thread_pool.shutdown_and_wait
+    if elapsed > 60
+      logger.warn "Waited #{elapsed} seconds for all threads, you may want to increase solr_writer.thread_pool (currently #{@settings["solr_writer.thread_pool"]})"
+    end
+    logger.debug "#{self.class.name}: Thread pool shutdown complete"
+    logger.warn "#{self.class.name}: #{skipped_record_count} skipped records" if skipped_record_count > 0
+
+    # check again now that we've waited, there could still be some
+    # that didn't show up before.
+    @thread_pool.raise_collected_exception!
+
+    # Commit if we're supposed to
+    if @commit_on_close
+      commit
+    end
+  end
+
+
+  # Send a commit
+  def commit
+    logger.info "#{self.class.name} sending commit to solr at url #{@solr_update_url}..."
+
+    original_timeout = @http_client.receive_timeout
+
+    @http_client.receive_timeout = (settings["commit_timeout"] || (10 * 60)).to_i
+
+    resp = @http_client.get(@solr_update_url, {"commit" => 'true'})
+    unless resp.status == 200
+      raise RuntimeError.new("Could not commit to Solr: #{resp.status} #{resp.body}")
+    end
+
+    @http_client.receive_timeout = original_timeout
+  end
+
+
+  # Return count of encountered skipped records. Most accurate to call
+  # it after #close, in which case it should include full count, even
+  # under async thread_pool.
+  def skipped_record_count
+    @skipped_record_incrementer.value
+  end
+
+
+  # Relatively complex logic to determine if we have a valid URL and what it is
+  def determine_solr_update_url
+    if settings['solr.update_url']
+      check_solr_update_url(settings['solr.update_url'])
+    else
+      derive_solr_update_url_from_solr_url(settings['solr.url'])
+    end
+  end
+
+
+  # If we've got a solr.update_url, make sure it's ok
+  def check_solr_update_url(url)
+    unless url =~ /^#{URI::regexp}$/
+      raise ArgumentError.new("#{self.class.name} setting `solr.update_url` doesn't look like a URL: `#{url}`")
+    end
+    url
+  end
+
+  def derive_solr_update_url_from_solr_url(url)
+    # Nil? Then we bail
+    if url.nil?
+      raise ArgumentError.new("#{self.class.name}: Neither solr.update_url nor solr.url set; need at least one")
+    end
+
+    # Not a URL? Bail
+    unless url =~ /^#{URI::regexp}$/
+      raise ArgumentError.new("#{self.class.name} setting `solr.url` doesn't look like a URL: `#{url}`")
+    end
+
+    # First, try the /update/json handler
+    candidate = [url.chomp('/'), 'update', 'json'].join('/')
+    resp      = @http_client.get(candidate)
+    if resp.status == 404
+      candidate = [url.chomp('/'), 'update'].join('/')
+    end
+    candidate
+  end
+
+
+end

--- a/marc_to_solr/lib/pul_solr_json_writer.rb
+++ b/marc_to_solr/lib/pul_solr_json_writer.rb
@@ -14,10 +14,9 @@ require 'concurrent' # for atomic_fixnum
 # ==========================
 # This class is a copy of Traject's SolrJsonWriter
 # (https://github.com/traject/traject/blob/master/lib/traject/solr_json_writer.rb)
-# but it has been updated to skip records with Unicode values that Ruby cannot
+# but it has been updated to skip records with UTF-8 values that Ruby cannot
 # handle in JSON.parse() - see https://github.com/pulibrary/bibdata/issues/1677
 # ==========================
-
 
 # Write to Solr using the JSON interface; only works for Solr >= 3.2
 #
@@ -51,9 +50,11 @@ require 'concurrent' # for atomic_fixnum
 # * solr_json_writer.http_client Mainly intended for testing, set your own HTTPClient
 #   or mock object to be used for HTTP.
 
-
 class Traject::PulSolrJsonWriter
   include Traject::QualifiedConstGet
+
+  # Disable RuboCop so that we can mimic the original in Traject as much as possible.
+  # rubocop:disable all
 
   DEFAULT_MAX_SKIPPED = 0
   DEFAULT_BATCH_SIZE  = 100
@@ -136,7 +137,7 @@ class Traject::PulSolrJsonWriter
       end
     end
   # This rescue clause is not in the original Traject::SolrJsonWriter
-  # Special handling for batch of records with Unicode characters that JSON.parse() cannot handle.
+  # Special handling for batch of records with UTF-8 characters that JSON.parse() cannot handle.
   rescue JSON::GeneratorError => ex
     logger.error "JSON error in Solr batch add. Will retry documents individually at performance penalty: #{ex}"
     batch.each do |c|
@@ -172,7 +173,7 @@ class Traject::PulSolrJsonWriter
 
     end
   # This rescue clause is not in the original Traject::SolrJsonWriter
-  # Special handling for single record with Unicode characters that JSON.parse() cannot handle.
+  # Special handling for single record with UTF-8 characters that JSON.parse() cannot handle.
   rescue JSON::GeneratorError => ex
     logger.error "Could not add record #{c.source_record_id}: #{ex}"
   end
@@ -280,5 +281,5 @@ class Traject::PulSolrJsonWriter
     candidate
   end
 
-
+  # rubocop:enable all
 end

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -46,7 +46,8 @@ each_record do |record, context|
 end
 
 after_processing do
-  if @settings["writer_class_name"] == "Traject::SolrJsonWriter"
+  using_solr = ["Traject::SolrJsonWriter", "Traject::PulSolrJsonWriter"].include?(@settings["writer_class_name"])
+  if using_solr
     # Delete records from Solr
     deleter = SolrDeleter.new(@settings["solr.url"], logger)
     deleter.delete(deleted_ids)

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -11,11 +11,11 @@ require_relative './alma_reader'
 require_relative './solr_deleter'
 require_relative './access_facet_builder'
 require_relative './change_the_subject'
+require_relative "./pul_solr_json_writer"
 require 'stringex'
 require 'library_stdnums'
 require 'time'
 require 'iso-639'
-
 extend Traject::Macros::Marc21Semantics
 extend Traject::Macros::MarcFormats
 

--- a/spec/fixtures/files/alma/full_dump/three_records_one_bad_utf8.xml
+++ b/spec/fixtures/files/alma/full_dump/three_records_one_bad_utf8.xml
@@ -1,0 +1,529 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns="http://www.loc.gov/MARC21/slim" xmlns:marc="http://www.loc.gov/MARC21/slim">
+ <record>
+  <leader>01645nam a2200397 i 4500</leader>
+  <controlfield tag="005">20210511120000.0</controlfield>
+  <controlfield tag="008">210511s2021    ru a          000 0brus d</controlfield>
+  <controlfield tag="001">99125394249206421</controlfield>
+  <datafield tag="020" ind1=" " ind2=" ">
+   <subfield code="a">9785910224722</subfield>
+   <subfield code="0">(uri) http://www.isbnsearch.org/isbn/9785910224722</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+   <subfield code="9">(RuMoNKB)1195770</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+   <subfield code="a">RuMoNKB</subfield>
+   <subfield code="b">eng</subfield>
+   <subfield code="e">rda</subfield>
+   <subfield code="c">RuMoNKB</subfield>
+  </datafield>
+  <datafield tag="041" ind1="0" ind2=" ">
+   <subfield code="a">rus</subfield>
+   <subfield code="b">eng</subfield>
+   <subfield code="b">dan</subfield>
+   <subfield code="b">ger</subfield>
+   <subfield code="b">ita</subfield>
+  </datafield>
+  <datafield tag="043" ind1=" " ind2=" ">
+   <subfield code="a">e-ur---</subfield>
+   <subfield code="a">e-ru---</subfield>
+  </datafield>
+  <datafield tag="050" ind1=" " ind2="4">
+   <subfield code="a">ML422.V43</subfield>
+   <subfield code="b">C44 2021</subfield>
+  </datafield>
+  <datafield tag="066" ind1=" " ind2=" ">
+   <subfield code="c">(N</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+   <subfield code="6">880-01</subfield>
+   <subfield code="a">Cherëmushkin, Pëtr</subfield>
+   <subfield code="q">(Pëtr Germanovich),</subfield>
+   <subfield code="e">author.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2=" ">
+   <subfield code="6">100-01</subfield>
+   <subfield code="a">Черёмушкин, Пётр</subfield>
+   <subfield code="q">(Пётр Германович),</subfield>
+   <subfield code="e">author.</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+   <subfield code="6">880-02</subfield>
+   <subfield code="a">Aleksandr Vedernikov, glavnyĭ dirizher /</subfield>
+   <subfield code="c">Pëtr Cherëmushkin.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2="0">
+   <subfield code="6">245-02</subfield>
+   <subfield code="a">Александр Ведерников, главный дирижер /</subfield>
+   <subfield code="c">Пётр Черёмушкин.</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+   <subfield code="6">880-03</subfield>
+   <subfield code="a">Moskva :</subfield>
+   <subfield code="b">AIRO-XXI, </subfield>
+   <subfield code="c">2021.</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2="1">
+   <subfield code="6">264-03</subfield>
+   <subfield code="a">Москва :</subfield>
+   <subfield code="b">АИРО-XXI, </subfield>
+   <subfield code="c">2021.</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+   <subfield code="a">183 pages :</subfield>
+   <subfield code="b">illustrations (chiefly color) ;</subfield>
+   <subfield code="c">30 cm</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+   <subfield code="a">text</subfield>
+   <subfield code="b">txt</subfield>
+   <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+   <subfield code="a">still image</subfield>
+   <subfield code="b">sti</subfield>
+   <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+   <subfield code="a">unmediated</subfield>
+   <subfield code="b">n</subfield>
+   <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+   <subfield code="a">volume</subfield>
+   <subfield code="b">nc</subfield>
+   <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="546" ind1=" " ind2=" ">
+   <subfield code="a">Summary in English, Danish, German and Italian.</subfield>
+  </datafield>
+  <datafield tag="600" ind1="1" ind2="0">
+   <subfield code="a">Vedernikov, A. (Aleksandr)</subfield>
+  </datafield>
+  <datafield tag="610" ind1="2" ind2="0">
+   <subfield code="a">Bolʹshoĭ teatr Rossii.</subfield>
+   <subfield code="b">Orkestr.</subfield>
+  </datafield>
+  <datafield tag="610" ind1="2" ind2="0">
+   <subfield code="a">Bolshoĭ teatr Rossii</subfield>
+   <subfield code="x">History.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+   <subfield code="a">Conductors (Music)</subfield>
+   <subfield code="z">Russia (Federation)</subfield>
+   <subfield code="v">Biography.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+   <subfield code="a">Conductors (Music)</subfield>
+   <subfield code="z">Soviet Union</subfield>
+   <subfield code="v">Biography.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+   <subfield code="a">Musicians, Russian</subfield>
+   <subfield code="v">Biography.</subfield>
+  </datafield>
+  <datafield tag="910" ind1=" " ind2=" ">
+   <subfield code="c">F1301mon</subfield>
+  </datafield>
+  <datafield tag="980" ind1=" " ind2=" ">
+   <subfield code="a">20210811</subfield>
+   <subfield code="b">RuMoNKB</subfield>
+   <subfield code="f">NPRA1447</subfield>
+   <subfield code="i">39.00</subfield>
+   <subfield code="j">31.20</subfield>
+   <subfield code="n">11957701447</subfield>
+  </datafield>
+  <datafield tag="982" ind1=" " ind2=" ">
+   <subfield code="b">FY22</subfield>
+   <subfield code="c">rcppa</subfield>
+   <subfield code="n">2022</subfield>
+   <subfield code="q">32101108804400</subfield>
+  </datafield>
+  <datafield tag="986" ind1=" " ind2=" ">
+   <subfield code="h">ML422.V43</subfield>
+   <subfield code="i">C44 2021</subfield>
+  </datafield>
+  <datafield tag="950" ind1=" " ind2=" ">
+   <subfield code="c">2021-09-22 20:51:54 US/Eastern</subfield>
+   <subfield code="b">2021-09-22 20:51:56 US/Eastern</subfield>
+   <subfield code="a">false</subfield>
+  </datafield>
+  <datafield tag="852" ind1="0" ind2=" ">
+   <subfield code="b">recap</subfield>
+   <subfield code="c">pa</subfield>
+   <subfield code="h">ML422.V43</subfield>
+   <subfield code="i">C44 2021</subfield>
+   <subfield code="8">22901505800006421</subfield>
+  </datafield>
+  <datafield tag="952" ind1=" " ind2=" ">
+   <subfield code="d">2021-09-23 00:52:12</subfield>
+   <subfield code="8">22901505800006421</subfield>
+   <subfield code="a">2021-09-23 00:52:11</subfield>
+   <subfield code="b">ReCAP</subfield>
+   <subfield code="c">rcppa: RECAP</subfield>
+   <subfield code="e">false</subfield>
+  </datafield>
+  <datafield tag="876" ind1=" " ind2=" ">
+   <subfield code="0">22901505800006421</subfield>
+   <subfield code="a">23901505790006421</subfield>
+   <subfield code="j">0</subfield>
+   <subfield code="x">ACQ</subfield>
+   <subfield code="z">pa</subfield>
+   <subfield code="d">2021-09-23 00:52:11</subfield>
+   <subfield code="p">32101108804400</subfield>
+   <subfield code="y">recap</subfield>
+  </datafield>
+ </record>
+ <record>
+  <leader>01735nam a2200361 i 4500</leader>
+  <controlfield tag="005">20210421120000.0</controlfield>
+  <controlfield tag="008">210421s2021    ru ac    b    001 0сrus d</controlfield>
+  <controlfield tag="001">99125394551506421</controlfield>
+  <datafield tag="020" ind1=" " ind2=" ">
+   <subfield code="a">9785001254249</subfield>
+   <subfield code="0">(uri) http://www.isbnsearch.org/isbn/9785001254249</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+   <subfield code="9">(RuMoNKB)1192400</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+   <subfield code="a">RuMoNKB</subfield>
+   <subfield code="b">eng</subfield>
+   <subfield code="e">rda</subfield>
+   <subfield code="c">RuMoNKB</subfield>
+  </datafield>
+  <datafield tag="043" ind1=" " ind2=" ">
+   <subfield code="a">e-ur---</subfield>
+  </datafield>
+  <datafield tag="050" ind1=" " ind2="4">
+   <subfield code="a">CT1217.B46</subfield>
+   <subfield code="b">I88 2021</subfield>
+  </datafield>
+  <datafield tag="066" ind1=" " ind2=" ">
+   <subfield code="c">(N</subfield>
+  </datafield>
+  <datafield tag="245" ind1="0" ind2="0">
+   <subfield code="6">880-01</subfield>
+   <subfield code="a">Istorii︠a︡ semʹi Benua v pisʹmakh :</subfield>
+   <subfield code="b">pisʹma iz domashnego arkhiva F.F. Benua /</subfield>
+   <subfield code="c">sostavitelʹ, predislovie, primechanie G.F. Benua.</subfield>
+  </datafield>
+   <datafield tag="880" ind1="0" ind2="0">
+   <subfield code="6">245-01</subfield>
+   <subfield code="a">История семьи Бенуа в письмах :</subfield>
+   <subfield code="b">письма из домашнего архива Ф.Ф. Бенуа /</subfield>
+   <subfield code="c">составитель, предисловие, примечание Г.Ф. Бенуа.</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+   <subfield code="6">880-02</subfield>
+   <subfield code="a">Sankt-Peterburg :</subfield>
+   <subfield code="b">Renome, </subfield>
+   <subfield code="c">2021.</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2="1">
+   <subfield code="6">264-02</subfield>
+   <subfield code="a">Санкт-Петербург :</subfield>
+   <subfield code="b">Реноме, </subfield>
+   <subfield code="c">2021.</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+   <subfield code="a">151 pages :</subfield>
+   <subfield code="b">illustrations, portraits ;</subfield>
+   <subfield code="c">23 cm</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+   <subfield code="a">text</subfield>
+   <subfield code="b">txt</subfield>
+   <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+   <subfield code="a">unmediated</subfield>
+   <subfield code="b">n</subfield>
+   <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+   <subfield code="a">volume</subfield>
+   <subfield code="b">nc</subfield>
+   <subfield code="2">rdacarrier</subfield>
+  </datafield>
+<datafield tag="500" ind1=" " ind2=" ">
+   <subfield code="6">880-03</subfield>
+   <subfield code="a">&#34;Nauchno-populi︠a︡rnoe izdanie&#34;--Colophon.</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2=" ">
+   <subfield code="6">500-03</subfield>
+   <subfield code="a">&#34;Научно-популярное издание&#34;--Colophon.</subfield>
+  </datafield>
+  <datafield tag="504" ind1=" " ind2=" ">
+   <subfield code="a">Includes bibliographical references and index.</subfield>
+  </datafield>
+  <datafield tag="600" ind1="3" ind2="0">
+   <subfield code="a">Benua family.</subfield>
+  </datafield>
+  <datafield tag="600" ind1="1" ind2="0">
+   <subfield code="a">Benua di Stetto, Aleksandr,</subfield>
+   <subfield code="d">1896-1979.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+   <subfield code="a">Intellectuals</subfield>
+   <subfield code="z">Russia</subfield>
+   <subfield code="v">Correspondence.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+   <subfield code="6">880-04</subfield>
+   <subfield code="a">Benua, G. F.,</subfield>
+   <subfield code="e">compiler,</subfield>
+   <subfield code="e">editor,</subfield>
+   <subfield code="e">writer of introduction.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2=" ">
+   <subfield code="6">700-04</subfield>
+   <subfield code="a">Бенуа, Г. Ф.,</subfield>
+   <subfield code="e">compiler,</subfield>
+   <subfield code="e">editor,</subfield>
+   <subfield code="e">writer of introduction.</subfield>
+  </datafield>
+  <datafield tag="910" ind1=" " ind2=" ">
+   <subfield code="c">F1301mon</subfield>
+  </datafield>
+<datafield tag="980" ind1=" " ind2=" ">
+   <subfield code="a">20210714</subfield>
+   <subfield code="b">RuMoNKB</subfield>
+   <subfield code="f">NPRA1441</subfield>
+   <subfield code="i">32.00</subfield>
+   <subfield code="j">25.60</subfield>
+   <subfield code="n">11924001441</subfield>
+  </datafield>
+  <datafield tag="982" ind1=" " ind2=" ">
+   <subfield code="b">FY22</subfield>
+   <subfield code="c">rcppa</subfield>
+   <subfield code="n">2022</subfield>
+   <subfield code="q">32101108835859</subfield>
+  </datafield>
+  <datafield tag="986" ind1=" " ind2=" ">
+   <subfield code="h">CT1217.B46</subfield>
+   <subfield code="i">I88 2021</subfield>
+  </datafield>
+  <datafield tag="950" ind1=" " ind2=" ">
+   <subfield code="c">2021-09-22 20:51:25 US/Eastern</subfield>
+   <subfield code="b">2021-09-22 20:51:28 US/Eastern</subfield>
+   <subfield code="a">false</subfield>
+  </datafield>
+  <datafield tag="852" ind1="0" ind2=" ">
+   <subfield code="b">recap</subfield>
+   <subfield code="c">pa</subfield>
+   <subfield code="h">CT1217.B46</subfield>
+   <subfield code="i">I88 2021</subfield>
+   <subfield code="8">22901493720006421</subfield>
+  </datafield>
+  <datafield tag="952" ind1=" " ind2=" ">
+   <subfield code="d">2021-09-23 00:51:58</subfield>
+   <subfield code="8">22901493720006421</subfield>
+   <subfield code="a">2021-09-23 00:51:56</subfield>
+   <subfield code="b">ReCAP</subfield>
+   <subfield code="c">rcppa: RECAP</subfield>
+   <subfield code="e">false</subfield>
+  </datafield>
+<datafield tag="876" ind1=" " ind2=" ">
+   <subfield code="0">22901493720006421</subfield>
+   <subfield code="a">23901493700006421</subfield>
+   <subfield code="j">0</subfield>
+   <subfield code="x">ACQ</subfield>
+   <subfield code="z">pa</subfield>
+   <subfield code="d">2021-09-23 00:51:57</subfield>
+   <subfield code="p">32101108835859</subfield>
+   <subfield code="y">recap</subfield>
+  </datafield>
+ </record>
+ <record>
+  <leader>02642nam a2200445 i 4500</leader>
+  <controlfield tag="005">20210603120000.0</controlfield>
+  <controlfield tag="008">210603s2021    ru ach   b    000 0brus d</controlfield>
+  <controlfield tag="001">99125394249406421</controlfield>
+  <datafield tag="020" ind1=" " ind2=" ">
+   <subfield code="a">9785824324396</subfield>
+   <subfield code="0">(uri) http://www.isbnsearch.org/isbn/9785824324396</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+   <subfield code="9">(RuMoNKB)1200500</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+   <subfield code="a">RuMoNKB</subfield>
+   <subfield code="b">eng</subfield>
+   <subfield code="e">rda</subfield>
+   <subfield code="c">RuMoNKB</subfield>
+  </datafield>
+  <datafield tag="043" ind1=" " ind2=" ">
+   <subfield code="a">e-ur---</subfield>
+  </datafield>
+  <datafield tag="050" ind1=" " ind2="4">
+   <subfield code="a">DK275.P67</subfield>
+   <subfield code="b">B37 2021</subfield>
+  </datafield>
+  <datafield tag="066" ind1=" " ind2=" ">
+   <subfield code="c">(N</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+   <subfield code="6">880-01</subfield>
+   <subfield code="a">Barkhatov, Alekseĭ,</subfield>
+   <subfield code="e">author.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2=" ">
+   <subfield code="6">100-01</subfield>
+   <subfield code="a">Бархатов, Алексей,</subfield>
+   <subfield code="e">author.</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+   <subfield code="6">880-02</subfield>
+   <subfield code="a">Kto? :</subfield>
+   <subfield code="b">&#34;gensek vozhdi︠a︡&#34; Aleksandr Poskrebyshev : istoricheskiĭ roman /</subfield>
+   <subfield code="c">Alekseĭ Barkhatov.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2="0">
+   <subfield code="6">245-02</subfield>
+   <subfield code="a">Кто? :</subfield>
+   <subfield code="b">&#34;генсек вождя&#34; Александр Поскребышев : исторический роман /</subfield>
+   <subfield code="c">Алексей Бархатов.</subfield>
+  </datafield>
+  <datafield tag="246" ind1="3" ind2="0">
+   <subfield code="6">880-03</subfield>
+   <subfield code="a">&#34;Gensek vozhdi︠a︡&#34; Aleksandr Poskrebyshev :</subfield>
+   <subfield code="b">istoricheskiĭ roman</subfield>
+  </datafield>
+  <datafield tag="880" ind1="3" ind2="0">
+   <subfield code="6">246-03</subfield>
+   <subfield code="a">&#34;Генсек вождя&#34; Александр Поскребышев :</subfield>
+   <subfield code="b">исторический роман</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+   <subfield code="6">880-04</subfield>
+   <subfield code="a">Moskva :</subfield>
+   <subfield code="b">ROSSPĖN, </subfield>
+   <subfield code="c">2021.</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2="1">
+   <subfield code="6">264-04</subfield>
+   <subfield code="a">Москва :</subfield>
+   <subfield code="b">РОССПЭН, </subfield>
+   <subfield code="c">2021.</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+   <subfield code="a">310 pages :</subfield>
+   <subfield code="b">illustrations, portraits, facsimiles ;</subfield>
+   <subfield code="c">25 cm.</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+   <subfield code="a">text</subfield>
+   <subfield code="b">txt</subfield>
+   <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+   <subfield code="a">unmediated</subfield>
+   <subfield code="b">n</subfield>
+   <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+   <subfield code="a">volume</subfield>
+   <subfield code="b">nc</subfield>
+   <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="490" ind1="0" ind2=" ">
+   <subfield code="6">880-05</subfield>
+   <subfield code="a">Stranit︠s︡y sovetskoĭ istorii. Belletristika</subfield>
+  </datafield>
+  <datafield tag="880" ind1="0" ind2=" ">
+   <subfield code="6">490-05</subfield>
+   <subfield code="a">Страницы советской истории. Беллетристика</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+   <subfield code="6">880-06</subfield>
+   <subfield code="a">&#34;AFK &#34;Sistema&#34; sovmestno s Rossiĭskim gosudarstvennym arkhivom sot︠s︡ialʹno-politicheskoĭ istorii predstavli︠a︡i︠u︡t&#34;--Preliminary page.</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2=" ">
+   <subfield code="6">500-06</subfield>
+   <subfield code="a">&#34;АФК &#34;Система&#34; совместно с Российским государственным архивом социально-политической истории представляют&#34;--Preliminary page.</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+   <subfield code="6">880-07</subfield>
+   <subfield code="a">&#34;Khudozhestvennoe izdanie&#34;--Colophon.</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2=" ">
+   <subfield code="6">500-07</subfield>
+   <subfield code="a">&#34;Художественное издание&#34;--Colophon.</subfield>
+  </datafield>
+  <datafield tag="504" ind1=" " ind2=" ">
+   <subfield code="a">Includes bibliographical references (pages 308-310).</subfield>
+  </datafield>
+  <datafield tag="600" ind1="1" ind2="0">
+   <subfield code="a">Poskrebyshev, A. N.</subfield>
+  </datafield>
+  <datafield tag="651" ind1=" " ind2="0">
+   <subfield code="a">Soviet Union</subfield>
+   <subfield code="x">Politics and government</subfield>
+   <subfield code="y">1936-1953</subfield>
+   <subfield code="v">Biography.</subfield>
+  </datafield>
+  <datafield tag="710" ind1="2" ind2=" ">
+   <subfield code="6">880-08</subfield>
+   <subfield code="a">Rossiĭskiĭ gosudarstvennyĭ arkhiv sot︠s︡ialʹno-politicheskoĭ istorii,</subfield>
+   <subfield code="e">host institution.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="2" ind2=" ">
+   <subfield code="6">710-08</subfield>
+   <subfield code="a">Российский государственный архив социально-политической истории,</subfield>
+   <subfield code="e">host institution.</subfield>
+  </datafield>
+  <datafield tag="910" ind1=" " ind2=" ">
+   <subfield code="c">F1301mon</subfield>
+  </datafield>
+  <datafield tag="980" ind1=" " ind2=" ">
+   <subfield code="a">20210811</subfield>
+   <subfield code="b">RuMoNKB</subfield>
+   <subfield code="f">NPRA1447</subfield>
+   <subfield code="i">34.00</subfield>
+   <subfield code="j">27.20</subfield>
+   <subfield code="n">12005001447</subfield>
+  </datafield>
+  <datafield tag="982" ind1=" " ind2=" ">
+   <subfield code="b">FY22</subfield>
+   <subfield code="c">rcppa</subfield>
+   <subfield code="n">2022</subfield>
+   <subfield code="q">32101108823012</subfield>
+  </datafield>
+  <datafield tag="986" ind1=" " ind2=" ">
+   <subfield code="h">DK275.P67</subfield>
+   <subfield code="i">B37 2021</subfield>
+  </datafield>
+  <datafield tag="950" ind1=" " ind2=" ">
+   <subfield code="c">2021-09-22 20:51:54 US/Eastern</subfield>
+   <subfield code="b">2021-09-22 20:51:56 US/Eastern</subfield>
+   <subfield code="a">false</subfield>
+  </datafield>
+  <datafield tag="852" ind1="0" ind2=" ">
+   <subfield code="b">recap</subfield>
+   <subfield code="c">pa</subfield>
+   <subfield code="h">DK275.P67</subfield>
+   <subfield code="i">B37 2021</subfield>
+   <subfield code="8">22901505940006421</subfield>
+  </datafield>
+  <datafield tag="952" ind1=" " ind2=" ">
+   <subfield code="d">2021-09-23 00:52:11</subfield>
+   <subfield code="8">22901505940006421</subfield>
+   <subfield code="a">2021-09-23 00:52:10</subfield>
+   <subfield code="b">ReCAP</subfield>
+   <subfield code="c">rcppa: RECAP</subfield>
+   <subfield code="e">false</subfield>
+  </datafield>
+  <datafield tag="876" ind1=" " ind2=" ">
+   <subfield code="0">22901505940006421</subfield>
+   <subfield code="a">23901505910006421</subfield>
+   <subfield code="j">0</subfield>
+   <subfield code="x">ACQ</subfield>
+   <subfield code="z">pa</subfield>
+   <subfield code="d">2021-09-23 00:52:10</subfield>
+   <subfield code="p">32101108823012</subfield>
+   <subfield code="y">recap</subfield>
+  </datafield>
+ </record>
+</collection>


### PR DESCRIPTION
Fixes #1677 

Adds a new Traject writer (`PulSolrJsonWriter`) that gracefully handles records with invalid UTF-8 characters. Notice that you need to explicitly request this new writer when invoking Traject via the `-w` parameter.

```
bundle exec traject -c marc_to_solr/lib/traject_config.rb $FILE -u $SOLR_URL -w Traject::PulSolrJsonWriter
```


Processing a file with the invalid record will show an output similar to this:

```
2021-09-29T10:47:40-04:00  INFO Reading from /Users/correah/Downloads/incremental_15001905180006421_20210923_020921[050]_new
2021-09-29T10:47:40-04:00  INFO    Traject::PulSolrJsonWriter writing to 'http://localhost:8983/solr/puldata/update/json' in batches of 100 with 1 bg threads
2021-09-29T10:47:40-04:00  INFO    Indexer with 1 processing threads, reader: AlmaReader and writer: Traject::PulSolrJsonWriter
2021-09-29T10:47:41-04:00  INFO Seeding the cache for figgy.princeton.edu using Solr...
2021-09-29T10:47:44-04:00 ERROR JSON error in Solr batch add. Will retry documents individually at performance penalty: source sequence is illegal/malformed utf-8
2021-09-29T10:47:46-04:00 ERROR Could not add record 99125394551506421/99125394551506421: source sequence is illegal/malformed utf-8
2021-09-29T10:47:47-04:00  INFO Record 99124679253506421 would be deleted
...
2021-09-29T10:47:47-04:00  INFO Record 99125387689706421 would be deleted
2021-09-29T10:47:47-04:00  INFO finished Indexer#process: 953 records in 7.232 seconds; 131.8 records/second overall.
```

Notice the two ERROR messages logged.