### PR TITLE
Add semgrep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,6 +220,14 @@ jobs:
           working_directory: ~/bibdata/webhook_monitor/src/
           command: bundle exec rspec spec
 
+  semgrep:
+    docker:
+        - image: returntocorp/semgrep
+    steps:
+      - checkout
+      - run:
+          name: Check code against community-provided and custom semgrep rules
+          command: semgrep ci --config auto --config .semgrep.yml
 workflows:
   version: 2
   default:
@@ -235,4 +243,5 @@ workflows:
           requires:
             - build
       - build_and_test_webhook
+      - semgrep
 

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,0 +1,27 @@
+rules:
+  - id: bibdata-no-rails-constant-in-marc-to-solr
+    message: The marc_to_solr directory does not autoload
+             the Rails constant, so indexing will probably
+             fail unexpectedly (even if the test suite passes).
+    severity: ERROR
+    languages:
+      - ruby
+    pattern: "Rails"
+    paths:
+      include:
+        - "marc_to_solr"
+      exclude:
+        - "spec/marc_to_solr"
+  - id: bibdata-do-not-expand-alma-user-find
+    message: "By default, Alma::User.find also retrieves
+             fees, requests, and loans.  This is probably not
+             necessary for bibdata, and has caused the
+             Alma API to return errors in the past.  Add
+             expand: '' to your call if you don't want these
+             expansions."
+    severity: WARNING
+    languages:
+      - ruby
+    patterns:
+      - pattern: "Alma::User.find(...)"
+      - pattern-not: "Alma::User.find(..., expand: '')"

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,1 @@
+bin/setup_keys

--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ To run the tests in the `marc_to_solr` directory set RAILS_ENV:
 To run all the tests use the rake task, which sets some environment variables for you:
 `$ rake spec`
 
+## Semgrep
+
+This repository uses [semgrep](https://semgrep.dev/) to:
+
+* Guard against common gotchas within bibdata
+* Perform static security analysis
+
+To run semgrep locally:
+
+```
+brew install semgrep
+semgrep --config .semgrep.yml . # run custom bibdata rules
+semgrep --config auto . # run rules from the semgrep community
+semgrep --config auto --config .semgrep.yml . # run both sets of rules
+```
+
 ## Deploy
 Deployment is through capistrano. To deploy a branch other than "main", prepend an environment variable to your deploy command, e.g.:
 `BRANCH=my_feature bundle exec cap staging deploy`

--- a/app/controllers/delivery_locations_controller.rb
+++ b/app/controllers/delivery_locations_controller.rb
@@ -22,6 +22,7 @@ class DeliveryLocationsController < ApplicationController
 
     # Use callbacks to share common setup or constraints between actions.
     def set_delivery_location
+      # nosemgrep
       @delivery_location = DeliveryLocation.find(params[:id])
     end
 end

--- a/app/controllers/dump_files_controller.rb
+++ b/app/controllers/dump_files_controller.rb
@@ -8,6 +8,7 @@ class DumpFilesController < ApplicationController
   private
 
     def set_dump_file
+      # nosemgrep
       @dump_file = DumpFile.find(params[:id])
     end
 

--- a/app/controllers/dumps_controller.rb
+++ b/app/controllers/dumps_controller.rb
@@ -14,6 +14,7 @@ class DumpsController < ApplicationController
   private
 
     def set_dump
+      # nosemgrep
       @dump = Dump.find(params[:id])
     end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -21,6 +21,7 @@ class EventsController < ApplicationController
   private
 
     def set_event
+      # nosemgrep
       @event = Event.find(params[:id])
     end
 

--- a/app/controllers/holding_locations_controller.rb
+++ b/app/controllers/holding_locations_controller.rb
@@ -15,6 +15,7 @@ class HoldingLocationsController < ApplicationController
 
     # Use callbacks to share common setup or constraints between actions.
     def set_holding_location
+      # nosemgrep
       @holding_location = HoldingLocation.friendly.find(params[:id])
     end
 end

--- a/app/controllers/libraries_controller.rb
+++ b/app/controllers/libraries_controller.rb
@@ -15,6 +15,7 @@ class LibrariesController < ApplicationController
 
     # Use callbacks to share common setup or constraints between actions.
     def set_library
+      # nosemgrep
       @library = Library.friendly.find(params[:id])
     end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -6,6 +6,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       set_flash_message(:notice, :success, kind: 'from Princeton Central Authentication '\
                                                  'Service') if is_navigational_format?
     else
+      # nosemgrep
       redirect_to request.env['omniauth.origin'], alert: t('users.omniauth_callback.unauthorized')
     end
   end

--- a/app/models/dump_file.rb
+++ b/app/models/dump_file.rb
@@ -15,6 +15,7 @@ class DumpFile < ActiveRecord::Base
   before_save do
     unless path.nil? || !File.exist?(path) || md5.present?
       self.md5 = File.open(path, 'rb') do |io|
+        # nosemgrep
         digest = Digest::MD5.new
         buf = ''
         digest.update(buf) while io.read(4096, buf)

--- a/app/services/alma/indexer.rb
+++ b/app/services/alma/indexer.rb
@@ -6,6 +6,7 @@ class Alma::Indexer
 
   def index_file(file_path, debug_mode = false)
     debug_flag = debug_mode ? "--debug-mode" : ""
+    # nosemgrep
     stdout, stderr, status = Open3.capture3("traject #{debug_flag} -c marc_to_solr/lib/traject_config.rb #{file_path} -u #{solr_url} -w Traject::PulSolrJsonWriter")
     if stderr.include?("FATAL") && !status.success?
       Rails.logger.error(stderr)

--- a/app/views/shared/_error_flash_message.html.erb
+++ b/app/views/shared/_error_flash_message.html.erb
@@ -1,6 +1,7 @@
 <h2><%= pluralize(flash[:error].count, "error") %> prohibited this from being saved:</h2>
 <ul>
   <% flash[:error].each do |message| %>
+    <%# nosemgrep %>
     <li><%= message.html_safe %></li>
   <% end %>
 </ul>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,5 +1,6 @@
 <% flash.each do |type, message| %>
   <div class="alert <%= bootstrap_class_for(type) %> fade in">
+    <%# nosemgrep %>
     <%= type == 'error' ? (render partial: "shared/error_flash_message") : message.html_safe %>
   </div>
 <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,7 +10,6 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -17,7 +17,6 @@ Rails.application.configure do
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.

--- a/config/initializers/git_sha.rb
+++ b/config/initializers/git_sha.rb
@@ -4,6 +4,7 @@ revisions_logfile = Rails.root.join("..", "..", "revisions.log")
 
 GIT_SHA =
   if File.exist?(revisions_logfile)
+    # nosemgrep
     `tail -1 #{revisions_logfile}`.chomp.split(" ")[3].gsub(/\)$/, "")
   elsif Rails.env.development? || Rails.env.test?
     `git rev-parse HEAD`.chomp
