### PR TITLE
Do not index SCSB items if they are private

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -1242,6 +1242,16 @@ to_field 'holdings_1display' do |record, accumulator|
   accumulator[0] = all_holdings.to_json.to_s unless all_holdings.empty?
 end
 
+# Skip SCSB records that include only private items
+each_record do |record, context|
+  recap_notes = process_recap_notes(record)
+  next if recap_notes.empty?
+  next if recap_notes.map { |note| note.include?("P") }.include?(false)
+
+  id = id_extractor.extract(record).first
+  context.skip!("Skipped #{id} because record includes only private items.")
+end
+
 ## for recap notes
 to_field 'recap_notes_display' do |record, accumulator|
   recap_notes = process_recap_notes(record)

--- a/spec/fixtures/marc_to_solr/scsb_harvard_multiple.mrx
+++ b/spec/fixtures/marc_to_solr/scsb_harvard_multiple.mrx
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?><marcxml:collection xmlns:marcxml="http://www.loc.gov/MARC21/slim">
+  <marcxml:record>
+    <marcxml:leader>01793cam a2200289Ma 4500</marcxml:leader>
+    <marcxml:controlfield tag="001">SCSB-9879609</marcxml:controlfield>
+    <marcxml:controlfield tag="005">20210108133627.0</marcxml:controlfield>
+    <marcxml:controlfield tag="008">080503s2007    ua            000 0 ara d</marcxml:controlfield>
+    <marcxml:controlfield tag="009">990115251640203941</marcxml:controlfield>
+    <marcxml:datafield tag="035" ind1=" " ind2=" ">
+      <marcxml:subfield code="a">(OCoLC)227281073</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="040" ind1=" " ind2=" ">
+      <marcxml:subfield code="a">LEILA</marcxml:subfield>
+      <marcxml:subfield code="b">eng</marcxml:subfield>
+      <marcxml:subfield code="c">LEILA</marcxml:subfield>
+      <marcxml:subfield code="d">HVL</marcxml:subfield>
+      <marcxml:subfield code="d">OCLCF</marcxml:subfield>
+      <marcxml:subfield code="d">OCLCQ</marcxml:subfield>
+      <marcxml:subfield code="d">OCLCO</marcxml:subfield>
+      <marcxml:subfield code="d">OCLCA</marcxml:subfield>
+      <marcxml:subfield code="d">HUL</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="043" ind1=" " ind2=" ">
+      <marcxml:subfield code="a">f-ua---</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="050" ind1=" " ind2="4">
+      <marcxml:subfield code="a">KRM2754</marcxml:subfield>
+      <marcxml:subfield code="b">.B36 2007x</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="100" ind1="1" ind2=" ">
+      <marcxml:subfield code="6">880-01</marcxml:subfield>
+      <marcxml:subfield code="a">Bannā, Maḥmūd ʻāṭif.</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="880" ind1="1" ind2=" ">
+      <marcxml:subfield code="6">100-01//r</marcxml:subfield>
+      <marcxml:subfield code="a">بنا، محمود عاطف.</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="245" ind1="1" ind2="3">
+      <marcxml:subfield code="6">880-02</marcxml:subfield>
+      <marcxml:subfield code="a">al-ʻUqūd al-idārīyah /</marcxml:subfield>
+      <marcxml:subfield code="c">Maḥmūd ʻāṭif al-Bannā.</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="880" ind1="1" ind2="2">
+      <marcxml:subfield code="6">245-02//r</marcxml:subfield>
+      <marcxml:subfield code="a">العقود الادارية /</marcxml:subfield>
+      <marcxml:subfield code="c">محمود عاطف البنا.</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="250" ind1=" " ind2=" ">
+      <marcxml:subfield code="6">880-03</marcxml:subfield>
+      <marcxml:subfield code="a">al-Ṭabʻah 1.</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="880" ind1=" " ind2=" ">
+      <marcxml:subfield code="6">250-03//r</marcxml:subfield>
+      <marcxml:subfield code="a">الطبعة 1.</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="260" ind1=" " ind2=" ">
+      <marcxml:subfield code="6">880-04</marcxml:subfield>
+      <marcxml:subfield code="a">Madīnat Naṣr, al-Qāhirah :</marcxml:subfield>
+      <marcxml:subfield code="b">Dār al-Fikr al-ʻArabī,</marcxml:subfield>
+      <marcxml:subfield code="c">2007.</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="880" ind1=" " ind2=" ">
+      <marcxml:subfield code="6">260-04//r</marcxml:subfield>
+      <marcxml:subfield code="a">مدينة نصر، القاهرة :</marcxml:subfield>
+      <marcxml:subfield code="b">دار الفكر العربي،</marcxml:subfield>
+      <marcxml:subfield code="c">2007.</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="300" ind1=" " ind2=" ">
+      <marcxml:subfield code="a">375 pages ;</marcxml:subfield>
+      <marcxml:subfield code="c">24 cm</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="336" ind1=" " ind2=" ">
+      <marcxml:subfield code="a">text</marcxml:subfield>
+      <marcxml:subfield code="b">txt</marcxml:subfield>
+      <marcxml:subfield code="2">rdacontent</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="337" ind1=" " ind2=" ">
+      <marcxml:subfield code="a">unmediated</marcxml:subfield>
+      <marcxml:subfield code="b">n</marcxml:subfield>
+      <marcxml:subfield code="2">rdamedia</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="338" ind1=" " ind2=" ">
+      <marcxml:subfield code="a">volume</marcxml:subfield>
+      <marcxml:subfield code="b">nc</marcxml:subfield>
+      <marcxml:subfield code="2">rdacarrier</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="650" ind1=" " ind2="0">
+      <marcxml:subfield code="a">Public contracts</marcxml:subfield>
+      <marcxml:subfield code="z">Egypt.</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="650" ind1=" " ind2="7">
+      <marcxml:subfield code="a">Public contracts</marcxml:subfield>
+      <marcxml:subfield code="2">fast</marcxml:subfield>
+      <marcxml:subfield code="0">(OCoLC)fst01082170</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="651" ind1=" " ind2="7">
+      <marcxml:subfield code="a">Egypt</marcxml:subfield>
+      <marcxml:subfield code="2">fast</marcxml:subfield>
+      <marcxml:subfield code="0">(OCoLC)fst01208755</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="583" ind1="1" ind2=" ">
+      <marcxml:subfield code="a">committed to retain</marcxml:subfield>
+      <marcxml:subfield code="c">20181001</marcxml:subfield>
+      <marcxml:subfield code="d">in perpetuity</marcxml:subfield>
+      <marcxml:subfield code="f">ReCAP Shared Collection</marcxml:subfield>
+      <marcxml:subfield code="5">HUL</marcxml:subfield>
+      <marcxml:subfield code="8">222123425660003941</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="852" ind1="0" ind2=" ">
+      <marcxml:subfield code="c">HD</marcxml:subfield>
+      <marcxml:subfield code="h">KRM2754</marcxml:subfield>
+      <marcxml:subfield code="i">.B36 2007x</marcxml:subfield>
+      <marcxml:subfield code="8">222123425660003941</marcxml:subfield>
+      <marcxml:subfield code="0">10615482</marcxml:subfield>
+      <marcxml:subfield code="b">scsbhl</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="876" ind1=" " ind2=" ">
+      <marcxml:subfield code="0">10615482</marcxml:subfield>
+      <marcxml:subfield code="3"/>
+      <marcxml:subfield code="a">16302174</marcxml:subfield>
+      <marcxml:subfield code="h"/>
+      <marcxml:subfield code="j">Available</marcxml:subfield>
+      <marcxml:subfield code="k">LAW</marcxml:subfield>
+      <marcxml:subfield code="p">32044123007148</marcxml:subfield>
+      <marcxml:subfield code="t"/>
+      <marcxml:subfield code="x">Private</marcxml:subfield>
+      <marcxml:subfield code="z">HL</marcxml:subfield>
+      <marcxml:subfield code="l">HD</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="852" ind1="0" ind2=" ">
+      <marcxml:subfield code="c">HD</marcxml:subfield>
+      <marcxml:subfield code="h">KRM2754</marcxml:subfield>
+      <marcxml:subfield code="i">.B36 2007x</marcxml:subfield>
+      <marcxml:subfield code="8">222123425660003941</marcxml:subfield>
+      <marcxml:subfield code="0">10615483</marcxml:subfield>
+      <marcxml:subfield code="b">scsbhl</marcxml:subfield>
+    </marcxml:datafield>
+    <marcxml:datafield tag="876" ind1=" " ind2=" ">
+      <marcxml:subfield code="0">10615483</marcxml:subfield>
+      <marcxml:subfield code="3"/>
+      <marcxml:subfield code="a">16302175</marcxml:subfield>
+      <marcxml:subfield code="h"/>
+      <marcxml:subfield code="j">Available</marcxml:subfield>
+      <marcxml:subfield code="k">LAW</marcxml:subfield>
+      <marcxml:subfield code="p">32044123007149</marcxml:subfield>
+      <marcxml:subfield code="t"/>
+      <marcxml:subfield code="x">Open</marcxml:subfield>
+      <marcxml:subfield code="z">HL</marcxml:subfield>
+      <marcxml:subfield code="l">HD</marcxml:subfield>
+    </marcxml:datafield>
+  </marcxml:record>
+</marcxml:collection>

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -52,6 +52,7 @@ describe 'From traject_config.rb', indexing: true do
       @scsb_nypl = @indexer.map_record(fixture_record('SCSB-8157262'))
       @scsb_alt_title = @indexer.map_record(fixture_record('scsb_cul_alt_title'))
       @scsb_private = @indexer.map_record(fixture_record('scsb_harvard_private'))
