### PR TITLE
Make request headers in test match reality

### DIFF
--- a/spec/controllers/availability_controller_spec.rb
+++ b/spec/controllers/availability_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 require 'json'
 
 RSpec.describe AvailabilityController, type: :controller do
+  let(:request_headers) { { 'Accept' => 'application/json', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'api_key' => 'TESTME', 'Content-Type' => 'application/json' } }
   describe '#index with ids param' do
     it "responds 400 bad request" do
       bib_id = '929437'
@@ -51,7 +52,7 @@ RSpec.describe AvailabilityController, type: :controller do
     it '404 when no item ID exists' do
       stub_request(:post, "https://test.api.com/sharedCollection/bibAvailabilityStatus")
         .with(body: "{\"bibliographicId\":\"foo\",\"institutionId\":\"scsb\"}",
-              headers: { 'Accept' => 'application/json', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Api-Key' => 'TESTME', 'Content-Type' => 'application/json' })
+              headers: request_headers)
         .to_return(status: 404, body: "", headers: {})
       allow(scsb_good_lookup).to receive(:find_by_id).and_return({})
       get :index, params: { scsb_id: no_id, format: :json }
@@ -61,7 +62,7 @@ RSpec.describe AvailabilityController, type: :controller do
     it 'returns barcodes and status attached to the id' do
       stub_request(:post, "https://test.api.com/sharedCollection/bibAvailabilityStatus")
         .with(body: '{"bibliographicId":"5270946","institutionId":"scsb"}',
-              headers: { 'Accept' => 'application/json', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Api-Key' => 'TESTME', 'Content-Type' => 'application/json' })
+              headers: request_headers)
         .to_return(status: 200, body: '[{ "itemBarcode": "32101055068314", "itemAvailabilityStatus": "Available", "errorMessage": null}]', headers: {})
       allow(scsb_good_lookup).to receive(:find_by_id).and_return(
         [
@@ -102,7 +103,7 @@ RSpec.describe AvailabilityController, type: :controller do
     it '404 when no item ID exists' do
       stub_request(:post, "https://test.api.com/sharedCollection/itemAvailabilityStatus")
         .with(body: "{\"barcodes\":[\"foo\",\"blah\"]}",
-              headers: { 'Accept' => 'application/json', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Api-Key' => 'TESTME', 'Content-Type' => 'application/json' })
+              headers: request_headers)
         .to_return(status: 404, body: "", headers: {})
       allow(scsb_good_lookup).to receive(:find_by_barcodes).and_return({})
       get :index, params: { barcodes: ['foo', 'blah'], format: :json }
@@ -112,7 +113,7 @@ RSpec.describe AvailabilityController, type: :controller do
     it 'returns barcodes and status attached to the id' do
       stub_request(:post, "https://test.api.com/sharedCollection/itemAvailabilityStatus")
         .with(body: "{\"barcodes\":[\"32101055068314\",\"32101055068313\"]}",
-              headers: { 'Accept' => 'application/json', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Api-Key' => 'TESTME', 'Content-Type' => 'application/json' })
+              headers: request_headers)
         .to_return(status: 200, body: '[{ "itemBarcode": "32101055068314", "itemAvailabilityStatus": "Available", "errorMessage": null},{ "itemBarcode": "32101055068313", "itemAvailabilityStatus": "Available", "errorMessage": null}]', headers: {})
       allow(scsb_bad_lookup).to receive(:find_by_barcodes).and_return(
         [


### PR DESCRIPTION
Strangely, it works in the test whether the header is `api_key` or `Api-Key`, but fails if you change it to something totally different, since it doesn't match the stub.