### PR TITLE
Use enum for DumpType

### DIFF
--- a/app/jobs/scsb_import_full_job.rb
+++ b/app/jobs/scsb_import_full_job.rb
@@ -13,7 +13,7 @@ class ScsbImportFullJob < ApplicationJob
   private
 
     def created_dump
-      Dump.create!(dump_type_id: 5)
+      Dump.create!(dump_type: :partner_recap_full)
     end
 
     def delete_stale_files

--- a/app/models/dump_type.rb
+++ b/app/models/dump_type.rb
@@ -1,5 +1,0 @@
-class DumpType < ActiveRecord::Base
-  PARTNER_RECAP_FULL = 'PARTNER_RECAP_FULL'.freeze
-
-  has_many :dumps
-end

--- a/app/models/index_manager.rb
+++ b/app/models/index_manager.rb
@@ -77,7 +77,7 @@ class IndexManager < ActiveRecord::Base
   end
 
   def recent_full_dump
-    Dump.full_dumps.joins(:event).order("events.start" => "DESC").first
+    Dump.full_dump.joins(:event).order("events.start" => "DESC").first
   end
 
   def first_incremental

--- a/app/services/aws_sqs_poller.rb
+++ b/app/services/aws_sqs_poller.rb
@@ -41,15 +41,15 @@ class AlmaDumpFactory
   end
 
   def bib_dump
-    dump = Dump.create(dump_type_id:)
+    dump = Dump.create(dump_type:)
     dump.event = dump_event
     dump.generated_date = dump_event.start
     dump.save
     dump
   end
 
-  def dump_type_id
-    @dump_type_id ||= Rails.configuration.alma[:jobs][job_name]["dump_type_id"]
+  def dump_type
+    @dump_type ||= Rails.configuration.alma[:jobs][job_name]["dump_type"]
   end
 
   def job_name

--- a/app/services/aws_sqs_poller.rb
+++ b/app/services/aws_sqs_poller.rb
@@ -41,11 +41,9 @@ class AlmaDumpFactory
   end
 
   def bib_dump
-    dump = Dump.create(dump_type:)
-    dump.event = dump_event
-    dump.generated_date = dump_event.start
-    dump.save
-    dump
+    Dump.create(dump_type:,
+                event: dump_event,
+                generated_date: dump_event.start)
   end
 
   def dump_type

--- a/app/services/dump_log_ids_service.rb
+++ b/app/services/dump_log_ids_service.rb
@@ -2,7 +2,7 @@ class DumpLogIdsService
   # Process a dump of MARC files and updates the Dump's delete_id and update_id properties
   def process_dump(id)
     dump = Dump.find(id)
-    raise StandardError.new, "Dump is of type #{dump.dump_type.constant}, must be CHANGED_RECORDS" if dump.dump_type.constant != "CHANGED_RECORDS"
+    raise StandardError.new, "Dump is of type #{dump.dump_type}, must be changed_records" unless dump.changed_records?
 
     delete_ids = []
     update_ids = []

--- a/app/utils/data_seeder.rb
+++ b/app/utils/data_seeder.rb
@@ -1,19 +1,11 @@
 # frozen_string_literal: true
 
 class DataSeeder
-  attr_accessor :logger, :dump_types, :dump_file_types
+  attr_accessor :logger, :dump_file_types
 
   def initialize(logger = Logger.new(STDOUT))
     @logger = logger
-    @dump_types = MARC_LIBERATION_CONFIG['dump_types']
     @dump_file_types = MARC_LIBERATION_CONFIG['dump_file_types']
-  end
-
-  def generate_dump_types
-    dump_types.each do |dt|
-      DumpType.find_or_create_by(id: dt['id'], label: dt['label'], constant: dt['constant'])
-    end
-    logger.info "Created #{dump_types.count} dump types"
   end
 
   def generate_dump_file_types

--- a/app/views/dumps/show.json.jbuilder
+++ b/app/views/dumps/show.json.jbuilder
@@ -1,4 +1,4 @@
-json.type @dump.dump_type.constant.downcase
+json.type @dump.dump_type.downcase
 json.generated_date @dump.generated_date
 json.files do
   DumpFileType.all.each do |dft|

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -30,9 +30,9 @@
         <% if event.dump.nil? %>
           <td colspan="3" />
         <% else %>
