### PR TITLE
Revert "Add 653 as uncontrolled keywords (#2160)"

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -856,10 +856,6 @@ to_field 'lc_subject_display' do |record, accumulator|
   accumulator.replace(subjects | local_subjects)
 end
 
-# Uncontrolled keyword:
-#    653 XX a
-to_field 'uncontrolled_keyword_s', extract_marc('653a')
-
 # A field to include both archaic and replaced terms, for search purposes
 to_field 'lc_subject_include_archaic_search_terms_index' do |record, accumulator|
   subjects = process_hierarchy(record, '600|*0|abcdfklmnopqrtvxyz:610|*0|abfklmnoprstvxyz:611|*0|abcdefgklnpqstvxyz:630|*0|adfgklmnoprstvxyz:650|*0|abcvxyz:651|*0|avxyz')
@@ -885,14 +881,13 @@ to_field 'homoit_subject_display' do |record, accumulator|
   accumulator.replace(subjects)
 end
 
-# Adds lc, siku, local, uncontrolled_keyword, and homoit subject unstem_search fields
+# Adds lc, siku, local, and homoit subject unstem_search fields
 # Note that lc unstem search should include both archaic and replaced terms
 each_record do |_record, context|
   context.output_hash['subject_unstem_search'] = context.output_hash['lc_subject_include_archaic_search_terms_index']
   context.output_hash['local_subject_unstem_search'] = context.output_hash['local_subject_display']
   context.output_hash['siku_subject_unstem_search'] = context.output_hash['siku_subject_display']
   context.output_hash['homoit_subject_unstem_search'] = context.output_hash['homoit_subject_display']
-  context.output_hash['uncontrolled_keyword_unstem_search'] = context.output_hash['uncontrolled_keyword_s']
 end
 
 # used for the browse lists and hierarchical subject/genre facet

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -303,7 +303,6 @@
         isbn_t^3
         issn_s^3
         lccn_s^3
-        uncontrolled_keyword_unstem_search^3
         text
         description_t
         cjk_all
@@ -330,7 +329,6 @@
         isbn_t^30
         issn_s^30
         lccn_s^30
-        uncontrolled_keyword_unstem_search^10
         text^10
         description_t^10
         cjk_all^10

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -1110,43 +1110,6 @@ describe 'From traject_config.rb', indexing: true do
         expect(@homosaurus_655["homoit_genre_s"]).to match(["LGBTQ+ periodicals"])
       end
     end
-    describe 'uncontrolled_keyword' do
-      subject(:record_with_uncontrolled_keywords) { @indexer.map_record(marc_record) }
-      let(:leader) { '1234567890' }
-      let(:field_653) do
-        {
-          "653" => {
-            "ind1" => "",
-            "ind2" => "",
-            "subfields" => [
-              {
-                "a" => "fuel cells"
-              }
-            ]
-          }
-        }
-      end
-      let(:field_653_2) do
-        {
-          "653" => {
-            "ind1" => "1",
-            "ind2" => "1",
-            "subfields" => [
-              {
-                "a" => "Joyce"
-              }
-            ]
-          }
-        }
-      end
-      let(:marc_record) do
-        MARC::Record.new_from_hash('leader' => leader, 'fields' => [field_653, field_653_2])
-      end
-      it 'has a field' do
-        expect(record_with_uncontrolled_keywords['uncontrolled_keyword_unstem_search']).to eq(['fuel cells', 'Joyce'])
-        expect(record_with_uncontrolled_keywords['uncontrolled_keyword_s']).to eq(['fuel cells', 'Joyce'])
-      end
-    end
     describe 'form_genre_display' do
       subject(:form_genre_display) { @indexer.map_record(marc_record) }
       let(:leader) { '1234567890' }


### PR DESCRIPTION
This reverts commit 43c4319cd6a0b191f5a6048f3f77ba1acd0df3bd.

- [Per Esmé, DSSG is still in discussions on whether to index 653 fields](https://pulibrary.slack.com/archives/CA891BNR0/p1684871645803389)