### PR TITLE
Fix json display of dumps

### DIFF
--- a/app/views/dumps/show.json.jbuilder
+++ b/app/views/dumps/show.json.jbuilder
@@ -1,7 +1,8 @@
 json.type @dump.dump_type.downcase
 json.generated_date @dump.generated_date
 json.files do
-  DumpFile.dump_file_types.each do |dft|
+  DumpFile.dump_file_types.each do |dft_name, _dft_id|
+    dft = dft_name.to_sym
     json.set! dft, @dump.dump_files.where(dump_file_type: dft).each do |df|
       json.dump_file dump_file_url(df)
       json.md5 df.md5

--- a/spec/views/dumps/show.json.erb_spec.rb
+++ b/spec/views/dumps/show.json.erb_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "dumps/show", type: :view do
       assign(:dump, FactoryBot.create(:full_dump))
       render
       response = JSON.parse(rendered)
+      expect(response["files"].keys.first).to eq("bib_records")
       expect(response["type"]).to eq "full_dump"
       expect(response["generated_date"]).to eq "2021-07-13T11:00:00.000Z"
     end


### PR DESCRIPTION
- The keys for the "files" were displaying as `["bib_records", 1]` which was distracting and difficult to read