-          <td class="nowrap"><%= link_to(event.dump.dump_type.label, dump_url(event.dump, format: :json)) %></td>
-          <td ><%= event.dump.update_ids&.length if event.dump.dump_type.constant == 'CHANGED_RECORDS' || event.dump.dump_type.constant == 'PRINCETON_RECAP'%></td>
-          <td ><%= event.dump.delete_ids&.length if event.dump.dump_type.constant == 'CHANGED_RECORDS' %></td>
+          <td class="nowrap"><%= link_to(event.dump.dump_type, dump_url(event.dump, format: :json)) %></td>
+          <td ><%= event.dump.update_ids&.length if event.dump.changed_records? || event.dump.princeton_recap? %></td>
+          <td ><%= event.dump.delete_ids&.length if event.dump.changed_records? %></td>
         <% end %>
         <% if user_signed_in? %>
           <td class="nowrap">

--- a/app/views/events/index.json.jbuilder
+++ b/app/views/events/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.array!(@events) do |event|
   json.extract! event, :id, :start, :finish, :success, :error
-  json.dump_type event.dump.dump_type.constant unless event.dump.nil?
+  json.dump_type event.dump.dump_type unless event.dump.nil?
   json.dump_url dump_url(event.dump, format: :json) unless event.dump.nil?
   # json.url event_url(event, format: :json)
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -23,7 +23,7 @@
 <% unless @event.dump.nil? %>
   <p>
     <strong>Dump type:</strong>
-    <%= @event.dump.dump_type.constant %>
+    <%= @event.dump.dump_type %>
   </p>
 
   <p>

--- a/app/views/events/show.json.jbuilder
+++ b/app/views/events/show.json.jbuilder
@@ -1,3 +1,3 @@
 json.extract! @event, :id, :start, :finish, :error, :success, :created_at, :updated_at
-json.dump_type @event.dump.dump_type.constant unless @event.dump.nil?
+json.dump_type @event.dump.dump_type unless @event.dump.nil?
 json.dump_url dump_url(@event.dump, format: :json) unless @event.dump.nil?

--- a/config/alma.yml
+++ b/config/alma.yml
@@ -8,16 +8,13 @@ default: &default
   sqs_queue_url: <%= ENV['SQS_QUEUE_URL'] %>
   jobs:
     "Publishing Platform Job General Publishing":
-      dump_type_id: 1
-      dump_type: "ALL_RECORDS"
+      dump_type: "full_dump"
       dump_file_type: "BIB_RECORDS"
     "Publishing Platform Job Incremental Publishing":
-      dump_type_id: 2
-      dump_type: "CHANGED_RECORDS"
+      dump_type: "changed_records"
       dump_file_type: "UPDATED_RECORDS"
     "Publishing Platform Job Incremental ReCAP Records":
-      dump_type_id: 3
-      dump_type: "PRINCETON_RECAP"
+      dump_type: "princeton_recap"
       dump_file_type: "RECAP_RECORDS"
   api_limit: <%= ENV["ALMA_API_LIMIT"] || 150000 %>
   sru_url: <%= ENV["ALMA_SRU_URL"] || "https://princeton-psb.alma.exlibrisgroup.com/view/sru/01PRI_INST" %>

--- a/config/marc_liberation.yml
+++ b/config/marc_liberation.yml
@@ -10,7 +10,7 @@ location_files_dir: <%= ENV['LOCATION_FILES_DIR'] || 'config/locations' %>
 
 dump_types:
 - id: 1
-  label: 'All Records' # used for full dumps
+  label: 'Full Dumps' # used for full dumps
   constant: 'ALL_RECORDS'
 - id: 2
   label: 'Changed Records' # used for incremental dumps

--- a/db/migrate/20240423192157_add_new_dump_type_to_dump.rb
+++ b/db/migrate/20240423192157_add_new_dump_type_to_dump.rb
@@ -1,0 +1,19 @@
+class AddNewDumpTypeToDump < ActiveRecord::Migration[7.0]
+  def up
+    add_column :dumps, :new_dump_type, :integer
+
+    Dump.update_all("new_dump_type=dump_type_id")
+
+    remove_reference :dumps, :dump_type
+    rename_column :dumps, :new_dump_type, :dump_type
+  end
+
+  def down
+    rename_column :dumps, :dump_type, :new_dump_type
+
+    add_reference :dumps, :dump_type, type: :integer, index: true
+    Dump.update_all("dump_type_id=new_dump_type")
+
+    remove_column :dumps, :new_dump_type, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_05_174853) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_23_192157) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,7 +60,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_05_174853) do
 
   create_table "dumps", id: :serial, force: :cascade do |t|
     t.integer "event_id"
