### PR TITLE
Update to use postgres 13 in development and CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           RAILS_ENV: test
           PGHOST: localhost
           PGUSER: bibdata
-      - image: postgres:10.6-alpine
+      - image: cimg/postgres:13.6
         environment:
           POSTGRES_USER: bibdata
           POSTGRES_DB: marc_liberation_test

--- a/.lando.yml
+++ b/.lando.yml
@@ -14,7 +14,7 @@ services:
     config:
       dir: "solr/conf"
   marc_liberation_database:
-    type: postgres:10
+    type: postgres:13
     portforward: true
   marc_liberation_redis:
     type: redis:4.0.9

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,11 +2,11 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 


### PR DESCRIPTION
- Our servers are using Postgres 13, so it's good to match them
- The Postgres 10 image was causing problems on M1 Macs

In order to upgrade locally, the easiest way is:
1. Stop lando `bundle exec rake servers:stop`
2. `lando destroy` (Thanks @sandbergja!)

The Hard way:
1. Stop lando `bundle exec rake servers:stop`
2. Delete the existing database container & Volumes (this will delete any data you have in the database locally)
  * You can do this using Docker Desktop 
    * For Containers/Apps, if you hover over the container that ends with `marc_liberation_database_1`, you will see a trash can, click that
    * For Volumes, find the two volumes that end with `marc_liberation_database`, hover over each and on the right side a contextual menu will pop up, click on the three dots and select "remove"
4. Run `bundle exec rake servers:start`