+      @scsb_multiple = @indexer.map_record(fixture_record('scsb_harvard_multiple'))
       @scsb_committed = @indexer.map_record(fixture_record('scsb_harvard_committed'))
       @scsb_uncommittable = @indexer.map_record(fixture_record('scsb_harvard_uncommittable'))
       @recap_record = @indexer.map_record(fixture_record('994081873506421'))
@@ -1259,12 +1260,21 @@ describe 'From traject_config.rb', indexing: true do
       end
     end
 
+    describe 'private recap items' do
+      it "skips indexing record if only item is private" do
+        expect(@scsb_private).to be nil
+      end
+      it "skips indexing private items" do
+        expect(@scsb_multiple).to be
+        holdings = JSON.parse(@scsb_multiple["holdings_1display"].first)
+        public_holding_id = "10615483"
+        expect(holdings.keys).to match_array([public_holding_id])
+      end
+    end
+
     describe 'recap_notes_display' do
       it "skips indexing for Princeton Recap records" do
         expect(@recap_record["recap_notes_display"]).to be nil
-      end
-      it "Indexes H - P, if a private SCSB record" do
-        expect(@scsb_private["recap_notes_display"]).to eq ["H - P"]
       end
       it "Indexes C - S, if a shared SCSB record" do
         expect(@scsb_alt_title["recap_notes_display"]).to eq ["C - S"]

