### PR TITLE
i2069: Add a new field for specific languages on the Show page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,4 +91,4 @@ end
 
 gem "omniauth-rails_csrf_protection"
 
-gem "human_languages", "~> 0.6.0"
+gem "human_languages", "~> 0.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,7 @@ GEM
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
-    human_languages (0.6.0)
+    human_languages (0.7.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     iso-639 (0.3.5)
@@ -631,7 +631,7 @@ DEPENDENCIES
   gyoku (~> 1.0)
   high_voltage (~> 3.0)
   honeybadger (~> 4.0)
-  human_languages (~> 0.6.0)
+  human_languages (~> 0.7)
   jbuilder
   jquery-rails
   jquery-tablesorter (~> 1.21)

--- a/marc_to_solr/lib/language_extractor.rb
+++ b/marc_to_solr/lib/language_extractor.rb
@@ -15,7 +15,7 @@ class LanguageExtractor
     elsif all_041_fields.any?
       codes.concat(all_041_codes)
     end
-    codes.reject { |general_code| includes_more_specific_version?(codes, general_code) }
+    codes.uniq.reject { |general_code| includes_more_specific_version?(codes, general_code) }
   end
 
   def specific_names
@@ -54,7 +54,7 @@ class LanguageExtractor
 
     def extract_from_multiple_041s(fields)
       fields.map do |field|
-        field.subfields.select { |sf| %(a h).include? sf.code }
+        field.subfields.select { |sf| %(a d).include? sf.code }
              .map(&:value)
       end.flatten
     end

--- a/marc_to_solr/lib/language_extractor.rb
+++ b/marc_to_solr/lib/language_extractor.rb
@@ -1,0 +1,61 @@
+# A class to pull out language information from
+# a MARC record
+class LanguageExtractor
+  def initialize(language_service, marc_record)
+    @marc_record = marc_record
+    @language_service = language_service
+  end
+
+  def specific_codes
+    codes = []
+    codes << fixed_field_code if fixed_field_code
+
+    if iso_041_fields.any?
+      codes.concat(iso_041_codes)
+    elsif all_041_fields.any?
+      codes.concat(all_041_codes)
+    end
+    codes.reject { |general_code| includes_more_specific_version?(codes, general_code) }
+  end
+
+  def specific_names
+    specific_codes.map { |code| @language_service.code_to_name(code) }
+                  .compact
+  end
+
+  private
+
+    def includes_more_specific_version?(codes, code_to_check)
+      codes.any? { |individual| @language_service.macrolanguage_codes(individual).include? code_to_check }
+    end
+
+    def iso_041_fields
+      all_041_fields.select { |field| field['2'] == 'iso639-3' }
+    end
+
+    def all_041_fields
+      @marc_record.fields('041')
+    end
+
+    def fixed_field_code
+      value = @marc_record['008']&.value
+      fixed_field_code = value ? value[35, 3] : nil
+    end
+
+    def iso_041_codes
+      return [] unless iso_041_fields.any?
+      extract_from_multiple_041s(iso_041_fields)
+    end
+
+    def all_041_codes
+      return [] unless all_041_fields.any?
+      extract_from_multiple_041s(all_041_fields)
+    end
+
+    def extract_from_multiple_041s(fields)
+      fields.map do |field|
+        field.subfields.select { |sf| %(a h).include? sf.code }
+             .map(&:value)
+      end.flatten
+    end
+end

--- a/marc_to_solr/lib/language_service.rb
+++ b/marc_to_solr/lib/language_service.rb
@@ -12,12 +12,34 @@ class LanguageService
 
   def valid_language_code?(code)
     return false if code.blank?
-    Languages[code].present? || iso639_5_collective_languages['code'].include?(code)
+    Languages[code].present? || iso_639_5_include?(code)
+  end
+
+  def code_to_name(code)
+    Languages[code]&.name || iso_639_5_name(code)
+  end
+
+  def macrolanguage_codes(individual_language_code)
+    individual = Languages[individual_language_code]
+    if individual.respond_to? :macrolanguage
+      [individual&.macrolanguage&.alpha3_bibliographic.to_s, individual&.macrolanguage&.iso639_3.to_s].uniq
+    else
+      []
+    end
   end
 
   private
 
     def iso639_5_collective_languages
       @iso639_5_collective_languages ||= CSV.read(Rails.root.join('config', 'iso639-5.tsv'), headers: true, col_sep: "\t")
+    end
+
+    def iso_639_5_include?(code)
+      iso639_5_collective_languages['code'].include?(code)
+    end
+
+    def iso_639_5_name(code)
+      return unless iso_639_5_include?(code)
+      iso639_5_collective_languages.find { |row| row['code'] == code }['Label (English)']
     end
 end

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -13,6 +13,7 @@ require_relative './solr_deleter'
 require_relative './access_facet_builder'
 require_relative './augment_the_subject'
 require_relative './language_service'
+require_relative './language_extractor'
 require_relative './pul_solr_json_writer'
 require 'stringex'
 require 'library_stdnums'
@@ -726,6 +727,10 @@ to_field 'participant_performer_display', extract_marc('511a')
 # Language(s):
 #    546 XX 3a
 to_field 'language_display', extract_marc('5463a')
+
+to_field 'language_name_display' do |record, accumulator|
+  accumulator.replace(LanguageExtractor.new(language_service, record).specific_names)
+end
 
 to_field 'language_facet', marc_languages
 

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -728,6 +728,8 @@ to_field 'participant_performer_display', extract_marc('511a')
 #    546 XX 3a
 to_field 'language_display', extract_marc('5463a')
 
+# Languages for the show page
+#    008, 041$a and 041$d
 to_field 'language_name_display' do |record, accumulator|
   accumulator.replace(LanguageExtractor.new(language_service, record).specific_names)
 end

--- a/spec/fixtures/marc_to_solr/99117463983506421.mrx
+++ b/spec/fixtures/marc_to_solr/99117463983506421.mrx
@@ -1,0 +1,322 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>04502cam a22006857i 4500</leader>
+  <controlfield tag="005">20210921213022.0</controlfield>
+  <controlfield tag="006">m#####o##d########</controlfield>
+  <controlfield tag="007">cr#mn######a#a</controlfield>
+  <controlfield tag="008">120627s2012    ncuabg  ob    001 0 eng d</controlfield>
+  <controlfield tag="001">99117463983506421</controlfield>
+  <datafield tag="019" ind1=" " ind2=" ">
+    <subfield code="a">822214277</subfield>
+    <subfield code="a">1077882617</subfield>
+    <subfield code="a">1082995253</subfield>
+    <subfield code="a">1086508821</subfield>
+    <subfield code="a">1086574747</subfield>
+    <subfield code="a">1097298210</subfield>
+    <subfield code="a">1110354952</subfield>
+    <subfield code="a">1119150740</subfield>
+    <subfield code="a">1125512363</subfield>
+    <subfield code="a">1135829859</subfield>
+    <subfield code="a">1136407428</subfield>
+    <subfield code="a">1144877401</subfield>
+    <subfield code="a">1167850616</subfield>
+    <subfield code="a">1200074602</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">0822395894</subfield>
+    <subfield code="q">(electronic bk.)</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">1283657694</subfield>
+    <subfield code="q">(MyiLibrary)</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9780822395898</subfield>
+    <subfield code="q">(electronic bk.)</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9781283657693</subfield>
+    <subfield code="q">(MyiLibrary)</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="z">0822353652</subfield>
+    <subfield code="q">(pbk. ;</subfield>
+    <subfield code="q">alk. paper)</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="z">9780822353652</subfield>
+    <subfield code="q">(pbk. ;</subfield>
+    <subfield code="q">alk. paper)</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)813529053</subfield>
+    <subfield code="z">(OCoLC)822214277</subfield>
+    <subfield code="z">(OCoLC)1077882617</subfield>
+    <subfield code="z">(OCoLC)1082995253</subfield>
+    <subfield code="z">(OCoLC)1086508821</subfield>
+    <subfield code="z">(OCoLC)1086574747</subfield>
+    <subfield code="z">(OCoLC)1097298210</subfield>
+    <subfield code="z">(OCoLC)1110354952</subfield>
+    <subfield code="z">(OCoLC)1119150740</subfield>
+    <subfield code="z">(OCoLC)1125512363</subfield>
+    <subfield code="z">(OCoLC)1135829859</subfield>
+    <subfield code="z">(OCoLC)1136407428</subfield>
+    <subfield code="z">(OCoLC)1144877401</subfield>
+    <subfield code="z">(OCoLC)1167850616</subfield>
+    <subfield code="z">(OCoLC)1200074602</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)ocn813529053</subfield>
+  </datafield>
+  <datafield tag="037" ind1=" " ind2=" ">
+    <subfield code="a">22573/ctv11227rf</subfield>
+    <subfield code="b">JSTOR</subfield>
+  </datafield>
+  <datafield tag="037" ind1=" " ind2=" ">
+    <subfield code="a">397019</subfield>
+    <subfield code="b">MIL</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">CDX</subfield>
+    <subfield code="b">eng</subfield>
+    <subfield code="e">rda</subfield>
+    <subfield code="e">pn</subfield>
+    <subfield code="c">CDX</subfield>
+    <subfield code="d">OCLCO</subfield>
+    <subfield code="d">YDXCP</subfield>
+    <subfield code="d">OCLCQ</subfield>
+    <subfield code="d">NDD</subfield>
+    <subfield code="d">VT2</subfield>
+    <subfield code="d">ZMC</subfield>
+    <subfield code="d">MHW</subfield>
+    <subfield code="d">E7B</subfield>
+    <subfield code="d">N$T</subfield>
+    <subfield code="d">OCLCF</subfield>
+    <subfield code="d">ZMC</subfield>
+    <subfield code="d">OCLCO</subfield>
+    <subfield code="d">DEBSZ</subfield>
+    <subfield code="d">OCLCO</subfield>
+    <subfield code="d">AZU</subfield>
+    <subfield code="d">OCLCQ</subfield>
+    <subfield code="d">OCLCO</subfield>
+    <subfield code="d">OCLCQ</subfield>
+    <subfield code="d">MERUC</subfield>
+    <subfield code="d">IOG</subfield>
+    <subfield code="d">OCLCA</subfield>
+    <subfield code="d">CNCGM</subfield>
+    <subfield code="d">OCLCQ</subfield>
+    <subfield code="d">YOU</subfield>
+    <subfield code="d">LEAUB</subfield>
+    <subfield code="d">BRX</subfield>
+    <subfield code="d">W2U</subfield>
+    <subfield code="d">AUD</subfield>
+    <subfield code="d">OCLCE</subfield>
+    <subfield code="d">CNTRU</subfield>
+    <subfield code="d">OCLCQ</subfield>
+    <subfield code="d">OCLCO</subfield>
+    <subfield code="d">OCLCQ</subfield>
+    <subfield code="d">BWN</subfield>
+    <subfield code="d">COCUF</subfield>
+    <subfield code="d">PUL</subfield>
+    <subfield code="d">JSTOR</subfield>
+    <subfield code="d">SFB</subfield>
+    <subfield code="d">UKUOP</subfield>
+    <subfield code="d">OCLCQ</subfield>
+    <subfield code="d">OCLCO</subfield>
+    <subfield code="d">JHP</subfield>
+    <subfield code="d">OCLCQ</subfield>
+  </datafield>
+  <datafield tag="041" ind1="0" ind2="7">
+    <subfield code="a">bco</subfield>
+    <subfield code="2">iso639-3</subfield>
+  </datafield>
+  <datafield tag="043" ind1=" " ind2=" ">
+    <subfield code="a">a-pp---</subfield>
+  </datafield>
+  <datafield tag="050" ind1=" " ind2="4">
+    <subfield code="a">DU740.42</subfield>
+    <subfield code="b">.F44 2012eb</subfield>
+  </datafield>
+  <datafield tag="082" ind1="0" ind2="4">
+    <subfield code="a">305.89/912</subfield>
+    <subfield code="2">23</subfield>
+  </datafield>
+  <datafield tag="099" ind1=" " ind2=" ">
+    <subfield code="a">Electronic Resource</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Feld, Steven,</subfield>
+    <subfield code="e">author.</subfield>
+    <subfield code="0">http://id.loc.gov/authorities/names/n82001550</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Sound and sentiment :</subfield>
+    <subfield code="b">birds, weeping, poetics, and song in Kaluli expression /</subfield>
+    <subfield code="c">Steven Feld.</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="a">Third edition.</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="a">Thirtieth anniversary edition with a new introduction.</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Durham, N.C. :</subfield>
+    <subfield code="b">Duke University Press,</subfield>
+    <subfield code="c">2012.</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">1 online resource (xli, 300 pages) :</subfield>
+    <subfield code="b">illustrations, map, music</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">computer</subfield>
+    <subfield code="b">c</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">online resource</subfield>
+    <subfield code="b">cr</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="347" ind1=" " ind2=" ">
+    <subfield code="a">data file</subfield>
+    <subfield code="2">rda</subfield>
+  </datafield>
+  <datafield tag="490" ind1="0" ind2=" ">
+    <subfield code="a">Music and sound collection</subfield>
+  </datafield>
+  <datafield tag="546" ind1=" " ind2=" ">
+    <subfield code="a">Includes text in Kaluli.</subfield>
+  </datafield>
+  <datafield tag="504" ind1=" " ind2=" ">
+    <subfield code="a">Includes bibliographical references (pages 284-292) and index.</subfield>
+  </datafield>
+  <datafield tag="520" ind1=" " ind2=" ">
+    <subfield code="a">"This thirtieth anniversary edition of Sound and Sentiment makes Steven Feld's landmark, field-defining book available to a new generation of scholars and students. A sensory ethnography set in the rain forest of Papua New Guinea, among the Kaluli people of Bosavi, Sound and Sentiment introduced the anthropology of sound, or the cultural study of sound. After it was first published in 1982, a second edition, incorporating additional field research and a new postscript, was released in 1990. The third edition includes all of the material from the first two editions, along with a substantial new introduction in which Feld discusses Bosavi's recent history and reflects on the challenges it poses for contemporary theory and representation."--Publisher's description</subfield>
+  </datafield>
+  <datafield tag="588" ind1="0" ind2=" ">
+    <subfield code="a">Online resource; title from digital title page (JSTOR; viewed on January 15, 2021).</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Kaluli (Papua New Guinean people)</subfield>
+    <subfield code="x">Social life and customs.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Kaluli (Papua New Guinean people)</subfield>
+    <subfield code="x">Rites and ceremonies.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Kaluli (Papua New Guinean people)</subfield>
+    <subfield code="x">Music</subfield>
+    <subfield code="x">History and criticism.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Folk music</subfield>
+    <subfield code="z">Papua New Guinea</subfield>
+    <subfield code="x">History and criticism.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Folk songs, Kaluli</subfield>
+    <subfield code="z">Papua New Guinea</subfield>
+    <subfield code="x">History and criticism.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Birds</subfield>
+    <subfield code="x">Mythology</subfield>
+    <subfield code="z">Papua New Guinea.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Birds</subfield>
+    <subfield code="z">Papua New Guinea.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="7">
+    <subfield code="a">Birds.</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst00832970</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="7">
+    <subfield code="a">Birds</subfield>
+    <subfield code="x">Mythology.</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst00833040</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="7">
+    <subfield code="a">Folk music.</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst00929383</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="7">
+    <subfield code="a">Folk songs, Kaluli.</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst00929980</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="7">
+    <subfield code="a">Kaluli (Papua New Guinean people)</subfield>
+    <subfield code="x">Music.</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst01430612</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="7">
+    <subfield code="a">Kaluli (Papua New Guinean people)</subfield>
+    <subfield code="x">Rites and ceremonies.</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst01430614</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="7">
+    <subfield code="a">Kaluli (Papua New Guinean people)</subfield>
+    <subfield code="x">Social life and customs.</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst01430615</subfield>
+  </datafield>
+  <datafield tag="651" ind1=" " ind2="7">
+    <subfield code="a">Papua New Guinea.</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst01212610</subfield>
+  </datafield>
+  <datafield tag="655" ind1=" " ind2="7">
+    <subfield code="a">Criticism, interpretation, etc.</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst01411635</subfield>
+  </datafield>
+  <datafield tag="776" ind1="0" ind2="8">
+    <subfield code="i">Print version:</subfield>
+    <subfield code="a">Feld, Steven.</subfield>
+    <subfield code="t">Sound and sentiment.</subfield>
+    <subfield code="d">Durham, N.C. : Duke University Press, 2012</subfield>
+    <subfield code="z">9780822353652</subfield>
+    <subfield code="z">0822353652</subfield>
+    <subfield code="w">(DLC)  2012024696</subfield>
+    <subfield code="w">(OCoLC)798058349</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2="0">
+    <subfield code="u">https://www.jstor.org/stable/10.2307/j.ctv113180h</subfield>
+  </datafield>
+  <datafield tag="950" ind1=" " ind2=" ">
+    <subfield code="c">2023-02-18 13:47:45 US/Eastern</subfield>
+    <subfield code="b">2021-07-13 04:33:04 US/Eastern</subfield>
+    <subfield code="a">false</subfield>
+  </datafield>
+  <datafield tag="951" ind1=" " ind2=" ">
+    <subfield code="v">2021-07-20 14:38:49 US/Eastern</subfield>
+    <subfield code="u">System</subfield>
+    <subfield code="t">2021-07-20 14:38:41 US/Eastern</subfield>
+    <subfield code="x">https://na05.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53835228700006421&amp;Force_direct=true</subfield>
+    <subfield code="s">P2E_JOB</subfield>
+    <subfield code="0">53835228700006421</subfield>
+    <subfield code="w">2021-07-20 18:38:41</subfield>
+    <subfield code="f">false</subfield>
+    <subfield code="b">static</subfield>
+    <subfield code="q">2265198-princetondb</subfield>
+    <subfield code="1">52835228710006421</subfield>
+    <subfield code="c">d?u.ignore_date_coverage=true&amp;rft.mms_id=99117463983506421</subfield>
+    <subfield code="a">Available</subfield>
+    <subfield code="e">BOOK</subfield>
+    <subfield code="8">53835228700006421</subfield>
+  </datafield>
+</record>

