### PR TITLE
Removing the ci run for ruby 2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,25 +228,6 @@ jobs:
           name: Rspec
           working_directory: ~/marc_liberation/webhook_monitor/src/
           command: bundle exec rspec spec
-  
-  # test that ruby 2.6 is still passing the tests.
-  test_2_6:
-    working_directory: ~/marc_liberation
-
-    docker:
-      - image: circleci/ruby:2.6-node-browsers
-        environment:
-          RAILS_ENV: test
-          PGHOST: localhost
-          PGUSER: bibdata
-          SOLR_URL: http://127.0.0.1:8983/solr/marc-liberation-core-test
-      - image: postgres:10.6-alpine
-        environment:
-          POSTGRES_USER: bibdata
-          POSTGRES_DB: marc_liberation_test
-          POSTGRES_HOST_AUTH_METHOD: trust
-      - image: redis:4.0.9-alpine
-    steps: *test_steps
 
 workflows:
   version: 2
@@ -259,7 +240,6 @@ workflows:
       - test:
           requires:
             - build
-      - test_2_6
       - doc:
           requires:
             - build


### PR DESCRIPTION
We are now utilizing Ruby 2.7 everywhere.  No need to continue to run 2.6 in CI