--- a/spec/marc_to_solr/lib/princeton_marc_spec.rb
+++ b/spec/marc_to_solr/lib/princeton_marc_spec.rb
@@ -770,6 +770,10 @@ describe 'From princeton_marc.rb' do
       @holdings_scsb_hl = JSON.parse(@record_scsb_hl["holdings_1display"][0])
       @holding_id_scsb_hl = "10615189"
       @holdings_scsb_hl_block = @holdings_scsb_hl[@holding_id_scsb_hl]
+
+      @record_scsb_mixed = @indexer.map_record(fixture_record('scsb_harvard_multiple'))
+      @holdings_scsb_mixed = JSON.parse(@record_scsb_mixed["holdings_1display"][0])
+      @holding_id_scsb_mixed_public = "10615483"
     end
 
     it 'indexes location if it exists' do
@@ -847,6 +851,12 @@ describe 'From princeton_marc.rb' do
       end
       it "indexes 876$l for scsb" do
         expect(@holdings_scsb_hl_block['items'][0]['storage_location']).to eq("HD")
+      end
+
+      context 'with a record with both public and private holdings' do
+        it 'indexes only public items for SCSB' do
+          expect(@holdings_scsb_mixed.keys).to match_array([@holding_id_scsb_mixed_public])
+        end
       end
     end
   end


### PR DESCRIPTION
- If there are only private items, skip indexing the whole record
- If there is a mix of private and non-private items, only index the private items

Connected to #2383

Tested successfully on staging using a file from SCSB that included private items.