### PR TITLE
Remove deprecation warning for URI.escape

### DIFF
--- a/marc_to_solr/lib/normal_uri_factory.rb
+++ b/marc_to_solr/lib/normal_uri_factory.rb
@@ -3,6 +3,7 @@ class NormalUriFactory
   # Constructor
   # @param value [String] String value for the URL
   def initialize(value:)
+    @parser = URI::Parser.new
     @value = clean(value)
   end
 
@@ -18,6 +19,7 @@ class NormalUriFactory
     # @param value [String] String value for the URL
     def clean(value)
       return value if /#.+/.match?(value)
-      URI.escape(URI.unescape(value).scrub)
+
+      @parser.escape(@parser.unescape(value).scrub)
     end
 end

--- a/spec/marc_to_solr/lib/normal_uri_factory_spec.rb
+++ b/spec/marc_to_solr/lib/normal_uri_factory_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NormalUriFactory do
+  let(:nuf) { described_class.new(value: test_uri) }
+
+  context "a url with queries" do
+    let(:test_uri) { "http://libguides.princeton.edu/content.php?pid=295717&sid=2427989" }
+
+    it "normalizes uris" do
+      expect(nuf.instance_variable_get("@value")).to eq test_uri
+    end
+  end
+
+  context "a url with an anchor link" do
+    let(:test_uri) { "https://catalog.princeton.edu/catalog/4765221#view" }
+
+    it "does not escape the anchor" do
+      expect(nuf.instance_variable_get("@value")).to eq test_uri
+    end
+  end
+end


### PR DESCRIPTION
- I believe we are only escaping / unescaping urls from trusted sources. If not, we might want a different approach.

Closes #1769 