### PR TITLE
i2158: only admin users can access sidekiq or patron API

### DIFF
--- a/app/controllers/patron_controller.rb
+++ b/app/controllers/patron_controller.rb
@@ -64,9 +64,15 @@ class PatronController < ApplicationController
     end
 
     def protect
-      unless user_signed_in?
+      if user_signed_in?
+        deny_access unless current_user.catalog_admin?
+      else
         ips = Rails.application.config.ip_allowlist
-        render plain: "You are unauthorized", status: :forbidden if ips.exclude?(request.remote_ip)
+        deny_access if ips.exclude?(request.remote_ip)
       end
+    end
+
+    def deny_access
+      render plain: "You are unauthorized", status: :forbidden
     end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
   post '/bibliographic', to: 'bibliographic#update'
 
   require 'sidekiq/web'
-  authenticate :user do
+  authenticate :user, ->(user) { user.catalog_admin? } do
     mount Sidekiq::Web => '/sidekiq'
   end
 end

--- a/spec/controllers/patron_controller_spec.rb
+++ b/spec/controllers/patron_controller_spec.rb
@@ -23,9 +23,18 @@ RSpec.describe PatronController, type: :controller do
       expect(response).to have_http_status(403)
     end
 
-    it "allows authenticated users to access patron info" do
+    it "does not allow non-admin users to access patron info" do
       stub_patron
-      user = double('user')
+      user = FactoryBot.create(:user)
+      allow(request.env['warden']).to receive(:authenticate!) { user }
+      allow(controller).to receive(:current_user) { user }
+      get :patron_info, params: { patron_id: 'bbird', format: :json }
+      expect(response).to have_http_status(403)
+    end
+
+    it "allows authenticated admin users to access patron info" do
+      stub_patron
+      user = FactoryBot.create(:admin)
       allow(request.env['warden']).to receive(:authenticate!) { user }
       allow(controller).to receive(:current_user) { user }
       get :patron_info, params: { patron_id: 'bbird', format: :json }
@@ -38,7 +47,7 @@ RSpec.describe PatronController, type: :controller do
 
     before do
       stub_patron(patron_identifier)
-      user = double('user')
+      user = FactoryBot.create(:admin)
       allow(request.env['warden']).to receive(:authenticate!) { user }
       allow(controller).to receive(:current_user) { user }
     end
@@ -172,7 +181,7 @@ RSpec.describe PatronController, type: :controller do
         .to_return(status: 429,
                    headers: { "Content-Type" => "application/json" },
                    body: stub_alma_per_second_threshold)
-      user = double('user')
+      user = FactoryBot.create(:admin)
       allow(request.env['warden']).to receive(:authenticate!) { user }
       allow(controller).to receive(:current_user) { user }
 


### PR DESCRIPTION
closes #2158 

Some ideas for testing on non-prod environments:

- Log in to the UI
- Confirm that you can access both /sidekiq and /patron/js7389
- Edit ~/app_configs/bibdata to remove your netid from the `BIBDATA_ADMIN_NETIDS` environment variable
- Restart nginx
- Try to access /sidekiq -- expected behavior is that you receive a 404
- Try to access /patron/js7389 -- expected behavior is that you receive a 403