### PR TITLE
Improved logging / error messages for traject errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,3 +92,5 @@ end
 gem "omniauth-rails_csrf_protection"
 
 gem "human_languages", "~> 0.7"
+
+gem "open3", "~> 0.1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,6 +366,7 @@ GEM
     omniauth-rails_csrf_protection (0.1.2)
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
+    open3 (0.1.2)
     orm_adapter (0.5.0)
     parallel (1.22.1)
     parser (3.1.2.1)
@@ -655,6 +656,7 @@ DEPENDENCIES
   oj
   omniauth-cas
   omniauth-rails_csrf_protection
+  open3 (~> 0.1.2)
   orangetheses!
   pg
   pry-byebug (~> 3.0)

--- a/app/services/alma/indexer.rb
+++ b/app/services/alma/indexer.rb
@@ -9,7 +9,7 @@ class Alma::Indexer
     stdout, stderr, status = Open3.capture3("traject #{debug_flag} -c marc_to_solr/lib/traject_config.rb #{file_path} -u #{solr_url} -w Traject::PulSolrJsonWriter")
     if stderr.include?("FATAL") && !status.success?
       Rails.logger.error(stderr)
-      raise "Traject indexing failed for #{file_path}"
+      raise "Traject indexing failed for #{file_path}: #{stderr}"
     else
       Rails.logger.info("Successfully indexed file #{file_path}")
     end

--- a/app/services/alma/indexer.rb
+++ b/app/services/alma/indexer.rb
@@ -6,6 +6,12 @@ class Alma::Indexer
 
   def index_file(file_path, debug_mode = false)
     debug_flag = debug_mode ? "--debug-mode" : ""
-    `traject #{debug_flag} -c marc_to_solr/lib/traject_config.rb #{file_path} -u #{solr_url} -w Traject::PulSolrJsonWriter 2>&1`
+    stdout, stderr, status = Open3.capture3("traject #{debug_flag} -c marc_to_solr/lib/traject_config.rb #{file_path} -u #{solr_url} -w Traject::PulSolrJsonWriter")
+    if stderr.include?("FATAL") && !status.success?
+      Rails.logger.error(stderr)
+      raise "Traject indexing failed for #{file_path}"
+    else
+      Rails.logger.info("Successfully indexed file #{file_path}")
+    end
   end
 end

--- a/app/services/alma/indexer/dump_file_indexer.rb
+++ b/app/services/alma/indexer/dump_file_indexer.rb
@@ -9,8 +9,7 @@ class Alma::Indexer
 
     def index!
       decompress_file do |file|
-        result = index_file(file.path)
-        raise "Traject indexing failed for #{file.path}" unless $CHILD_STATUS.success? && result.exclude?("FATAL")
+        index_file(file.path)
       end
     end
 

--- a/spec/services/alma/indexer/dump_file_indexer_spec.rb
+++ b/spec/services/alma/indexer/dump_file_indexer_spec.rb
@@ -14,13 +14,6 @@ RSpec.describe Alma::Indexer::DumpFileIndexer do
     let(:dump_file) { FactoryBot.create(:dump_file, path: file_path) }
     let(:dump_file_indexer) { described_class.new(dump_file, solr_url:) }
 
-    context "with a file that doesn't exist" do
-      let(:file_path) { 'spec/fixtures/files/alma/do_not_create_me.tar.gz' }
-
-      it 'raises an error' do
-        expect { |b| dump_file_indexer.decompress_file(&b) }.to raise_error(Errno::ENOENT)
-      end
-    end
     context "with a .tar.gz file" do
       let(:file_path) { 'spec/fixtures/files/alma/full_dump/1.xml.tar.gz' }
 

--- a/spec/services/alma/indexer_spec.rb
+++ b/spec/services/alma/indexer_spec.rb
@@ -86,10 +86,11 @@ RSpec.describe Alma::Indexer, indexing: true do
 
       it 'raises an error' do
         indexer = described_class.new(solr_url:)
+        expected_error_snippet = %r{No such file or directory @ rb_sysopen - spec/fixtures/files/alma/do_not_create_me.tar.gz}
         Sidekiq::Testing.inline! do
