### PR TITLE
Break up contents_display

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -757,7 +757,16 @@ end
 # Contents:
 #    505 0X agrt
 #    505 8X agrt
-to_field 'contents_display', extract_marc('505agrt')
+to_field 'contents_display', extract_marc('505agrt') do |_record, accumulator|
+  if accumulator.present?
+    contents = []
+    accumulator.map do |contents_list|
+      contents << contents_list.split(' -- ')
+    end
+    contents.flatten!
+  end
+  accumulator.replace(contents) if contents
+end
 
 # Provenance:
 #    561 XX 3ab

--- a/spec/fixtures/marc_to_solr/9969362593506421.mrx
+++ b/spec/fixtures/marc_to_solr/9969362593506421.mrx
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<record>
+  <leader>02173cam a2200481 a 4500</leader>
+  <controlfield tag="001">9969362593506421</controlfield>
+  <controlfield tag="005">20200928163727.0</controlfield>
+  <controlfield tag="008">111111s2011    ru a          000 f rus  </controlfield>
+  <datafield ind1=" " ind2=" " tag="010">
+    <subfield code="a">  2011490573</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="035">
+    <subfield code="a">(OCoLC)ocn772475593</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="035">
+    <subfield code="a">6936259</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="035">
+    <subfield code="a">(OCoLC)772475593</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="035">
+    <subfield code="a">(NjP)6936259-princetondb</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="037">
+    <subfield code="a">ATA 2011/12 195</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="037">
+    <subfield code="a">22</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="040">
+    <subfield code="a">DLC</subfield>
+    <subfield code="b">eng</subfield>
+    <subfield code="c">DLC</subfield>
+    <subfield code="d">ORU</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="066">
+    <subfield code="c">(N</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="020">
+    <subfield code="a">9785358092044</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="020">
+    <subfield code="a">5358092048</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="042">
+    <subfield code="a">pcc</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="043">
+    <subfield code="a">e-ur---</subfield>
+    <subfield code="a">e-ru---</subfield>
+  </datafield>
+  <datafield ind1="0" ind2="0" tag="050">
+    <subfield code="a">PG3479.7.S48</subfield>
+    <subfield code="b">M37 2011</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="049">
+    <subfield code="a">PULL</subfield>
+  </datafield>
+  <datafield ind1="1" ind2=" " tag="100">
+    <subfield code="6">880-01</subfield>
+    <subfield code="a">Esin, Sergeĭ.</subfield>
+    <subfield code="0">http://id.loc.gov/authorities/names/n84209597</subfield>
+  </datafield>
+  <datafield ind1="1" ind2="0" tag="245">
+    <subfield code="6">880-02</subfield>
+    <subfield code="a">Markiz :</subfield>
+    <subfield code="b">roman /</subfield>
+    <subfield code="c">Sergeĭ Esin.</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="260">
+    <subfield code="6">880-03</subfield>
+    <subfield code="a">Moskva :</subfield>
+    <subfield code="b">Drofa,</subfield>
+    <subfield code="c">2011.</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="300">
+    <subfield code="a">334 p. :</subfield>
+    <subfield code="b">ill. ;</subfield>
+    <subfield code="c">22 cm.</subfield>
+  </datafield>
+  <datafield ind1="2" ind2=" " tag="505">
+    <subfield code="6">880-04</subfield>
+    <subfield code="a">Pod svodami mraka i sveta / Anatoliĭ Korolev -- Markiz Astolʹf de Ki︠u︡stin: pochta dukhov, ili Rossii︠a︡ v 2007 godu: perelozhenie na otechestvennyĭ Sergei︠a︡ Esina.</subfield>
+  </datafield>
+  <datafield ind1=" " ind2="0" tag="651">
+    <subfield code="a">Russia (Federation)</subfield>
+    <subfield code="x">History</subfield>
+    <subfield code="y">1991-</subfield>
+    <subfield code="v">Fiction.</subfield>
+  </datafield>
+  <datafield ind1=" " ind2="0" tag="651">
+    <subfield code="a">Russia</subfield>
+    <subfield code="x">History</subfield>
+    <subfield code="v">Fiction.</subfield>
+  </datafield>
+  <datafield ind1=" " ind2="0" tag="651">
+    <subfield code="a">Soviet Union</subfield>
+    <subfield code="v">Fiction.</subfield>
+    <subfield code="0">http://id.loc.gov/authorities/subjects/sh2008111701</subfield>
+  </datafield>
+  <datafield ind1="1" ind2="0" tag="600">
+    <subfield code="a">Custine, Astolphe,</subfield>
+    <subfield code="c">marquis de,</subfield>
+    <subfield code="d">1790-1857</subfield>
+    <subfield code="v">Fiction.</subfield>
+  </datafield>
+  <datafield ind1=" " ind2="7" tag="655">
+    <subfield code="a">Fiction.</subfield>
+    <subfield code="2">lcgft</subfield>
+    <subfield code="0">http://id.loc.gov/authorities/genreForms/gf2014026339</subfield>
+  </datafield>
+  <datafield ind1=" " ind2="7" tag="655">
+    <subfield code="a">Novels.</subfield>
+    <subfield code="2">lcgft</subfield>
+    <subfield code="0">http://id.loc.gov/authorities/genreForms/gf2015026020</subfield>
+  </datafield>
+  <datafield ind1="1" ind2=" " tag="880">
+    <subfield code="6">100-01/(N</subfield>
+    <subfield code="a">Есин, Сергей.</subfield>
+  </datafield>
+  <datafield ind1="1" ind2="0" tag="880">
+    <subfield code="6">245-02/(N</subfield>
+    <subfield code="a">Маркиз :</subfield>
+    <subfield code="b">роман /</subfield>
+    <subfield code="c">Сергей Есин.</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="880">
+    <subfield code="6">260-03/(N</subfield>
+    <subfield code="a">Москва :</subfield>
+    <subfield code="b">Дрофа,</subfield>
+    <subfield code="c">2011.</subfield>
+  </datafield>
+  <datafield ind1="2" ind2=" " tag="880">
+    <subfield code="6">505-04/(N</subfield>
+    <subfield code="a">Под сводами мрака и света / Анатолий Королев -- Маркиз Астольф де Кюстин: почта духов, или Россия в 2007 году: переложение на отечественный Сергея Есина.</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="880">
+    <subfield code="6">500-00/(N</subfield>
+    <subfield code="a">"Литературно-художественное издание"--Colophon.</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="936">
+    <subfield code="a">PR 753315038</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="994">
+    <subfield code="a">C0</subfield>
+    <subfield code="b">PUL</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="999">
+    <subfield code="a">6936259</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="904">
+    <subfield code="a">ark</subfield>
+    <subfield code="b">a</subfield>
+    <subfield code="h">m</subfield>
+    <subfield code="c">b</subfield>
+    <subfield code="e">20120209</subfield>
+  </datafield>
+  <datafield ind1=" " ind2=" " tag="902">
+    <subfield code="a">ark</subfield>
+    <subfield code="b">l</subfield>
+    <subfield code="6">a</subfield>
+    <subfield code="7">m</subfield>
+    <subfield code="d">v</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="e">20120209</subfield>
+  </datafield>
+</record>

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -68,6 +68,7 @@ describe 'From traject_config.rb', indexing: true do
       @holdings_with_and_no_items = @indexer.map_record(fixture_record('99122643653506421'))
       @local_subject_heading = @indexer.map_record(fixture_record('local_subject_heading'))
       @siku_subject_headings = @indexer.map_record(fixture_record('9918309193506421'))
+      @translated_contents = @indexer.map_record(fixture_record('9969362593506421'))
     end
 
     describe "alma loading" do
@@ -112,6 +113,17 @@ describe 'From traject_config.rb', indexing: true do
         expect(holding_2["location"]).to eq "Stacks"
         expect(holding_2["library"]).to eq "Firestone Library"
         expect(holding_2["location_code"]).to eq "firestone$stacks"
+      end
+    end
+
+    describe 'contents_display' do
+      context 'with a contents note' do
+        it 'naively splits on double dashes' do
+          expect(@sample34['contents_display']).to match_array(["Disc 1. Mammy water", "(1956, 19 min.) ; The mad masters", "(1956, 29 min.)", "Moi, un noir", "(1959, 74 min.)", "Disc 2. The human pyramid", "(1961, 93 min.)", "The lion hunters", "(1967, 81 min.)", "Disc 3. Jaguar", "(1967, 93 min.)", "Little by little (1971, 96 min.)", "Disc 4. The punishment", "(1964, 64 min.)", "Jean Rouch, the adventerous filmmaker / Laurent VeÌdrine (2017, 55 min.)."])
+          expect(@sample37['contents_display']).to match_array(["Book 1. April-June", "Book 2. July-September", "Book 3. October-December."])
+          expect(@record_call_number2['contents_display']).to match_array(["Sechs Lieder nach Christian Morgenstern = Six songs after Christian Morganstern (1952-1953) / Heinz Holliger (12:06)", "Due melodie = Two melodies = Zwei Melodien (1978) / Salvatore Sciarrino (6:17)", "Got lost (2007-2008) / Helmut Lachenmann (24:56)", "Requiem po drugu = Requiem for the Beloved = Requiem für den Geliebten, op. 26 (1982-1987) / György Kurtág (6:27)", "Ophelia sings (2012) / Wolfgang Rihm (9:45)", "Wenn die Landschaft aufhört = When the landscape ceases (2015) / Bernhard Lang (5:30)."])
+          expect(@translated_contents['contents_display']).to match_array(["Pod svodami mraka i sveta / Anatoliĭ Korolev", "Markiz Astolʹf de Ki︠u︡stin: pochta dukhov, ili Rossii︠a︡ v 2007 godu: perelozhenie na otechestvennyĭ Sergei︠a︡ Esina.", "Под сводами мрака и света / Анатолий Королев", "Маркиз Астольф де Кюстин: почта духов, или Россия в 2007 году: переложение на отечественный Сергея Есина."])
+        end
       end
     end
     describe 'the cataloged_date from publishing job' do


### PR DESCRIPTION
- so it shows on multiple lines

Closes pulibrary/orangelight/issues/1502

Works re-indexed on bibdata-qa:
* https://catalog-qa.princeton.edu/catalog/99105855523506421 (@sandbergja and I suspect there may be a cataloging issue with this one - will check with cataloging)
* https://catalog-qa.princeton.edu/catalog/99103141233506421 (songs with composers)
* https://catalog-qa.princeton.edu/catalog/9969362593506421 (transliterated ToC)
* https://catalog-qa.princeton.edu/catalog/9958465153506421
* https://catalog-qa.princeton.edu/catalog/9948688413506421 (super long ToC)
* https://catalog-qa.princeton.edu/catalog/9976174773506421