### PR TITLE
Add rake task to request full records from SCSB

### DIFF
--- a/app/models/scsb_full_records_request.rb
+++ b/app/models/scsb_full_records_request.rb
@@ -36,7 +36,7 @@ class ScsbFullRecordsRequest
       req.headers['api_key'] = scsb_auth_key
     end
     expected_response_body = "Export process has started and we will send an email notification upon completion"
-    Rails.logger.error("Receved unexpected response: #{response.body}") unless response.body == expected_response_body
+    Rails.logger.error("Received unexpected response: #{response.body}") unless response.body == expected_response_body
     response
   rescue Faraday::ConnectionFailed, Faraday::TimeoutError => connection_failed
     Rails.logger.warn("#{self.class}: Connection error for #{scsb_server}")

--- a/app/models/scsb_full_records_request.rb
+++ b/app/models/scsb_full_records_request.rb
@@ -27,7 +27,7 @@ class ScsbFullRecordsRequest
       req.params['collectionGroupIds'] = '1,2'
       req.params['emailToAddress'] = email
       req.params['fetchType'] = 10
-      req.params['imsDepositoryCodes'] = 'RECAP,HD'
+      req.params['imsDepositoryCodes'] = repository_codes(institution_code)
       req.params['institutionCodes'] = institution_code
       req.params['outputFormat'] = 0
       req.params['requestingInstitutionCode'] = 'PUL'
@@ -41,6 +41,15 @@ class ScsbFullRecordsRequest
   rescue Faraday::ConnectionFailed, Faraday::TimeoutError => connection_failed
     Rails.logger.warn("#{self.class}: Connection error for #{scsb_server}")
     raise connection_failed
+  end
+
+  def repository_codes(institution_code)
+    case institution_code
+    when 'PUL', 'CUL'
+      'RECAP'
+    when 'HL'
+      'RECAP,HD'
+    end
   end
 
   private

--- a/app/models/scsb_full_records_request.rb
+++ b/app/models/scsb_full_records_request.rb
@@ -1,0 +1,55 @@
+class ScsbFullRecordsRequest
+  attr_accessor :scsb_env, :email
+
+  def initialize(scsb_env, email)
+    @scsb_env = scsb_env
+    @email = email
+  end
+
+  def scsb_host
+    case scsb_env
+    when 'uat'
+      'https://uat-recap.htcinc.com:9093'
+    when 'production'
+      'https://scsb.recaplib.org:9093'
+    end
+  end
+
+  def scsb_conn
+    Faraday.new(url: scsb_host) do |faraday|
+      faraday.request(:url_encoded)
+    end
+  end
+
+  def scsb_request(institution_code)
+    response = scsb_conn.get do |req|
+      req.path = '/dataDump/exportDataDump'
+      req.params['collectionGroupIds'] = '1,2'
+      req.params['emailToAddress'] = email
+      req.params['fetchType'] = 10
+      req.params['imsDepositoryCodes'] = 'RECAP,HD'
+      req.params['institutionCodes'] = institution_code
+      req.params['outputFormat'] = 0
+      req.params['requestingInstitutionCode'] = 'PUL'
+      req.params['transmissionType'] = 0
+      req.headers['Accept'] = '*/*'
+      req.headers['api_key'] = scsb_auth_key
+    end
+    expected_response_body = "Export process has started and we will send an email notification upon completion"
+    Rails.logger.error("Receved unexpected response: #{response.body}") unless response.body == expected_response_body
+    response
+  rescue Faraday::ConnectionFailed, Faraday::TimeoutError => connection_failed
+    Rails.logger.warn("#{self.class}: Connection error for #{scsb_server}")
+    raise connection_failed
+  end
+
+  private
+
+    def scsb_auth_key
+      if !Rails.env.test?
+        ENV['SCSB_AUTH_KEY']
+      else
+        'TESTME'
+      end
+    end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -42,3 +42,15 @@ end
 every 1.week, roles: [:cron_staging, :cron_production] do
   rake "marc_liberation:delete:events"
 end
+
+every 2.weeks, at: '7:00am', roles: [:cron_production] do
+  rake "scsb:request_records[production,mk8066@princeton.edu,CUL]", output: "/tmp/cron_log.log"
+end
+
+every 2.weeks, at: '3:00pm', roles: [:cron_production] do
+  rake "scsb:request_records[production,mk8066@princeton.edu,NYPL]", output: "/tmp/cron_log.log"
+end
+
+every 2.weeks, at: '11:00pm', roles: [:cron_production] do
+  rake "scsb:request_records[production,mk8066@princeton.edu,HL]", output: "/tmp/cron_log.log"
+end

--- a/lib/tasks/scsb.rake
+++ b/lib/tasks/scsb.rake
@@ -51,6 +51,30 @@ namespace :scsb do
     dump_file.save
   end
 