--- a/spec/fixtures/marc_to_solr/99125416143306421.mrx
+++ b/spec/fixtures/marc_to_solr/99125416143306421.mrx
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>02022cam a2200421 i 4500</leader>
+  <controlfield tag="005">20230223130343.0</controlfield>
+  <controlfield tag="008">220216s2020    mx a     b    000 0bspa  </controlfield>
+  <controlfield tag="001">99125416143306421</controlfield>
+  <datafield tag="010" ind1=" " ind2=" ">
+    <subfield code="a">  2021398906</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9786073035262</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">6073035268</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)on1287951978</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">DLC</subfield>
+    <subfield code="b">eng</subfield>
+    <subfield code="e">rda</subfield>
+    <subfield code="c">DLC</subfield>
+    <subfield code="d">CUY</subfield>
+    <subfield code="d">OCLCF</subfield>
+    <subfield code="d">UKMGB</subfield>
+    <subfield code="d">CLU</subfield>
+    <subfield code="d">TJC</subfield>
+  </datafield>
+  <datafield tag="041" ind1="0" ind2=" ">
+    <subfield code="a">spa</subfield>
+    <subfield code="a">myn</subfield>
+  </datafield>
+  <datafield tag="041" ind1="0" ind2="7">
+    <subfield code="a">spa</subfield>
+    <subfield code="a">kek</subfield>
+    <subfield code="2">iso639-3</subfield>
+  </datafield>
+  <datafield tag="042" ind1=" " ind2=" ">
+    <subfield code="a">pcc</subfield>
+  </datafield>
+  <datafield tag="043" ind1=" " ind2=" ">
+    <subfield code="a">ncgt---</subfield>
+  </datafield>
+  <datafield tag="050" ind1="0" ind2="0">
+    <subfield code="a">PM3913</subfield>
+    <subfield code="b">.R89 2020</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Ruz, Mario Humberto,</subfield>
+    <subfield code="e">author.</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="4">
+    <subfield code="a">Las lenguas mayas en la Guatemala colonial :</subfield>
+    <subfield code="b">lengua K'ekch&#xED; /</subfield>
+    <subfield code="c">versi&#xF3;n paleogr&#xE1;fica y edici&#xF3;n de Mario Humberto Ruz y Claudia Margarita B&#xE1;ez Ju&#xE1;rez.</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="a">Primera edici&#xF3;n,</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Ciudad de M&#xE9;xico :</subfield>
+    <subfield code="b">Universidad Nacional Aut&#xF3;noma de M&#xE9;xico,</subfield>
+    <subfield code="c">2020.</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">xxxi, 144 pages, pages xxxiii-xxxix :</subfield>
+    <subfield code="b">illustrations ;</subfield>
+    <subfield code="c">28 cm.</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">unmediated</subfield>
+    <subfield code="b">n</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">volume</subfield>
+    <subfield code="b">nc</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="490" ind1="1" ind2=" ">
+    <subfield code="a">Fuentes para el estudio de la cultura maya ;</subfield>
+    <subfield code="v">22</subfield>
+  </datafield>
+  <datafield tag="505" ind1="0" ind2=" ">
+    <subfield code="a">Arte de la lengua cacch&#xED; de cob&#xE1;n en la verapaz -- Apuntes de lengua queechi y peque&#xF1;o confesionario en la misma lengua -- Doctrina Cristiana en lengua quecchi, escrita por padr&#xF5;n del pueblo de San Agust&#xED;n Lanqu&#xED;n, en la verapaz, por Eugenio Pop, alcalde que fue en [el] a&#xF1;o de [1795] -- Confesionario en lengua kahch&#xED; en m&#xE9;todo breve.</subfield>
+  </datafield>
+  <datafield tag="504" ind1=" " ind2=" ">
+    <subfield code="a">Includes bibliographical references (pages XXXIII-XXXVII).</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Kekchi language</subfield>
+    <subfield code="z">Guatemala.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Mayan languages</subfield>
+    <subfield code="z">Guatemala.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="7">
+    <subfield code="a">Kekchi language.</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst00986700</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="7">
+    <subfield code="a">Mayan languages.</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst01012756</subfield>
+  </datafield>
+  <datafield tag="651" ind1=" " ind2="7">
+    <subfield code="a">Guatemala.</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst01205154</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Ba&#x301;ez Ju&#x301;arez, Claudia M.,</subfield>
+    <subfield code="e">editor.</subfield>
+  </datafield>
+  <datafield tag="830" ind1=" " ind2="0">
+    <subfield code="a">Fuentes para el estudio de la cultura maya ;</subfield>
+    <subfield code="v">22.</subfield>
+  </datafield>
+  <datafield tag="902" ind1=" " ind2=" ">
+    <subfield code="a">940007607</subfield>
+    <subfield code="w">copy</subfield>
+    <subfield code="1">20221118125632.0</subfield>
+  </datafield>
+  <datafield tag="914" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)on1287951978</subfield>
+    <subfield code="b">OCoLC</subfield>
+    <subfield code="c">match</subfield>
+    <subfield code="d">20230223</subfield>
+    <subfield code="e">processed</subfield>
+    <subfield code="f">1287951978</subfield>
+  </datafield>
+  <datafield tag="950" ind1=" " ind2=" ">
+    <subfield code="c">2023-02-23 13:03:43 US/Eastern</subfield>
+    <subfield code="b">2021-11-11 12:39:00 US/Eastern</subfield>
+    <subfield code="a">false</subfield>
+  </datafield>
+  <datafield tag="852" ind1="0" ind2=" ">
+    <subfield code="b">firestone</subfield>
+    <subfield code="c">stacks</subfield>
+    <subfield code="h">PM3913</subfield>
+    <subfield code="i">.R89 2020</subfield>
+    <subfield code="8">22906895560006421</subfield>
+  </datafield>
+  <datafield tag="952" ind1=" " ind2=" ">
+    <subfield code="d">2022-11-18 17:57:31</subfield>
+    <subfield code="8">22906895560006421</subfield>
+    <subfield code="a">2021-11-11 17:39:10</subfield>
+    <subfield code="b">Firestone Library</subfield>
+    <subfield code="c">stacks: Firestone Library</subfield>
+    <subfield code="e">false</subfield>
+  </datafield>
+  <datafield tag="876" ind1=" " ind2=" ">
+    <subfield code="0">22906895560006421</subfield>
+    <subfield code="a">23906895550006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="z">stacks</subfield>
+    <subfield code="d">2021-11-11 12:39:10 US/Eastern</subfield>
+    <subfield code="p">32101113007205</subfield>
+    <subfield code="y">firestone</subfield>
+  </datafield>
+</record>