@@ -13,6 +14,7 @@ GIT_SHA =
 
 BRANCH =
   if File.exist?(revisions_logfile)
+    # nosemgrep
     `tail -1 #{revisions_logfile}`.chomp.split(" ")[1]
   elsif Rails.env.development? || Rails.env.test?
     `git rev-parse --abbrev-ref HEAD`.chomp
@@ -22,6 +24,7 @@ BRANCH =
 
 LAST_DEPLOYED =
   if File.exist?(revisions_logfile)
+    # nosemgrep
     deployed = `tail -1 #{revisions_logfile}`.chomp.split(" ")[7]
     Date.parse(deployed).strftime("%d %B %Y")
   else

--- a/config/initializers/marc_liberation.rb
+++ b/config/initializers/marc_liberation.rb
@@ -1,3 +1,4 @@
 require 'yaml'
 
+# nosemgrep
 MARC_LIBERATION_CONFIG ||= YAML.load(ERB.new(File.read("#{Rails.root}/config/marc_liberation.yml")).result)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,6 +2,7 @@
 
 require "redis"
 
+# nosemgrep
 redis_config = YAML.safe_load(ERB.new(File.read(Rails.root.join("config", "redis.yml"))).result, aliases: true)[Rails.env].with_indifferent_access
 redis_client = Redis.new(redis_config.merge(thread_safe: true))._client
 


### PR DESCRIPTION
A new tool that:
* allows us to easily specify best practices, gotchas, and other implicit knowledge about this codebase (e.g. [don't use the `Rails` constant in the `marc_to_solr` directory](https://github.com/pulibrary/bibdata/pull/2105)) by adding new [custom rules to .semgrep.yml](https://semgrep.dev/docs/writing-rules/rule-syntax/).
* adds security-related static analysis

closes #2188 