-    t.integer "dump_type_id"
     t.text "delete_ids"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
@@ -68,7 +67,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_05_174853) do
     t.text "create_ids"
     t.string "index_status"
     t.datetime "generated_date", precision: nil
-    t.index ["dump_type_id"], name: "index_dumps_on_dump_type_id"
+    t.integer "dump_type"
     t.index ["event_id"], name: "index_dumps_on_event_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,15 @@
 seeder = DataSeeder.new
-seeder.generate_dump_types
 seeder.generate_dump_file_types
 
 if Event.count < 10 && Rails.env.development?
   10.times do |i|
     Event.find_or_create_by(start: "200#{i}-10-10", finish: "200#{i}-10-11", success: true)
+  end
+end
+
+if Dump.count < 10 && Rails.env.development?
+  Event.all.each do |event|
+    event.dump = Dump.create!(dump_type: :changed_records)
+    event.save
   end
 end

--- a/lib/tasks/marc_liberation.rake
+++ b/lib/tasks/marc_liberation.rake
@@ -1,16 +1,15 @@
 namespace :marc_liberation do
   namespace :delete do
     task events: :environment do
-      DeleteEventsJob.perform_later(dump_type: 'ALL_RECORDS', older_than: 2.months.ago.to_i)
-      DeleteEventsJob.perform_later(dump_type: 'CHANGED_RECORDS', older_than: 2.months.ago.to_i)
-      DeleteEventsJob.perform_later(dump_type: 'PARTNER_RECAP_FULL', older_than: 2.months.ago.to_i)
-      DeleteEventsJob.perform_later(dump_type: 'PARTNER_RECAP', older_than: 2.months.ago.to_i)
+      DeleteEventsJob.perform_later(dump_type: :full_dump, older_than: 2.months.ago)
+      DeleteEventsJob.perform_later(dump_type: :changed_records, older_than: 2.months.ago)
+      DeleteEventsJob.perform_later(dump_type: :partner_recap_full, older_than: 2.months.ago)
+      DeleteEventsJob.perform_later(dump_type: :partner_recap, older_than: 2.months.ago)
     end
   end
 
   task load_dump_types: :environment do
     seeder = DataSeeder.new
-    seeder.generate_dump_types
     seeder.generate_dump_file_types
   end
 end

--- a/lib/tasks/scsb.rake
+++ b/lib/tasks/scsb.rake
@@ -36,13 +36,12 @@ namespace :scsb do
 
   desc "Adds a local dump file to the database"
   task add_local_dump_file: :environment do
-    abort "usage: FILE=full-file-path.xml.gz rake add_local_dump_file" unless ENV['FILE']
+    abort "usage: FILE=full-file-path.xml.gz rake scsb:add_local_dump_file" unless ENV['FILE']
     ev = Event.new(success: true)
     ev.save
 
-    dump_type = ENV['DUMP_TYPE'] || "PARTNER_RECAP"
-    dump_type_id = DumpType.where(constant: dump_type).first.id
-    dump = Dump.new(event_id: ev.id, dump_type_id:)
+    dump_type = ENV['DUMP_TYPE'] || :partner_recap
+    dump = Dump.new(event_id: ev.id, dump_type: dump_type.downcase.to_sym)
     dump.save
 
     dump_file_type = ENV['DUMP_FILE_TYPE'] || "RECAP_RECORDS"

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -54,27 +54,27 @@ FactoryBot.define do
   end
 
   factory :empty_dump, class: "Dump" do
-    dump_type_id { 1 }
+    dump_type { :full_dump }
     association :event
   end
 
   factory :empty_incremental_dump, class: "Dump" do
-    dump_type_id { 2 }
+    dump_type { :changed_records }
     association :event
   end
 
   factory :empty_partner_recap_incremental_dump, class: "Dump" do
-    dump_type_id { 4 }
+    dump_type { :partner_recap }
     association :event
   end
 
   factory :empty_partner_full_dump, class: "Dump" do
-    dump_type_id { 5 }
+    dump_type { :partner_recap_full }
     association :event
   end
 
   factory :empty_partner_recap_dump, class: "Dump" do
-    dump_type_id { 4 }
+    dump_type { :partner_recap }
     association :event
   end
 
@@ -82,7 +82,7 @@ FactoryBot.define do
     generated_date { Time.new(2021, 7, 13, 11, 0, 0, "+00:00") }
     delete_ids { [] }
     update_ids { [] }