--- a/spec/fixtures/marc_to_solr/9930372403506421.mrx
+++ b/spec/fixtures/marc_to_solr/9930372403506421.mrx
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>02072cam a2200421 i 4500</leader>
+  <controlfield tag="005">20230125141828.0</controlfield>
+  <controlfield tag="008">000310s1859    cc            000 0 chi d</controlfield>
+  <controlfield tag="001">9930372403506421</controlfield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="9">CPT6292TS</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">3037240</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(NjP)3037240-princetondb</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)ocm43606015</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">PUL</subfield>
+    <subfield code="b">eng</subfield>
+    <subfield code="e">rda</subfield>
+    <subfield code="c">PUL</subfield>
+    <subfield code="d">OCLCQ</subfield>
+    <subfield code="d">OCLCG</subfield>
+    <subfield code="d">OCLCQ</subfield>
+    <subfield code="d">OCLCO</subfield>
+    <subfield code="d">OCLCA</subfield>
+    <subfield code="d">OCLCQ</subfield>
+    <subfield code="d">OCLCO</subfield>
+    <subfield code="d">PUL</subfield>
+  </datafield>
+  <datafield tag="041" ind1="1" ind2="7">
+    <subfield code="a">wuu</subfield>
+    <subfield code="h">eng</subfield>
+    <subfield code="2">iso639-3</subfield>
+  </datafield>
+  <datafield tag="130" ind1="0" ind2=" ">
+    <subfield code="a">Bible.</subfield>
+    <subfield code="p">Romans.</subfield>
+    <subfield code="k">Selections (Rankin).</subfield>
+    <subfield code="l">Chinese.</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="6">880-01</subfield>
+    <subfield code="a">S-du Pao-lo sia-peh Lo-mo Nying-go Shü-sing.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2="0">
+    <subfield code="6">245-01</subfield>
+    <subfield code="a">[使徒保罗写给罗马人的书信]</subfield>
+  </datafield>
+  <datafield tag="246" ind1="3" ind2="1">
+    <subfield code="a">[Shi tu Baoluo xie gei Luoma ren de shu xin]</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="6">880-02</subfield>
+    <subfield code="a">[Nying-Po?] ;</subfield>
+    <subfield code="c">[1859?]</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2="1">
+    <subfield code="6">264-02/$1</subfield>
+    <subfield code="a">[宁波?] :</subfield>
+    <subfield code="b">[华花圣经书房?],</subfield>
+    <subfield code="c">[1859?]</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">15 unnumbered leaves ;</subfield>
+    <subfield code="c">25 cm</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">unmediated</subfield>
+    <subfield code="b">n</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">volume</subfield>
+    <subfield code="b">nc</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="590" ind1=" " ind2=" ">
+    <subfield code="a">Originally No. 3 of four volumes in one bookcase.</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">The epistle to the Romans romanized into Ningpo colloquial from the Chinese translation, by Henry Van Vleck Rankin.</subfield>
+  </datafield>
+  <datafield tag="546" ind1=" " ind2=" ">
+    <subfield code="a">Text in Romanized dialect of Ningbo, Zhejiang Province, China</subfield>
+    <subfield code="b">Latin alphabet.</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">On folded leaves, stitch bound.</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="3">Princeton copy 1:</subfield>
+    <subfield code="a">"May 24, '21, H. V. [sic.] Rankin, '73 gift"--inscription penciled on the first leaf.</subfield>
+    <subfield code="5">NjP</subfield>
+  </datafield>
+  <datafield tag="541" ind1="0" ind2=" ">
+    <subfield code="c">Gift;</subfield>
+    <subfield code="a">Henry William Rankin, member of the Princeton Class of 1873;</subfield>
+    <subfield code="d">1921-05-24.</subfield>
+    <subfield code="5">NjP</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Chinese language</subfield>
+    <subfield code="x">Dialects</subfield>
+    <subfield code="z">China</subfield>
+    <subfield code="z">Ningbo Shi</subfield>
+    <subfield code="v">Texts.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Chinese language</subfield>
+    <subfield code="x">Transliteration</subfield>
+    <subfield code="v">Texts.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Rankin, Henry Van Vleck,</subfield>
+    <subfield code="d">1825-1863,</subfield>
+    <subfield code="e">translator.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Rankin, Henry William,</subfield>
+    <subfield code="d">1851-1937,</subfield>
+    <subfield code="e">former owner,</subfield>
+    <subfield code="e">donor.</subfield>
+    <subfield code="5">NjP</subfield>
+  </datafield>
+  <datafield tag="902" ind1=" " ind2=" ">
+    <subfield code="a">960761236</subfield>
+    <subfield code="w">original</subfield>
+    <subfield code="1">20221207161849.0</subfield>
+  </datafield>
+  <datafield tag="911" ind1=" " ind2=" ">
+    <subfield code="a">20000603</subfield>
+  </datafield>
+  <datafield tag="914" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)ocm43606015</subfield>
+    <subfield code="b">OCoLC</subfield>
+    <subfield code="c">match</subfield>
+    <subfield code="d">20230125</subfield>
+    <subfield code="e">processed</subfield>
+    <subfield code="f">43606015</subfield>
+  </datafield>
+  <datafield tag="945" ind1=" " ind2=" ">
+    <subfield code="a">P</subfield>
+    <subfield code="b">1</subfield>
+    <subfield code="c">P94.843.045.02</subfield>
+  </datafield>
+  <datafield tag="950" ind1=" " ind2=" ">
+    <subfield code="c">2023-01-25 14:18:28 US/Eastern</subfield>
+    <subfield code="b">2021-07-12 09:22:04 US/Eastern</subfield>
+    <subfield code="a">false</subfield>
+  </datafield>
+  <datafield tag="852" ind1="8" ind2="0">
+    <subfield code="b">rare</subfield>
+    <subfield code="c">ex</subfield>
+    <subfield code="h">N-003607</subfield>
+    <subfield code="8">22490737260006421</subfield>
+  </datafield>
+  <datafield tag="952" ind1=" " ind2=" ">
+    <subfield code="d">2022-11-30 16:47:22</subfield>
+    <subfield code="8">22490737260006421</subfield>
+    <subfield code="a">2021-07-12 13:22:04</subfield>
+    <subfield code="b">Special Collections</subfield>
+    <subfield code="c">ex: Rare Books</subfield>
+    <subfield code="e">false</subfield>
+  </datafield>
+  <datafield tag="876" ind1=" " ind2=" ">
+    <subfield code="0">22490737260006421</subfield>
+    <subfield code="a">23952307950006421</subfield>
+    <subfield code="j">1</subfield>
+    <subfield code="z">ex</subfield>
+    <subfield code="d">2022-11-21 12:25:15 US/Eastern</subfield>
+    <subfield code="p">32101103391593</subfield>
+    <subfield code="y">rare</subfield>
+  </datafield>
+</record>

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -74,6 +74,9 @@ describe 'From traject_config.rb', indexing: true do
       @invalid_774w = @indexer.map_record(fixture_record('9979952033506421'))
       @valid_774w = @indexer.map_record(fixture_record('9938522893506421'))
       @linked_773 = @indexer.map_record(fixture_record('9913692683506421'))
