### PR TITLE
Logging for liberate::full rake task

### DIFF
--- a/app/models/index_manager.rb
+++ b/app/models/index_manager.rb
@@ -9,11 +9,12 @@ class IndexManager < ActiveRecord::Base
   def self.reindex!(solr_url: nil)
     solr_url ||= rebuild_solr_url
     manager = self.for(solr_url)
-    return if manager.in_progress?
+    return false if manager.in_progress?
     manager.last_dump_completed = nil
     manager.save
     manager.wipe!
     manager.index_remaining!
+    true
   end
 
   def self.rebuild_solr_url

--- a/lib/tasks/orangeindex.rake
+++ b/lib/tasks/orangeindex.rake
@@ -103,7 +103,12 @@ namespace :liberate do
   task full: :environment do
     solr_url = ENV['SET_URL'] || default_solr_url
     solr = IndexFunctions.rsolr_connection(solr_url)
-    IndexManager.reindex!(solr_url: solr_url)
+    reindex = IndexManager.reindex!(solr_url: solr_url)
+    if reindex
+      puts "INFO: Reindex started"
+    else
+      puts "WARN: The reindex was not started (perhaps there is another reindex in progress.)"
+    end
   end
 
   desc "Index remaining incrementals against SET_URL"

--- a/spec/models/index_manager_spec.rb
+++ b/spec/models/index_manager_spec.rb
@@ -37,7 +37,13 @@ RSpec.describe IndexManager, type: :model do
       solr.commit
 
       Sidekiq::Testing.inline! do
-        described_class.reindex!(solr_url: solr_url)
+        reindex = described_class.reindex!(solr_url: solr_url)
+        expect(reindex).to eq true
+
+        # Checks that a second reindex cannot started while the first one is in progress
+        reindex = described_class.reindex!(solr_url: solr_url)
+        expect(reindex).to eq false
+
         run_all_callbacks
       end
       solr.commit


### PR DESCRIPTION
Logs whether a new reindex was started or not when running `liberate::full` rake task.

This will help to diagnose when running `rake liberate::full` does not queue any new jobs like the issue that @christinach and I ran into last night.