-    dump_type_id { 1 }
+    dump_type { :full_dump }
     dump_files do
       [
         association(:dump_file, path: 'spec/fixtures/files/alma/full_dump/1.xml.tar.gz'),
@@ -94,7 +94,7 @@ FactoryBot.define do
   factory :incremental_dump, class: "Dump" do
     delete_ids { [] }
     update_ids { [] }
-    dump_type_id { 2 }
+    dump_type { :changed_records }
     dump_files do
       [
         association(:incremental_dump_file, path: 'spec/fixtures/files/alma/incremental_dump/1.tar.gz'),
@@ -104,7 +104,7 @@ FactoryBot.define do
   end
 
   factory :partner_recap_daily_dump, class: "Dump" do
-    dump_type_id { 4 }
+    dump_type { :partner_recap }
     delete_ids { [] }
     update_ids { [] }
     dump_files do
@@ -116,7 +116,7 @@ FactoryBot.define do
   end
 
   factory :partner_recap_full_dump, class: "Dump" do
-    dump_type_id { 5 }
+    dump_type { :partner_recap_full }
     delete_ids { [] }
     update_ids { [] }
     dump_files do

--- a/spec/jobs/delete_events_job_spec.rb
+++ b/spec/jobs/delete_events_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DeleteEventsJob, type: :job do
           e.save
         end
 
-        described_class.perform_now(dump_type: 'ALL_RECORDS', older_than: 2.months.ago.to_i)
+        described_class.perform_now(dump_type: :full_dump, older_than: 2.months.ago)
 
         expect(Event.all.to_a.map(&:id)).to contain_exactly(new_event.id, incremental_event.id)
         expect(Dump.all.to_a.map(&:id)).to contain_exactly(new_event.dump.id, incremental_event.dump.id)
@@ -46,7 +46,7 @@ RSpec.describe DeleteEventsJob, type: :job do
           e.save
         end
 
-        described_class.perform_now(dump_type: 'CHANGED_RECORDS', older_than: 2.months.ago.to_i)
+        described_class.perform_now(dump_type: :changed_records, older_than: 2.months.ago)
 
         expect(Event.all.to_a.map(&:id)).to contain_exactly(new_event.id, full_event.id)
         expect(Dump.all.to_a.map(&:id)).to contain_exactly(new_event.dump.id, full_event.dump.id)
@@ -71,7 +71,7 @@ RSpec.describe DeleteEventsJob, type: :job do
           e.save
         end
 
-        described_class.perform_now(dump_type: 'PARTNER_RECAP', older_than: 2.months.ago.to_i)
+        described_class.perform_now(dump_type: :partner_recap, older_than: 2.months.ago)
 
         expect(Event.all.to_a.map(&:id)).to contain_exactly(new_partner_recap_daily_event.id, full_partner_recap_event.id)
         expect(Dump.all.to_a.map(&:id)).to contain_exactly(new_partner_recap_daily_event.dump.id, full_partner_recap_event.dump.id)
@@ -94,7 +94,7 @@ RSpec.describe DeleteEventsJob, type: :job do
           e.save
         end
 
-        described_class.perform_now(dump_type: 'PARTNER_RECAP_FULL', older_than: 2.months.ago.to_i)
+        described_class.perform_now(dump_type: :partner_recap_full, older_than: 2.months.ago)
 
         expect(Event.all.to_a.map(&:id)).to contain_exactly(new_full_partner_recap_event.id, partner_recap_daily_event.id)
         expect(Dump.all.to_a.map(&:id)).to contain_exactly(new_full_partner_recap_event.dump.id, partner_recap_daily_event.dump.id)

--- a/spec/jobs/scsb_import_full_job_spec.rb
+++ b/spec/jobs/scsb_import_full_job_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe ScsbImportFullJob do
     expect(event.start).not_to be nil
     expect(event.finish).not_to be nil
     expect(event.dump).to be_a(Dump)
-    expect(event.dump.dump_type).to be_a(DumpType)
-    expect(event.dump.dump_type.constant).to eq 'PARTNER_RECAP_FULL'
+    expect(event.dump.dump_type).to eq("partner_recap_full")
     expect(Scsb::PartnerUpdates).to have_received(:full)
   end
 

--- a/spec/models/dump_spec.rb
+++ b/spec/models/dump_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe Dump, type: :model do
   let(:partner_recap) { 'PARTNER_RECAP' }
   let(:princeton_recap) { 'PRINCETON_RECAP' }
   let(:partner_recap_full) { 'PARTNER_RECAP_FULL' }
-  let(:princeton_recap_dump_type) { DumpType.find(3) }
-  let(:partner_recap_dump_type) { DumpType.find(4) }
-  let(:partner_recap_full_dump_type) { DumpType.find(5) }
+  let(:princeton_recap_dump_type) { 'princeton_recap' }
+  let(:partner_recap_dump_type) { 'partner_recap' }
+  let(:partner_recap_full_dump_type) { 'partner_recap_full' }
   let(:test_create_time) { '2017-04-29 20:10:29'.to_time }
   let(:event_success) { Event.create(start: '2020-10-20 19:00:15', finish: '2020-10-20 19:00:41', error: nil, success: true, created_at: "2020-10-20 19:00:41", updated_at: "2020-10-20 19:00:41") }
-  let(:dump_princeton_recap_success) { described_class.create(event_id: event_success.id, dump_type_id: princeton_recap_dump_type.id, created_at: "2020-10-20 19:00:15", updated_at: "2020-10-20 19:00:41") }
+  let(:dump_princeton_recap_success) { described_class.create(event_id: event_success.id, dump_type: :princeton_recap, created_at: "2020-10-20 19:00:15", updated_at: "2020-10-20 19:00:41") }
 
   describe ".partner_recap" do
     it "is a scope that can chain" do
@@ -29,7 +29,7 @@ RSpec.describe Dump, type: :model do
           described_class.partner_update
 
           created_dump = described_class.last
-          expect(created_dump.dump_type.constant).to eq "PARTNER_RECAP"
+          expect(created_dump.dump_type).to eq "partner_recap"
           expect(ScsbImportJob).to have_received(:perform_later).with(anything, (frozen_time - 1.day).strftime('%Y-%m-%d %H:%M:%S.%6N %z'))
         end
       end
@@ -42,7 +42,7 @@ RSpec.describe Dump, type: :model do
         described_class.partner_update
 
         created_dump = described_class.last
-        expect(created_dump.dump_type.constant).to eq "PARTNER_RECAP"
+        expect(created_dump.dump_type).to eq "partner_recap"
         expect(ScsbImportJob).to have_received(:perform_later).with(anything, dump.created_at.to_time.strftime('%Y-%m-%d %H:%M:%S.%6N %z'))
       end
     end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Event, type: :model do
   before(:all) do
     bibs = './spec/fixtures/sample_bib_ids.txt'
     10.times { dump_test_bib_ids(bibs) }
-    10.times { test_events('CHANGED_RECORDS') }
-    5.times { test_events('ALL_RECORDS') }
+    10.times { test_events(:changed_records) }
+    5.times { test_events(:full_dump) }
   end
 
   after(:all) do
@@ -22,7 +22,7 @@ RSpec.describe Event, type: :model do
   def dump_test_bib_ids(bibs)
     dump = nil
     Event.record do |event|
-      dump = Dump.create(dump_type: DumpType.find_by(constant: 'BIB_IDS'))
+      dump = Dump.create(dump_type: :bib_ids)
       dump.event = event
       dump_file = DumpFile.create(dump:, dump_file_type: DumpFileType.find_by(constant: 'BIB_IDS'))
       FileUtils.cp bibs, dump_file.path
@@ -37,7 +37,7 @@ RSpec.describe Event, type: :model do
   def test_events(type)
     dump = nil
     Event.record do |event|
-      dump = Dump.create(dump_type: DumpType.find_by(constant: type))
+      dump = Dump.create(dump_type: type)
       dump.event = event
       dump.save
     end

--- a/spec/models/scsb/partner_updates_spec.rb
+++ b/spec/models/scsb/partner_updates_spec.rb
@@ -2,9 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Scsb::PartnerUpdates, type: :model do
   include ActiveJob::TestHelper
-  let(:partner_recap_dump_type) { DumpType.find_by(constant: 'PARTNER_RECAP') }
   let(:log_file_type) { DumpFileType.find_by(constant: 'LOG_FILE') }
-  let(:dump) { Dump.create(dump_type: partner_recap_dump_type) }
+  let(:dump) { Dump.create(dump_type: :partner_recap) }
   let(:timestamp) { Dump.send(:incremental_update_timestamp) }
   let(:update_directory_path) { Rails.root.join("tmp", "specs", "update_directory") }
   let(:scsb_file_dir) { Rails.root.join("tmp", "specs", "data") }

--- a/spec/services/alma_dump_factory_spec.rb
+++ b/spec/services/alma_dump_factory_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+# This class is currently defined in the aws_sqs_poller.rb file, so auto-loaders can't find it
+require 'app/services/aws_sqs_poller.rb'
+
+RSpec.describe AlmaDumpFactory do
+  context 'looking at the dump more than once' do
+    let(:message_body) { JSON.parse(File.read(Rails.root.join('spec', 'fixtures', 'aws', 'sqs_recap_incremental_dump.json'))) }
+
+    it 'only instantiates one dump' do
+      dump = AlmaDumpFactory.bib_dump(message_body)
+      expect(dump).to be_an_instance_of(Dump)
+      expect(Dump.count).to eq(1)
+      expect { dump }.not_to change(Dump, :count)
+    end
+  end
+end

--- a/spec/services/aws_sqs_poller_spec.rb
+++ b/spec/services/aws_sqs_poller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe AwsSqsPoller do
       )
 
       expect(Dump.all.count).to eq 1
-      expect(Dump.first.dump_type.constant).to eq "ALL_RECORDS"
+      expect(Dump.first.dump_type).to eq('full_dump')
       event = Dump.first.event
       expect(event.message_body).to eq message_body
       expect(event.start).to eq "2020-12-15T19:56:37.694Z"
@@ -92,7 +92,7 @@ RSpec.describe AwsSqsPoller do
       )
 
       expect(Dump.all.count).to eq 1
