### PR TITLE
Change the Subject applied to one term only

### DIFF
--- a/marc_to_solr/lib/change_the_subject.rb
+++ b/marc_to_solr/lib/change_the_subject.rb
@@ -5,8 +5,8 @@
 class ChangeTheSubject
   def self.terms_mapping
     {
-      "Illegal Aliens": {
-        replacement: "Undocumented Immigrants",
+      "Illegal aliens": {
+        replacement: "Undocumented immigrants",
         rationale: "The term immigrant or undocumented/unauthorized immigrants are the terms LoC proposed as replacements for illegal aliens and other uses of the world alien in LCSH."
       }
     }
@@ -17,6 +17,8 @@ class ChangeTheSubject
   # @param [<String>] subject_terms
   # @return [<String>]
   def self.fix(subject_terms)
+    return [] if subject_terms.nil? || subject_terms.blank?
+    # byebug if subject_terms.first.match(/Illegal alien/)
     subject_terms.map { |term| check_for_replacement(term) }
   end
 
@@ -26,8 +28,13 @@ class ChangeTheSubject
   # @param [String] term
   # @return [String]
   def self.check_for_replacement(term)
-    replacement = terms_mapping[term.to_sym]
-    return replacement[:replacement] if replacement
-    term
+    subterms = term.split(SEPARATOR)
+    # byebug if term.match(/Illegal alien/)
+    subfield_a = subterms.first
+    subterms.delete(subfield_a)
+    replacement = terms_mapping[subfield_a.to_sym]
+    return term unless replacement
+    subterms.prepend(replacement[:replacement])
+    subterms.join(SEPARATOR)
   end
 end

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -798,7 +798,17 @@ to_field 'cumulative_index_finding_aid_display', extract_marc('555|8*|3abcd')
 to_field 'lc_subject_display' do |record, accumulator|
   subjects = process_hierarchy(record, '600|*0|abcdfklmnopqrtvxyz:610|*0|abfklmnoprstvxyz:611|*0|abcdefgklnpqstvxyz:630|*0|adfgklmnoprstvxyz:650|*0|abcvxyz:651|*0|avxyz')
   subjects = augment_the_subject.add_indigenous_studies(subjects) if ENV['CHANGE_THE_SUBJECT'] == 'true'
+  subjects = ChangeTheSubject.fix(subjects) if ENV['CHANGE_THE_SUBJECT'] == 'true'
   accumulator.replace(subjects)
+end
+
+# A field to include both archaic and replaced terms, for search purposes
+to_field 'lc_subject_include_archaic_search_terms' do |record, accumulator|
+  subjects = process_hierarchy(record, '600|*0|abcdfklmnopqrtvxyz:610|*0|abfklmnoprstvxyz:611|*0|abcdefgklnpqstvxyz:630|*0|adfgklmnoprstvxyz:650|*0|abcvxyz:651|*0|avxyz')
+  new_subjects = augment_the_subject.add_indigenous_studies(subjects) if ENV['CHANGE_THE_SUBJECT'] == 'true'
+  new_subjects = ChangeTheSubject.fix(new_subjects) if ENV['CHANGE_THE_SUBJECT'] == 'true'
+  combined_subjects = subjects.concat(new_subjects).uniq
+  accumulator.replace(combined_subjects)
 end
 
 to_field 'siku_subject_display' do |record, accumulator|
@@ -807,8 +817,9 @@ to_field 'siku_subject_display' do |record, accumulator|
 end
 
 # Adds lc and siku subject unstem_search fields
+# Note that lc unstem search should include both archaic and replaced terms
 each_record do |_record, context|
-  context.output_hash['subject_unstem_search'] = context.output_hash['lc_subject_display']
+  context.output_hash['subject_unstem_search'] = context.output_hash['lc_subject_include_archaic_search_terms']
   context.output_hash['siku_subject_unstem_search'] = context.output_hash['siku_subject_display']
 end
 
@@ -816,6 +827,7 @@ end
 to_field 'subject_facet' do |record, accumulator|
   subjects = process_hierarchy(record, '600|*0|abcdfklmnopqrtvxyz:610|*0|abfklmnoprstvxyz:611|*0|abcdefgklnpqstvxyz:630|*0|adfgklmnoprstvxyz:650|*0|abcvxyz:651|*0|avxyz')
   subjects = augment_the_subject.add_indigenous_studies(subjects) if ENV['CHANGE_THE_SUBJECT'] == 'true'
+  subjects = ChangeTheSubject.fix(subjects) if ENV['CHANGE_THE_SUBJECT'] == 'true'
   sk_subjects = process_hierarchy(record, '650|*7|abcvxyz', ['sk'])
   genres = process_hierarchy(record, '655|*7|avxyz', ['lcgft', 'aat', 'rbbin', 'rbgenr', 'rbmscv', 'rbpap', 'rbpri', 'rbprov', 'rbpub', 'rbtyp'])
   accumulator.replace([subjects, sk_subjects, genres].flatten)
@@ -842,6 +854,7 @@ to_field 'cjk_subject', extract_marc('600|*0|abcdfklmnopqrtvxyz:610|*0|abfklmnop
 to_field 'subject_topic_facet' do |record, accumulator|
   subjects = process_subject_topic_facet(record)
   subjects = augment_the_subject.add_indigenous_studies(subjects) if ENV['CHANGE_THE_SUBJECT'] == 'true'
+  subjects = ChangeTheSubject.fix(subjects) if ENV['CHANGE_THE_SUBJECT'] == 'true'
   accumulator.replace(subjects)
 end
 

--- a/spec/marc_to_solr/lib/change_the_subject_spec.rb
+++ b/spec/marc_to_solr/lib/change_the_subject_spec.rb
@@ -7,10 +7,10 @@ require 'rails_helper'
 # to update them at index time to preferred terms.
 RSpec.describe ChangeTheSubject do
   context "a replaced term" do
-    let(:subject_term) { "Illegal Aliens" }
+    let(:subject_term) { "Illegal aliens" }
 
     it "suggests a replacement" do
-      expect(described_class.check_for_replacement(subject_term)).to eq "Undocumented Immigrants"
+      expect(described_class.check_for_replacement(subject_term)).to eq "Undocumented immigrants"
     end
   end
 
@@ -23,10 +23,19 @@ RSpec.describe ChangeTheSubject do
   end
 
   context "an array of subject terms" do
-    let(:subject_terms) { ["Illegal Aliens", "Workplace Safety"] }
-    let(:fixed_subject_terms) { ["Undocumented Immigrants", "Workplace Safety"] }
+    let(:subject_terms) { ["Illegal aliens", "Workplace safety"] }
+    let(:fixed_subject_terms) { ["Undocumented immigrants", "Workplace safety"] }
 
     it "changes only the subject terms that have been configured" do
+      expect(described_class.fix(subject_terms)).to eq fixed_subject_terms
+    end
+  end
+
+  context "subject terms with subheadings" do
+    let(:subject_terms) { ["Illegal aliens#{SEPARATOR}United States.", "Workplace safety"] }
+    let(:fixed_subject_terms) { ["Undocumented immigrants#{SEPARATOR}United States.", "Workplace safety"] }
+
+    it "changes subfield a and re-assembles the full subject heading" do
       expect(described_class.fix(subject_terms)).to eq fixed_subject_terms
     end
   end

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -737,6 +737,18 @@ describe 'From traject_config.rb' do
         expect(@indigenous_studies["subject_unstem_search"]).to match_array(["Indians of Central America", "Indians of Mexico", "Indians of North America", "Indians of the West Indies", "Indigenous Studies"])
       end
     end
+    describe 'subject terms changed for Change the Subject' do
+      context 'when the subject term is an exact match in $a' do
+        let(:s650_lcsh) { { "650" => { "ind1" => "", "ind2" => "0", "subfields" => [{ "a" => "Illegal aliens", "z" => "United States." }] } } }
+        let(:subject_marc) { @indexer.map_record(MARC::Record.new_from_hash('fields' => [s650_lcsh], 'leader' => leader)) }
+        it 'changes the subject term in display fields, but includes both old and new in search fields' do
+          expect(subject_marc["subject_facet"]).to match_array(["Undocumented immigrants#{SEPARATOR}United States"])
+          expect(subject_marc['subject_topic_facet']).to match_array(["Undocumented immigrants", "United States"])
+          expect(subject_marc['lc_subject_display']).to match_array(["Undocumented immigrants#{SEPARATOR}United States"])
+          expect(subject_marc["subject_unstem_search"]).to match_array(["Illegal aliens#{SEPARATOR}United States", "Undocumented immigrants#{SEPARATOR}United States"])
+        end
+      end
+    end
   end
   describe 'form_genre_display' do
     subject(:form_genre_display) { @indexer.map_record(marc_record) }


### PR DESCRIPTION
Proof of concept to show that we can change subject terms at index time
and still be able to search by the archaic term.

Fixes #1665 