### PR TITLE
Add aria-labels to tables in documentation, since github removes <caption> tags

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -11,7 +11,7 @@ There are several standards for representing human languages.  Bibdata concerns 
 These standards have various levels of overlap, as discussed in the following table:
 
 <!-- Using HTML in this table to add row headers and a caption, which are not included in Github-flavored markdown -->
-<table>
+<table aria-label="Codes and other data included in language standards">
     <caption>Codes and other data included in language standards</caption>
     <thead>
         <tr>
@@ -54,7 +54,7 @@ These standards have various levels of overlap, as discussed in the following ta
 MARC codes and ISO 639-3 codes may be found in MARC records, as described in the following table.  IANA codes are not in MARC records, so we compute those ourselves.
 
 <!-- Using HTML in this table to add row headers and a caption, which are not included in Github-flavored markdown -->
-<table>
+<table aria-label="Language codes included in MARC records">
     <caption>Language codes included in MARC records</caption>
     <thead>
         <tr>
@@ -83,7 +83,7 @@ MARC codes and ISO 639-3 codes may be found in MARC records, as described in the
 Language data is stored in the following solr fields.  In general, the `language_facet` field will contain the most languages, to provide patrons with additional access points.  The `language_name_display` is intended for the show page, where we instead want to display only the most specific language information we have.
 
 <!-- Using HTML in this table to add row headers and a caption, which are not included in Github-flavored markdown -->
-<table>
+<table aria-label="Language-related Solr fields">
     <caption>Language-related Solr fields</caption>
     <thead>
         <tr>


### PR DESCRIPTION
#2113 added some tables to the documentation, and used `<caption>` tags to provide accessible names.  However, github removes these tags, so this PR uses an `aria-label` to provide the accessible names instead.

Without `aria-label`, the Voiceover table rotor lists:
- 4 columns, 5 rows
- 3 columns, 3 rows
- 3 columns, 5 rows

With the `aria-label`, Voiceover can let the user know what each table is:

- Codes and other data included in language standards 4 columns, 5 rows
- Language codes included in MARC records 3 columns, 3 rows
- Language-related Solr fields 3 columns, 5 rows