-      expect(Dump.first.dump_type.constant).to eq "CHANGED_RECORDS"
+      expect(Dump.first.dump_type).to eq 'changed_records'
       event = Dump.first.event
       expect(event.message_body).to eq message_body
       expect(event.start).to eq "2021-02-08T17:03:52.894Z"
@@ -114,7 +114,7 @@ RSpec.describe AwsSqsPoller do
       )
 
       expect(Dump.all.count).to eq 1
-      expect(Dump.first.dump_type.constant).to eq "PRINCETON_RECAP"
+      expect(Dump.first.dump_type).to eq "princeton_recap"
       event = Dump.first.event
       expect(event.message_body).to eq message_body
       expect(event.start).to eq "2021-02-08T17:03:52.894Z"

--- a/spec/system/devise_spec.rb
+++ b/spec/system/devise_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Devise restricts features for unauthenticated users', type: :sys
   def dump_test_bib_ids(bibs)
     dump = nil
     Event.record do |event|
-      dump = Dump.create(dump_type: DumpType.find_by(constant: 'BIB_IDS'))
+      dump = Dump.create(dump_type: :bib_ids)
       dump.event = event
       dump_file = DumpFile.create(dump:, dump_file_type: DumpFileType.find_by(constant: 'BIB_IDS'))
       FileUtils.cp bibs, dump_file.path

