### PR TITLE
Rescue when trying to delete a dump associated with an IndexManager

### DIFF
--- a/app/jobs/delete_events_job.rb
+++ b/app/jobs/delete_events_job.rb
@@ -7,5 +7,7 @@ class DeleteEventsJob < ApplicationJob
                      .where(start: ..older_than)
                      .map(&:id)
     Event.destroy(event_ids)
+  rescue ActiveRecord::InvalidForeignKey => error
+    Rails.logger.warn("Likely tried to delete a dump that is either the 'dump_in_progress' or 'last_dump_completed' for an index manager.\n Error message: #{error.message}")
   end
 end


### PR DESCRIPTION
If a dump is still referenced by an IndexManager, just let it hang out until it is no longer referenced.

Closes #1749 