+      @iso639_3 = @indexer.map_record(fixture_record('99117463983506421'))
+      @iso639_3_with_parallel_041 = @indexer.map_record(fixture_record('99125416143306421'))
+      @iso639_3_with_macrolanguage = @indexer.map_record(fixture_record('9930372403506421'))
     end
 
     describe "alma loading" do
@@ -359,6 +362,20 @@ describe 'From traject_config.rb', indexing: true do
 
       it 'returns language value "it" for an italian record' do
         expect(@italian_language_iana['language_iana_s']).to eq ["it"]
+      end
+    end
+
+    describe 'the language_name_display field' do
+      it 'uses 041$2iso-639 if available' do
+        expect(@iso639_3['language_name_display']).to contain_exactly("English", "Kaluli")
+      end
+      it 'prefers 041$2iso-639 over other 041s if available' do
+        expect(@iso639_3_with_parallel_041['language_name_display']).to contain_exactly("Spanish", "Kekchí")
+      end
+      context 'when both an individual and macrolanguage code are available in the record' do
+        it 'prefers the individual code' do
+          expect(@iso639_3_with_macrolanguage['language_name_display']).to contain_exactly("Wu Chinese", "English")
+        end
       end
     end
 

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -374,7 +374,7 @@ describe 'From traject_config.rb', indexing: true do
       end
       context 'when both an individual and macrolanguage code are available in the record' do
         it 'prefers the individual code' do
