### PR TITLE
Fix event seeds, address deprecation warning

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -23,8 +23,8 @@
     <% @events.each do |event| %>
       <tr class="table-striped<%= event.success ? '' : ' warning'%>">
         <td><%=event.id%></td>
-        <td class="nowrap"><%= event.start.localtime.to_s(:db_twelve_hour) %></td>
-        <td class="nowrap "><%= event.finish.localtime.to_s(:db_twelve_hour) if event.finish %></td>
+        <td class="nowrap"><%= event.start.localtime.to_fs(:db_twelve_hour) %></td>
+        <td class="nowrap "><%= event.finish.localtime.to_fs(:db_twelve_hour) if event.finish %></td>
         <td><%= event.success %></td>
         <td ><%= event.error %></td>
         <% if event.dump.nil? %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,10 @@
-if Event.count < 10 && Rails.env.development?
-  10.times do |i|
+if Event.count < 9 && Rails.env.development?
+  9.times do |i|
     Event.find_or_create_by(start: "200#{i}-10-10", finish: "200#{i}-10-11", success: true)
   end
 end
 
-if Dump.count < 10 && Rails.env.development?
+if Dump.count < 9 && Rails.env.development?
   Event.all.each do |event|
     event.dump = Dump.create!(dump_type: :changed_records)
     event.save

--- a/spec/views/events.html.erb_spec.rb
+++ b/spec/views/events.html.erb_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe "events/index", type: :view do
                event3 = FactoryBot.create(:event, start: Time.now - 1.month, finish: Time.now - 1.month + 180, error: nil, success: true)
              ])
       render
-      expect(rendered).to have_css('tr.table-striped:nth-child(1) > td:nth-child(2)', text: event1.start.localtime.to_s(:db_twelve_hour))
-      expect(rendered).to have_css('tr.table-striped:nth-child(2) > td:nth-child(2)', text: event2.start.localtime.to_s(:db_twelve_hour))
-      expect(rendered).to have_css('tr.table-striped:nth-child(3) > td:nth-child(2)', text: event3.start.localtime.to_s(:db_twelve_hour))
+      expect(rendered).to have_css('tr.table-striped:nth-child(1) > td:nth-child(2)', text: event1.start.localtime.to_fs(:db_twelve_hour))
+      expect(rendered).to have_css('tr.table-striped:nth-child(2) > td:nth-child(2)', text: event2.start.localtime.to_fs(:db_twelve_hour))
+      expect(rendered).to have_css('tr.table-striped:nth-child(3) > td:nth-child(2)', text: event3.start.localtime.to_fs(:db_twelve_hour))
     end
 
     it "does not include Delete column for unauthenticated users" do


### PR DESCRIPTION
- The seeds were creating events without dates, since they were trying to create the year "20010", which the DB apparently doesn't believe in. This made it so that the events could not be viewed in the UI.
- Address deprecation warning that was distracting from the real issue