### PR TITLE
Ensuring that the orangetheses dependency tracks the `main` branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'net-sftp', '~> 2.1', '>= 2.1.2'
 gem 'net-smtp', require: false
 gem 'oj'
 gem 'omniauth-cas'
-gem 'orangetheses', github: 'pulibrary/orangetheses', ref: '4ac8dc2bd04b10db764fc37df3261531c9937061'
+gem 'orangetheses', github: 'pulibrary/orangetheses', ref: 'main'
 gem 'pg'
 gem "rack", ">= 2.0.6"
 gem 'rack-conneg', '~> 0.1.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,8 +15,8 @@ GIT
 
 GIT
   remote: https://github.com/pulibrary/orangetheses.git
-  revision: 4ac8dc2bd04b10db764fc37df3261531c9937061
-  ref: 4ac8dc2bd04b10db764fc37df3261531c9937061
+  revision: 3c288ca746bbe5369bca9027d5b159b47dbc97e2
+  ref: main
   specs:
     orangetheses (1.4.2)
       chronic
@@ -25,6 +25,7 @@ GIT
       iso-639
       nokogiri
       oai
+      psych (~> 5.1)
       retriable
       rsolr
       yaml
@@ -199,7 +200,7 @@ GEM
       xpath (~> 3.2)
     celluloid (0.16.0)
       timers (~> 4.0.0)
-    cgi (0.3.6)
+    cgi (0.4.1)
     change_the_subject (0.3.3)
       yaml
     chronic (0.10.2)
@@ -242,7 +243,7 @@ GEM
     dumb_delegator (1.0.0)
     e2mmap (0.1.0)
     ed25519 (1.3.0)
-    erb (4.0.2)
+    erb (4.0.3)
       cgi (>= 0.3.3)
     erubi (1.12.0)
     execjs (2.8.1)
@@ -404,6 +405,8 @@ GEM
       pry (>= 0.13, < 0.15)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    psych (5.1.1.1)
+      stringio
     public_suffix (5.0.3)
     puma (5.6.7)
       nio4r (~> 2.0)
@@ -572,6 +575,7 @@ GEM
     sshkit-interactive (0.3.0)
       sshkit (~> 1.12)
     stomp (1.4.10)
+    stringio (3.1.0)
     sync (0.5.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)


### PR DESCRIPTION
This is required to deploy the changes introduced with https://github.com/pulibrary/orangetheses/pull/79 which addressed https://github.com/pulibrary/bibdata/issues/2267