-          expect(@iso639_3_with_macrolanguage['language_name_display']).to contain_exactly("Wu Chinese", "English")
+          expect(@iso639_3_with_macrolanguage['language_name_display']).to contain_exactly("Wu Chinese")
         end
       end
     end

--- a/spec/marc_to_solr/lib/language_extractor.rb
+++ b/spec/marc_to_solr/lib/language_extractor.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe LanguageExtractor do
+  let(:fields) do
+    [
+      { '008' => '120627s2012    ncuabg  ob    001 0 gre d' }
+    ]
+  end
+  let(:extractor) { described_class.new(LanguageService.new, MARC::Record.new_from_hash('fields' => fields)) }
+  it 'finds a language from the 008' do
+    expect(extractor.specific_names).to eq(['Modern Greek (1453-)'])
+  end
+  context 'when the 008 is a collective code' do
+    let(:fields) do
+      [
+        { '008' => '120627s2012    ncuabg  ob    001 0 myn d' }
+      ]
+    end
+    it 'provides the collective name' do
+      expect(extractor.specific_names).to eq(['Mayan languages'])
+    end
+  end
+  context 'when language info in the 041' do
+    let(:fields) do
+      [
+        { '008' => '120627s2012    ncuabg  ob    001 0 myn d' },
+        { '041' => { 'subfields' => [{ 'a' => 'nah' }] } }
+      ]
+    end
+    it 'includes the language from the 041' do
+      expect(extractor.specific_names).to include('Nahuatl languages')
+    end
+    it 'includes the language from the 008' do
+      expect(extractor.specific_names).to include('Mayan languages')
+    end
+  end
+  context 'when ISO 639-3 language info in the 041' do
+    let(:fields) do
+      [
+        { '008' => '120627s2012    ncuabg  ob    001 0 myn d' },
+        { '041' => { 'subfields' => [{ 'a' => 'nah' }] } },
+        { '041' => { 'subfields' => [{ 'a' => 'nuz' }, { '2' => 'iso639-3' }] } }
+      ]
+    end
+    it 'prefers ISO 639-3 language codes to MARC language codes' do
+      expect(extractor.specific_names).to include('Tlamacazapa Nahuatl')
+      expect(extractor.specific_names).not_to include('Nahuatl languages')
+    end
+    it 'includes the language from the 008' do
+      expect(extractor.specific_names).to include('Mayan languages')
+    end
+    context 'when 008 is a macrolanguage of the ISO 639-3 specific language' do
+      let(:fields) do
+        [
+          { '008' => '120627s2012    ncuabg  ob    001 0 chi d' },
+          { '041' => { 'subfields' => [{ 'a' => 'wuu' }, { '2' => 'iso639-3' }] } }
+        ]
+      end
+      it 'includes only the specific language' do
+        expect(extractor.specific_names).to include('Wu Chinese')
+        expect(extractor.specific_names).not_to include('Chinese')
+      end
+    end
+  end
+end

--- a/spec/marc_to_solr/lib/language_extractor_spec.rb
+++ b/spec/marc_to_solr/lib/language_extractor_spec.rb
@@ -62,5 +62,28 @@ RSpec.describe LanguageExtractor do
         expect(extractor.specific_names).not_to include('Chinese')
       end
     end
+    context '041$h' do
+      let(:fields) do
+        [
+          { '008' => '120627s2012    ncuabg  ob    001 0 chi d' },
+          { '041' => { 'subfields' => [{ 'a' => 'chi' }, { 'h' => 'eng' }] } }
+        ]
+      end
+      it 'does not include the translation from 041$h' do
+        expect(extractor.specific_names).to include('Chinese')
+        expect(extractor.specific_names).not_to include('English')
+      end
+    end
+    context '041$d' do
+      let(:fields) do
+        [
+          { '008' => '120627s2012    ncuabg  ob    001 0 spa d' },
+          { '041' => { 'subfields' => [{ 'a' => 'spa' }, { 'd' => 'por' }] } }
+        ]
+      end
+      it 'includes the spoken language from 041$d' do
+        expect(extractor.specific_names).to contain_exactly('Spanish', 'Portuguese')
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds a new solr field, `language_name_display`, which we could then add to the Show page.

Part of #2069 