### PR TITLE
Ensure poller is restarted on poller box

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -9,7 +9,8 @@ set :stage, :production
 set :rails_env, 'production'
 server 'bibdata-alma1.princeton.edu', user: 'deploy', roles: [:web, :app, :db]
 server 'bibdata-alma2.princeton.edu', user: 'deploy', roles: [:web, :app, :db, :hr_cron]
-server 'bibdata-alma-worker1.princeton.edu', user: 'deploy', roles: [:db, :worker, :cron, :cron_production]
+# Worker 1 gets the poller daemon installed via Princeton Ansible
+server 'bibdata-alma-worker1.princeton.edu', user: 'deploy', roles: [:db, :worker, :cron, :cron_production, :poller]
 server 'bibdata-alma-worker2.princeton.edu', user: 'deploy', roles: [:db, :worker]
 
 # Extended Server Syntax

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -8,10 +8,11 @@ set :application, 'bibdata'
 
 set :stage, :production
 set :rails_env, 'qa'
-server 'bibdata-qa1.princeton.edu', user: 'deploy', roles: [:web, :app, :db, :hr_cron, :poller]
-server 'bibdata-qa2.princeton.edu', user: 'deploy', roles: [:web, :app, :db, :hr_cron, :poller]
+server 'bibdata-qa1.princeton.edu', user: 'deploy', roles: [:web, :app, :db, :hr_cron]
+server 'bibdata-qa2.princeton.edu', user: 'deploy', roles: [:web, :app, :db, :hr_cron]
+# Worker 1 gets the poller daemon installed via Princeton Ansible
 server 'bibdata-worker-qa1.princeton.edu', user: 'deploy', roles: [:db, :worker, :cron, :cron_staging, :poller]
-server 'bibdata-worker-qa2.princeton.edu', user: 'deploy', roles: [:db, :worker, :cron, :cron_staging, :poller]
+server 'bibdata-worker-qa2.princeton.edu', user: 'deploy', roles: [:db, :worker, :cron, :cron_staging]
 
 # Extended Server Syntax
 # ======================

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -7,10 +7,11 @@
 set :application, 'bibdata'
 set :stage, :production
 set :rails_env, 'staging'
-server 'bibdata-alma-staging1.princeton.edu', user: 'deploy', roles: [:web, :app, :db, :hr_cron, :poller]
-server 'bibdata-alma-staging2.princeton.edu', user: 'deploy', roles: [:web, :app, :db, :hr_cron, :poller]
+server 'bibdata-alma-staging1.princeton.edu', user: 'deploy', roles: [:web, :app, :db, :hr_cron]
+server 'bibdata-alma-staging2.princeton.edu', user: 'deploy', roles: [:web, :app, :db, :hr_cron]
+# Worker 1 gets the poller daemon installed via Princeton Ansible
 server 'bibdata-alma-worker-staging1.princeton.edu', user: 'deploy', roles: [:db, :worker, :cron, :cron_staging, :poller]
-server 'bibdata-alma-worker-staging2.princeton.edu', user: 'deploy', roles: [:db, :worker, :cron, :cron_staging, :poller]
+server 'bibdata-alma-worker-staging2.princeton.edu', user: 'deploy', roles: [:db, :worker, :cron, :cron_staging]
 
 # Extended Server Syntax
 # ======================


### PR DESCRIPTION
- We should only run the poller on one server per environment
- Princeton Ansible installs the daemon on the first worker box (see https://github.com/pulibrary/princeton_ansible/pull/4875)