### PR TITLE
Adds a stricter validation to detect OCLC numbers

### DIFF
--- a/marc_to_solr/lib/princeton_marc.rb
+++ b/marc_to_solr/lib/princeton_marc.rb
@@ -141,9 +141,9 @@ def other_versions record
     field.subfields.each do |s_field|
       linked_nums << StdNum::ISBN.normalize(s_field.value) if (field.tag == "020") || ((field.tag == "776") && (s_field.code == 'z'))
       linked_nums << StdNum::ISSN.normalize(s_field.value) if (field.tag == "022") || ((field.tag == "776") && (s_field.code == 'x'))
-      linked_nums << oclc_normalize(s_field.value, prefix: true) if s_field.value.start_with?('(OCoLC)') && (field.tag == "035")
+      linked_nums << oclc_normalize(s_field.value, prefix: true) if (field.tag == "035") && oclc_number?(s_field.value)
       if ((field.tag == "776") && (s_field.code == 'w')) || ((field.tag == "787") && (s_field.code == 'w'))
-        linked_nums << oclc_normalize(s_field.value, prefix: true) if s_field.value.include?('(OCoLC)')
+        linked_nums << oclc_normalize(s_field.value, prefix: true) if oclc_number?(s_field.value)
         linked_nums << "BIB" + strip_non_numeric(s_field.value) unless s_field.value.include?('(')
         logger.error "#{record['001']} - linked field formatting: #{s_field.value}" if s_field.value.include?('(') && !s_field.value.start_with?('(')
       end
@@ -320,6 +320,14 @@ end
 
 def strip_non_numeric num_str
   num_str.gsub(/\D/, '').to_i.to_s
+end
+
+def oclc_number? oclc
+  # Strip spaces and dashes
+  clean_oclc = oclc.gsub(/[\-\s]/, '')
+  # Ensure it follows the OCLC standard
+  # (see https://help.oclc.org/Metadata_Services/WorldShare_Collection_Manager/Data_sync_collections/Prepare_your_data/30035_field_and_OCLC_control_numbers)
+  clean_oclc.match(/\(OCoLC\)(ocn|ocm|on)*\d+/) != nil
 end
 
 def oclc_normalize oclc, opts = { prefix: false }

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -1121,7 +1121,7 @@ end
 to_field 'oclc_s', extract_marc('035a') do |_record, accumulator|
   oclcs = []
   accumulator.each_with_index do |value, _i|
-    oclcs << oclc_normalize(value) if value.start_with?('(OCoLC)')
+    oclcs << oclc_normalize(value) if oclc_number?(value)
   end
   accumulator.replace(oclcs)
 end

--- a/spec/marc_to_solr/lib/princeton_marc_spec.rb
+++ b/spec/marc_to_solr/lib/princeton_marc_spec.rb
@@ -307,6 +307,27 @@ describe 'From princeton_marc.rb' do
     end
   end
 
+  describe "oclc_number?" do
+    it "detects invalid OCLC numbers" do
+      expect(oclc_number?("(OCoLC)TGPSM11-B2267 ")).to be false
+      expect(oclc_number?("(OCoLC)xon9990014350")).to be false
+      expect(oclc_number?("(OCoLC)onx9990014350")).to be false
+    end
+
+    it "detects valid OCLC numbers" do
+      # Includes various prefixes and extraneous (but harmless) spaces
+      values = []
+      values << "(OCoLC)882089266"
+      values << "(OCoLC)on9990014350"
+      values << "(OCoLC)ocn899745778"
+      values << "(OCoLC)ocm00112267 "
+      values << "(OCoLC)on 9990014350"
+      values.each do |value|
+        expect(oclc_number?(value)).to be true
+      end
+    end
+  end
+
   describe 'other_versions function' do
     before(:all) do
       @bib = '9947652213506421'


### PR DESCRIPTION
Fixes #1708 

The code now checks for more than "string starts with (OCoLC)" and makes sure the format adheres better to the OCLC number specification.