+  desc "Request full partner records from SCSB API"
+  task request_records: :environment do
+    abort "usage: bundle exec rake scsb:request_records EMAIL=YOUR_EMAIL_HERE SCSB_ENV=[uat|production] SCSB_AUTH_KEY=auth-key" unless ENV['SCSB_ENV'] && ENV['EMAIL'] && ENV['SCSB_AUTH_KEY']
+    scsb_env = ENV['SCSB_ENV'].downcase
+    abort "SCSB_ENV must be set to either uat or production" unless scsb_env == "uat" || scsb_env == "production"
+    email = ENV['EMAIL']
+    scsb_records_request = ScsbFullRecordsRequest.new(scsb_env, email)
+    # Request records from each institution - each call must be made separately
+    puts("Requesting records for Columbia")
+    cul_response = scsb_records_request.scsb_request('CUL')
+    puts("Columbia response: #{cul_response.body}")
+
+    puts("Requesting records for New York Public Library")
+    nypl_response = scsb_records_request.scsb_request('NYPL')
+    puts("NYPL response: #{nypl_response.body}")
+
+    puts("Requesting records for Harvard")
+    hl_response = scsb_records_request.scsb_request('HL')
+    puts("Harvard response: #{hl_response.body}")
+
+    puts("Requests complete, you should receive emails from recaplib.org when each one is started" \
+         "(there may be a significant lag between each institution).")
+  end
+
   namespace :import do
     desc "Creates an Event and downloads files for a full partner record set"
     task full: :environment do

--- a/spec/models/scsb_full_records_request_spec.rb
+++ b/spec/models/scsb_full_records_request_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ScsbFullRecordsRequest do
   let(:records_request) { described_class.new(scsb_env, email) }
   let(:conn) { records_request.scsb_conn }
   before do
-    stub_request(:get, "#{scsb_url}/dataDump/exportDataDump?collectionGroupIds=1,2&emailToAddress=test@princeton.edu&fetchType=10&imsDepositoryCodes=RECAP,HD&institutionCodes=CUL&outputFormat=0&requestingInstitutionCode=PUL&transmissionType=0")
+    stub_request(:get, "#{scsb_url}/dataDump/exportDataDump?collectionGroupIds=1,2&emailToAddress=test@princeton.edu&fetchType=10&imsDepositoryCodes=RECAP&institutionCodes=CUL&outputFormat=0&requestingInstitutionCode=PUL&transmissionType=0")
       .with(headers: { 'Accept': '*/*', 'Api-Key': 'TESTME' })
       .to_return(status: 200, body: "Export process has started and we will send an email notification upon completion", headers: {})
   end
@@ -26,6 +26,17 @@ RSpec.describe ScsbFullRecordsRequest do
 
     it 'builds a request' do
       expect(records_request.scsb_request('CUL')).to be_instance_of(Faraday::Response)
+    end
+    context 'requesting Harvard items' do
+      before do
+        stub_request(:get, "#{scsb_url}/dataDump/exportDataDump?collectionGroupIds=1,2&emailToAddress=test@princeton.edu&fetchType=10&imsDepositoryCodes=RECAP,HD&institutionCodes=HL&outputFormat=0&requestingInstitutionCode=PUL&transmissionType=0")
+          .with(headers: { 'Accept': '*/*', 'Api-Key': 'TESTME' })
+          .to_return(status: 200, body: "Export process has started and we will send an email notification upon completion", headers: {})
+      end
+
+      it 'builds a request' do
+        expect(records_request.scsb_request('HL')).to be_instance_of(Faraday::Response)
+      end
     end
   end
   context 'using the production environment' do

--- a/spec/models/scsb_full_records_request_spec.rb
+++ b/spec/models/scsb_full_records_request_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe ScsbFullRecordsRequest do
+  let(:email) { 'test@princeton.edu' }
+  let(:records_request) { described_class.new(scsb_env, email) }
+  let(:conn) { records_request.scsb_conn }
+  before do
+    stub_request(:get, "#{scsb_url}/dataDump/exportDataDump?collectionGroupIds=1,2&emailToAddress=test@princeton.edu&fetchType=10&imsDepositoryCodes=RECAP,HD&institutionCodes=CUL&outputFormat=0&requestingInstitutionCode=PUL&transmissionType=0")
+      .with(headers: { 'Accept': '*/*', 'Api-Key': 'TESTME' })
+      .to_return(status: 200, body: "Export process has started and we will send an email notification upon completion", headers: {})
+  end
+  context 'using the uat environment' do
+    let(:scsb_env) { 'uat' }
+    let(:scsb_url) { 'https://uat-recap.htcinc.com:9093' }
+
+    it 'can be instantiated' do
+      expect(records_request).to be
+      expect(records_request.scsb_env).to eq('uat')
+      expect(records_request.email).to eq('test@princeton.edu')
+      expect(records_request.scsb_host).to eq(scsb_url)
+    end
+
+    it 'has a connection' do
+      expect(conn).to be_instance_of(Faraday::Connection)
+    end
+
+    it 'builds a request' do
+      expect(records_request.scsb_request('CUL')).to be_instance_of(Faraday::Response)
+    end
+  end
+  context 'using the production environment' do
+    let(:scsb_env) { 'production' }
+    let(:scsb_url) { 'https://scsb.recaplib.org:9093' }
+
+    it 'can be instantiated' do
+      expect(records_request).to be
+      expect(records_request.scsb_env).to eq('production')
+      expect(records_request.email).to eq('test@princeton.edu')
+      expect(records_request.scsb_host).to eq(scsb_url)
+    end
+
+    it 'builds a request' do
+      expect(records_request.scsb_request('CUL')).to be_instance_of(Faraday::Response)
+    end
+  end
+end


### PR DESCRIPTION
@kevinreiss  - I'm I right in thinking that the response:

```
Can't run export now as another process is in progress. We have saved your request.We will initiate and notify once the exiting process completes
```

means that requests after the first one are in the queue and will be processed once the first one is done?

If I'm mistaken, we should change the rake task to only request from one institution at a time, which could be passed in from the environment as well.

Closes #1544 