### PR TITLE
SQS Poller - Create dump in one transaction

### DIFF
--- a/app/services/aws_sqs_poller.rb
+++ b/app/services/aws_sqs_poller.rb
@@ -41,11 +41,9 @@ class AlmaDumpFactory
   end
 
   def bib_dump
-    dump = Dump.create(dump_type:)
-    dump.event = dump_event
-    dump.generated_date = dump_event.start
-    dump.save
-    dump
+    Dump.create(dump_type:,
+                event: dump_event,
+                generated_date: dump_event.start)
   end
 
   def dump_type

--- a/spec/services/alma_dump_factory_spec.rb
+++ b/spec/services/alma_dump_factory_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+# This class is currently defined in the aws_sqs_poller.rb file, so auto-loaders can't find it
+require 'app/services/aws_sqs_poller.rb'
+
+RSpec.describe AlmaDumpFactory do
+  context 'looking at the dump more than once' do
+    let(:message_body) { JSON.parse(File.read(Rails.root.join('spec', 'fixtures', 'aws', 'sqs_recap_incremental_dump.json'))) }
+
+    it 'only instantiates one dump' do
+      dump = AlmaDumpFactory.bib_dump(message_body)
+      expect(dump).to be_an_instance_of(Dump)
+      expect(Dump.count).to eq(1)
+      expect { dump }.not_to change(Dump, :count)
+    end
+  end
+end


### PR DESCRIPTION
We have seen long-running postgres queries in this area of the code, trying making the Dump object in a single transaction, to see if that helps. Add a test for an untested class.