### PR TITLE
Adds monthly scsb:import cron job

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -54,3 +54,8 @@ end
 every 2.weeks, at: '11:00pm', roles: [:cron_production] do
   rake "scsb:request_records[production,mk8066@princeton.edu,HL]", output: "/tmp/cron_log.log"
 end
+
+# Runs on the second Saturday of the month at 9:00 am
+every '0 9 8-14 * *', roles: [:cron_production] do
+  rake "scsb:import:full_saturdays_only", output: "/tmp/cron_log.log"
+end

--- a/lib/tasks/scsb.rake
+++ b/lib/tasks/scsb.rake
@@ -74,5 +74,11 @@ namespace :scsb do
     task full: :environment do
       ScsbImportFullJob.perform_later
     end
+
+    desc "Used for monthly cron job - downloads files for full partner record set only on Saturdays"
+    task full_saturdays_only: :environment do
+      abort "This task will only run on Saturdays, to facilitate monthly cron job. If you want to run this job manually on another day, use scsb:import:full" unless Date.today.saturday?
+      ScsbImportFullJob.perform_later
+    end
   end
 end


### PR DESCRIPTION
- crontab does not have a concept of "Every 4th Saturday" or "Monthly on Saturday", so we give a one-week range, and then use logic in the rake task to either run or not run the job.

Closes #2017