### PR TITLE
i1841: CJK transliterations in browse list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,3 +87,5 @@ group :development, :test do
 end
 
 gem "omniauth-rails_csrf_protection"
+
+gem "ffi-icu", "~> 0.4.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,8 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    ffi-icu (0.4.3)
+      ffi (~> 1.0, >= 1.0.9)
     friendly_id (5.1.0)
       activerecord (>= 4.0.0)
     globalid (1.0.0)
@@ -607,6 +609,7 @@ DEPENDENCIES
   faraday (~> 1.0.1)
   faraday_middleware (~> 1.0.0)
   ffi (>= 1.9.25)
+  ffi-icu (~> 0.4.3)
   friendly_id (~> 5.1.0)
   gyoku (~> 1.0)
   high_voltage (~> 3.0)

--- a/marc_to_solr/lib/cjk_factory.rb
+++ b/marc_to_solr/lib/cjk_factory.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'ffi-icu'
+
+module CJKFactory
+  def self.traditional_to_simplified(string)
+    transliterate('Traditional-Simplified', string)
+  end
+
+  def self.katakana_to_hiragana(string)
+    transliterate('Katakana-Hiragana', string)
+  end
+
+  def self.contains_chinese?(string)
+    /\p{Han}/.match string
+  end
+
+  def self.contains_katakana?(string)
+    /\p{Katakana}/.match string
+  end
+
+  def self.transliterate(icu_id, string)
+    ICU::Transliteration.transliterate(icu_id, string)
+  end
+end

--- a/spec/marc_to_solr/lib/cjk_factory_spec.rb
+++ b/spec/marc_to_solr/lib/cjk_factory_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'CJK Factory' do
+  let(:traditional_chinese_name) { '沈從文' }
+  let(:simplified_chinese_name) { '沈从文' }
+  let(:katakana_word) { 'アメリカ' }
+  let(:hiragana_word) { 'あめりか' }
+  it 'can accurately identify Chinese characters' do
+    expect(CJKFactory.contains_chinese?(traditional_chinese_name)).to be_truthy
+    expect(CJKFactory.contains_chinese?(katakana_word)).to be_falsey
+  end
+
+  it 'can accurately identify Katakana' do
+    expect(CJKFactory.contains_katakana?(katakana_word)).to be_truthy
+    expect(CJKFactory.contains_katakana?(traditional_chinese_name)).to be_falsey
+  end
+
+  it 'can transliterate Traditional Chinese characters to Simplified' do
+    expect(CJKFactory.traditional_to_simplified(traditional_chinese_name)).to eq(simplified_chinese_name)
+  end
+
+  it 'can transliterate Katakana to Hiragana' do
+    expect(CJKFactory.katakana_to_hiragana(katakana_word)).to eq(hiragana_word)
+  end
+end

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -774,6 +774,18 @@ describe 'From traject_config.rb', indexing: true do
           expect(no_uniform_title['name_title_browse_s']).to match_array(["Name. Title 245a",
                                                                           "AltName. VernTitle 245a"])
         end
+        context 'CJK records' do
+          let(:n100) { { "100" => { "ind1" => "", "ind2" => " ", "subfields" => [{ "6" => "880-01" }, { "a" => "Shen, Jieren," }] } } }
+          let(:n100_vern) { { "880" => { "ind1" => "", "ind2" => " ", "subfields" => [{ "6" => "100-01" }, { "a" => "沈介人," }] } } }
+          let(:t245) { { "245" => { "ind1" => "", "ind2" => " ", "subfields" => [{ "6" => "880-03" }, { "a" => "Ge guo qing nian xun lian yu xin sheng huo yun dong" }] } } }
+          let(:t245_vern) { { "880" => { "ind1" => "", "ind2" => " ", "subfields" => [{ "6" => "245-03" }, { "a" => "各國靑年訓練與新生活運動" }] } } }
+          it 'includes transliterated simplified Chinese characters in name_title_browse_s' do
+            expect(no_uniform_title['name_title_browse_s']).to include("沈介人. 各国靑年训练与新生活运动")
+          end
+          it 'includes original traditional Chinese characters in name_title_browse_s' do
+            expect(no_uniform_title['name_title_browse_s']).to include("沈介人. 各國靑年訓練與新生活運動")
+          end
+        end
       end
     end
 
@@ -968,6 +980,19 @@ describe 'From traject_config.rb', indexing: true do
             expect(@change_the_subject1["lc_subject_display"]).to match_array(corrected_subjects_compound)
             expect(@change_the_subject1["subject_unstem_search"]).to match_array(subjects_for_searching)
           end