-          expect { indexer.index_file(file_path) }.to raise_error(RuntimeError)
+          expect { indexer.index_file(file_path) }.to raise_error(RuntimeError, expected_error_snippet)
         end
-        expect(Rails.logger).to have_received(:error).once.with(%r{No such file or directory @ rb_sysopen - spec/fixtures/files/alma/do_not_create_me.tar.gz})
+        expect(Rails.logger).to have_received(:error).once.with(expected_error_snippet)
       end
     end
   end

--- a/spec/services/alma/indexer_spec.rb
+++ b/spec/services/alma/indexer_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe Alma::Indexer, indexing: true do
       solr.delete_by_query("*:*")
 
       indexer = described_class.new(solr_url:)
-      file_name = file_fixture("alma/full_dump/2.xml")
+      file_path = file_fixture("alma/full_dump/2.xml")
       Sidekiq::Testing.inline! do
-        indexer.index_file(file_name)
+        indexer.index_file(file_path)
       end
 
       solr.commit
@@ -29,22 +29,22 @@ RSpec.describe Alma::Indexer, indexing: true do
       indexer = described_class.new(solr_url:)
 
       # Indexes a file with 5 non-deleted records
-      file_name = file_fixture("alma/incremental_11_records.xml")
-      indexer.index_file(file_name)
+      file_path = file_fixture("alma/incremental_11_records.xml")
+      indexer.index_file(file_path)
       solr.commit
       response = solr.get("select", params: { q: "*:*" })
       expect(response['response']['numFound']).to eq 5
 
       # Forcefully add a record (id=99122238836006421)...
-      file_name = file_fixture("alma/incremental_01_record_add.xml")
-      indexer.index_file(file_name)
+      file_path = file_fixture("alma/incremental_01_record_add.xml")
+      indexer.index_file(file_path)
       solr.commit
       response = solr.get("select", params: { q: "id:99122238836006421" })
       expect(response['response']['numFound']).to eq 1
 
       # ...and make sure it is deleted
-      file_name = file_fixture("alma/incremental_01_record_delete.xml")
-      indexer.index_file(file_name)
+      file_path = file_fixture("alma/incremental_01_record_delete.xml")
+      indexer.index_file(file_path)
       solr.commit
       response = solr.get("select", params: { q: "id:99122238836006421" })
       expect(response['response']['numFound']).to eq 0
@@ -55,9 +55,9 @@ RSpec.describe Alma::Indexer, indexing: true do
       solr.delete_by_query("*:*")
 
       indexer = described_class.new(solr_url:)
-      file_name = file_fixture("alma/full_dump/three_records_one_bad_utf8.xml")
+      file_path = file_fixture("alma/full_dump/three_records_one_bad_utf8.xml")
       Sidekiq::Testing.inline! do
-        indexer.index_file(file_name)
+        indexer.index_file(file_path)
       end
 
       solr.commit
@@ -65,6 +65,32 @@ RSpec.describe Alma::Indexer, indexing: true do
 
       # It should have skipped the bad UTF-8 record but kept the other two.
       expect(response['response']['numFound']).to eq 2
+    end
+
+    it "logs at the info level when it indexes a file successfully" do
+      allow(Rails.logger).to receive(:info)
+      indexer = described_class.new(solr_url:)
+      file_path = file_fixture("alma/full_dump/2.xml")
+      Sidekiq::Testing.inline! do
+        indexer.index_file(file_path)
+      end
+      expect(Rails.logger).to have_received(:info).once.with("Successfully indexed file #{file_path}")
+    end
+
+    context "with a file that doesn't exist" do
+      before do
+        allow(Rails.logger).to receive(:error)
+      end
+
+      let(:file_path) { 'spec/fixtures/files/alma/do_not_create_me.tar.gz' }
+
+      it 'raises an error' do
+        indexer = described_class.new(solr_url:)
+        Sidekiq::Testing.inline! do
+          expect { indexer.index_file(file_path) }.to raise_error(RuntimeError)
+        end
+        expect(Rails.logger).to have_received(:error).once.with(%r{No such file or directory @ rb_sysopen - spec/fixtures/files/alma/do_not_create_me.tar.gz})
+      end
     end
   end
 end


### PR DESCRIPTION
closes #1885 

Also, please note that traject errors can also be found in log/traject-errors.log, which is included in datadog.