### PR TITLE
Only require lando_env in dev and test envs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,7 @@
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
-require_relative 'lando_env'
+require_relative 'lando_env' if Rails.env.development? || Rails.env.test?
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
Listing rake tasks on staging no longer gives Lando-related errors.

```
deploy@catalog-staging1:/opt/orangelight/current$ bundle exec rake -T
** [Honeybadger] Initializing Honeybadger Error Tracker for Ruby. Ship it! version=5.0.2 framework=ruby level=1 pid=19040
rake about                                           # List versions of all Rails frameworks and the environment
```

Closes #2186 