### PR TITLE
Capture UTF8 errors and ignore them

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'selenium-webdriver'
 gem 'stomp'
 gem 'stringex', github: "pulibrary/stringex", tag: 'vpton.2.5.2.2'
-gem 'traject', '2.3.1'
+gem 'traject'
 gem 'turbolinks'
 gem 'uglifier', '>= 1.3.0'
 gem 'whenever', "~> 0.10"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,7 @@ GEM
     gyoku (1.3.1)
       builder (>= 2.1.2)
     hashdiff (1.0.1)
-    hashie (3.6.0)
+    hashie (5.0.0)
     high_voltage (3.1.2)
     hitimes (2.0.0)
     honeybadger (3.3.1)
@@ -466,7 +466,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    slop (3.6.0)
+    slop (4.9.1)
     solargraph (0.38.0)
       backport (~> 1.1)
       bundler (>= 1.17.2)
@@ -508,14 +508,16 @@ GEM
       hitimes
     tins (1.31.0)
       sync
-    traject (2.3.1)
+    traject (3.7.0)
       concurrent-ruby (>= 0.8.0)
       dot-properties (>= 0.1.1)
-      hashie (~> 3.1)
+      hashie (>= 3.1, < 6)
+      http (>= 3.0, < 6)
       httpclient (~> 2.5)
       marc (~> 1.0)
       marc-fastxmlwriter (~> 1.0)
-      slop (>= 3.4.5, < 4.0)
+      nokogiri (~> 1.9)
+      slop (~> 4.0)
       yell
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
@@ -627,7 +629,7 @@ DEPENDENCIES
   stomp
   stringex!
   timecop
-  traject (= 2.3.1)
+  traject
   turbolinks
   uglifier (>= 1.3.0)
   webdrivers

--- a/app/controllers/bibliographic_controller.rb
+++ b/app/controllers/bibliographic_controller.rb
@@ -214,7 +214,7 @@ class BibliographicController < ApplicationController # rubocop:disable Metrics/
     end
 
     # Access the global Traject Object
-    # @return [Traject::Indexer] the Traject indexer
+    # @return [Traject::Indexer::MarcIndexer] the Traject indexer
     def indexer
       TRAJECT_INDEXER
     end

--- a/app/services/indexer_service.rb
+++ b/app/services/indexer_service.rb
@@ -17,7 +17,7 @@ class IndexerService
   end
 
   def indexer
-    @indexer ||= Traject::Indexer.new
+    @indexer ||= Traject::Indexer::MarcIndexer.new
   end
 
   def traject_config_file_path

--- a/spec/controllers/bibliographic_controller_spec.rb
+++ b/spec/controllers/bibliographic_controller_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe BibliographicController, type: :controller do
           "electronic_access_1display" => ["{\"http://arks.princeton.edu/ark:/88435/h702qb15q\":[\"Table of contents\"]}"]
         }
       end
-      let(:indexer) { instance_double(Traject::Indexer) }
+      let(:indexer) { instance_double(Traject::Indexer::MarcIndexer) }
 
       it 'generates JSON-LD' do
         get :bib_jsonld, params: { bib_id: ark_record }, format: :jsonld

--- a/spec/jobs/alma_dump_transfer_job_spec.rb
+++ b/spec/jobs/alma_dump_transfer_job_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe AlmaDumpTransferJob, type: :job do
 
         expect(dump.dump_files.count).to eq 2
         expect(dump.dump_files.map(&:dump_file_type).map(&:constant).uniq).to eq ["BIB_RECORDS"]
-        expect(dump.dump_files.first.path).to eq File.join(MARC_LIBERATION_CONFIG['data_dir'], filename1)
+        expect(dump.dump_files.map(&:path)).to contain_exactly(File.join(MARC_LIBERATION_CONFIG['data_dir'], filename1), File.join(MARC_LIBERATION_CONFIG['data_dir'], filename2))
 
         expect(IndexRemainingDumpsJob).not_to have_received(:perform_async)
       end

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -928,7 +928,7 @@ describe 'From traject_config.rb' do
     it "ignores errors and allows the indexer to continue" do
       indexer = IndexerService.build
       sample = indexer.map_record(fixture_record('99125119454006421', indexer: indexer))
-      expect(sample).to eq({})
+      expect(sample).to be_nil
     end
   end
 end

--- a/spec/models/jsonld_record_spec.rb
+++ b/spec/models/jsonld_record_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe JSONLDRecord, type: :model do
     it 'includes both the vernacular and english titles' do
       json_ld = {
         title: [{ '@value': 'كتاب المناهل الصافية / لطف الله بن محمد] [ظفيري', '@language': 'ara' },
-                { '@value': 'Kitāb al-Manāhil al-ṣāfīyah / Luṭf Allāh ibn Muḥammad Ẓufayrī.', '@language': 'ara-Latn' }],
+                { '@value': 'Kitāb al-Manāhil al-ṣāfīyah / Luṭf Allāh ibn Muḥammad Ẓufayrī', '@language': 'ara-Latn' }],
         language: 'ara',
         creator: ['Ẓufayrī, Luṭf Allāh ibn Muḥammad, 1570-1626', 'ظفيري، لطف الله بن محمد'],
         author: 'Ẓufayrī, Luṭf Allāh ibn Muḥammad, 1570-1626'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,7 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
   config.extend ControllerMacros, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :system
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/services/indexer_service_spec.rb
+++ b/spec/services/indexer_service_spec.rb
@@ -3,5 +3,5 @@ require 'rails_helper'
 RSpec.describe IndexerService do
   subject { described_class.build }
 
-  it { is_expected.to be_a(Traject::Indexer) }
+  it { is_expected.to be_a(Traject::Indexer::MarcIndexer) }
 end

--- a/spec/system/devise_spec.rb
+++ b/spec/system/devise_spec.rb
@@ -25,12 +25,15 @@ RSpec.describe 'Devise restricts features for unauthenticated users', type: :sys
       visit "/events.json"
     end
 
-    scenario "only authenticated users can delete events" do
+    scenario "unauthenticated users can not delete events" do
       visit "/events"
-      accept_alert do
-        click_link "Delete"
-      end
-      find("div.alert", text: I18n.t("devise.failure.unauthenticated"))
+      expect(page).not_to have_link "Delete"
+    end
+
+    scenario "only authenticated users can delete events" do
+      sign_in FactoryBot.create(:admin), scope: :user
+      visit "/events"
+      expect(page).to have_link "Delete"
     end
   end
 


### PR DESCRIPTION
Also updated to traject 3.7 from 2.3.1 to get better error handeling options