+        end
+      end
+
+      describe 'CJK subjects' do
+        let(:s650_local) { { "650" => { "ind1" => "", "ind2" => "7", "subfields" => [{ "a" => "アメリカ" }, { "2" => "local" }, { "5" => "NjP" }] } } }
+        let(:s600_name) { { "600" => { "ind1" => "", "ind2" => "0", "subfields" => [{ "a" => "沈從文" }] } } }
+        let(:subject_marc) { @indexer.map_record(MARC::Record.new_from_hash('fields' => [s650_local, s600_name], 'leader' => leader)) }
+        it 'includes transliterated hiragana in subject_facet' do
+          expect(subject_marc["subject_facet"]).to include('あめりか')
+        end
+
+        it 'includes transliterated simplified Chinese characters in subject_facet' do
+          expect(subject_marc["subject_facet"]).to include('沈从文')
         end
       end
     end

--- a/spec/marc_to_solr/lib/princeton_marc_spec.rb
+++ b/spec/marc_to_solr/lib/princeton_marc_spec.rb
@@ -382,24 +382,38 @@ describe 'From princeton_marc.rb' do
   end
 
   describe 'process_names, process_alt_script_names function' do
-    before(:all) do
-      @t100 = { "100" => { "ind1" => "", "ind2" => " ", "subfields" => [{ "a" => "John" }, { "d" => "1492" }, { "t" => "TITLE" }, { "k" => "ignore" }] } }
-      @t700 = { "700" => { "ind1" => "", "ind2" => " ", "subfields" => [{ "a" => "John" }, { "d" => "1492" }, { "k" => "don't ignore" }, { "t" => "TITLE" }] } }
-      @t880 = { "880" => { "ind1" => "", "ind2" => " ", "subfields" => [{ "6" => "100-1" }, { "a" => "Κινέζικα" }, { "t" => "TITLE" }, { "k" => "ignore" }] } }
-      @sample_marc = MARC::Record.new_from_hash('fields' => [@t100, @t700, @t880])
+    let(:t100) do
+      { "100" => { "ind1" => "", "ind2" => " ", "subfields" => [{ "a" => "John" }, { "d" => "1492" }, { "t" => "TITLE" }, { "k" => "ignore" }] } }
     end
+    let(:t700) do
+      { "700" => { "ind1" => "", "ind2" => " ", "subfields" => [{ "a" => "John" }, { "d" => "1492" }, { "k" => "don't ignore" }, { "t" => "TITLE" }] } }
+    end
+    let(:t880) do
+      { "880" => { "ind1" => "", "ind2" => " ", "subfields" => [{ "6" => "100-1" }, { "a" => "Κινέζικα" }, { "t" => "TITLE" }, { "k" => "ignore" }] } }
+    end
+    let(:sample_marc) { MARC::Record.new_from_hash('fields' => [t100, t700, t880]) }
 
     it 'strips subfields that appear after subfield $t, includes 880' do
-      names = process_names(@sample_marc)
+      names = process_names(sample_marc)
       expect(names).to include("John 1492")
       expect(names).to include("John 1492 don't ignore")
       expect(names).not_to include("John 1492 ignore")
       expect(names).to include("Κινέζικα")
     end
     it 'alt_script version only includes the 880' do
-      names = process_alt_script_names(@sample_marc)
+      names = process_alt_script_names(sample_marc)
       expect(names).to include("Κινέζικα")
       expect(names).not_to include("John 1492")
+    end
+    context 'when names are in Traditional Chinese Characters' do
+      let(:t880) do
+        { "880" => { "ind1" => "", "ind2" => " ", "subfields" => [{ "6" => "100-1" }, { "a" => "沈從文" }] } }
+      end
+      it 'includes the name in both traditional and simplified characters' do
+        names = process_names(sample_marc)
+        expect(names).to include('沈從文')
+        expect(names).to include('沈从文')
+      end
     end
   end
 


### PR DESCRIPTION
An example:

- [Name in traditional Chinese characters has 50 results](https://catalog-qa.princeton.edu/browse/names?search_field=browse_name&q=%E6%B2%88%E5%BE%9E%E6%96%87%2C+1902-)
- [Name in simplified Chinese characters has 51 results, including all the results for the traditional characters](https://catalog-qa.princeton.edu/browse/names?search_field=browse_name&q=%E6%B2%88%E4%BB%8E%E6%96%87%2C+1902-), and also [one record that only includes the simplified characters](https://catalog-qa.princeton.edu/catalog/9963001083506421)