--- a/spec/utils/data_seeder_spec.rb
+++ b/spec/utils/data_seeder_spec.rb
@@ -1,19 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe DataSeeder do
-  it 'creates DumpType and DumpFileType entries' do
-    DumpType.all.map(&:destroy)
+  it 'creates DumpFileType entries' do
     DumpFileType.all.map(&:destroy)
     seeder = described_class.new
-    seeder.generate_dump_types
     seeder.generate_dump_file_types
-    expect(DumpType.count).not_to be_zero
     expect(DumpFileType.count).not_to be_zero
   end
 
   it 'is idempotent' do
     seeder = described_class.new
-    expect { seeder.generate_dump_types }.not_to change { DumpType.count }
     expect { seeder.generate_dump_file_types }.not_to change { DumpFileType.count }
   end
 end

--- a/spec/views/dumps/show.json.erb_spec.rb
+++ b/spec/views/dumps/show.json.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "dumps/show", type: :view do
       assign(:dump, FactoryBot.create(:full_dump))
       render
       response = JSON.parse(rendered)
-      expect(response["type"]).to eq "all_records"
+      expect(response["type"]).to eq "full_dump"
       expect(response["generated_date"]).to eq "2021-07-13T11:00:00.000Z"
     end
   end


### PR DESCRIPTION
We have seen many issues with the postgres database queries around DumpTypes, so trying putting them into an enum. The number in the database table should be the same whether it's a `dump_type_id` or the enum. 

Enums come with some nice stuff for free, like scopes and booleans (e.g. `dump.changed_records?`). 

Closes #2348