### PR TITLE
Index 852 subfield k to holdings_1display

### DIFF
--- a/marc_to_solr/lib/process_holdings_helpers.rb
+++ b/marc_to_solr/lib/process_holdings_helpers.rb
@@ -101,6 +101,10 @@ class ProcessHoldingsHelpers
     holding['call_number'] = build_call_number(field_852)
     holding['call_number_browse'] = build_call_number(field_852)
     # Updates current holding key; values are from 852
+    if field_852["k"]
+      holding['sub_location'] = []
+      holding['sub_location'] << field_852['k']
+    end
     if field_852['l']
       holding['shelving_title'] = []
       holding['shelving_title'] << field_852['l']

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -682,6 +682,13 @@ describe 'From traject_config.rb', indexing: true do
         expect(@holdings['22543249720006421']).to be_falsey # items from this holding are in the temporary location lews$res
       end
 
+      it 'includes 852 subfield k as sub_location' do
+        @holdings = JSON.parse(@sample40['holdings_1display'][0])
+        holding = @holdings["22666524470006421"]
+        expect(holding.keys).to include('sub_location')
+        expect(holding['sub_location']).to match_array(['Oversize RA566.27'])
+      end
+
       describe 'electronic_access_1display' do
         it 'holding 856s are excluded from electronic_access_1display' do
           @electronic_access_1display = JSON.parse(@sample37["electronic_access_1display"].to_s)


### PR DESCRIPTION
Puts the 852 ("Location") subfield k ("Call number prefix") -  into holdings_1display as the `sub_location`.

I chose to put it into an array, since it is technically a repeatable field, per [the LOC Marc 21 description](https://www.loc.gov/marc/holdings/hd852.html).

Example objects:
- https://catalog-staging.princeton.edu/catalog/9947201943506421/raw
- https://catalog-staging.princeton.edu/catalog/9989503313506421/raw
- https://catalog-staging.princeton.edu/catalog/9941598513506421/raw

Closes #873