### PR TITLE
[#2413] Index MMS IDs from 773 and 774 that have (NjP) prefix

### DIFF
--- a/marc_to_solr/lib/linked_fields_extractor.rb
+++ b/marc_to_solr/lib/linked_fields_extractor.rb
@@ -1,0 +1,24 @@
+# This class is responsible for extracting and validating
+# Alma MMS IDs from the 773 and 774 MARC fields
+class LinkedFieldsExtractor
+  def initialize(record, field_tag)
+    @record = record
+    @field_tag = field_tag
+  end
+
+  def mms_ids
+    valid_fields.map { |field| field['w'].delete_prefix('(NjP)') }
+  end
+
+  private
+
+    attr_accessor :record, :field_tag
+
+    def valid_fields
+      @valid_fields ||= record.fields(field_tag).select do |field|
+        value = field['w']
+        # The regular expression /99[0-9]+6421/ ensures that an mms id is present in a $w
+        value =~ /99[0-9]+6421/ && value.start_with?(/(\(NjP\))?99/) && value.end_with?('06421')
+      end
+    end
+end

--- a/marc_to_solr/lib/princeton_marc.rb
+++ b/marc_to_solr/lib/princeton_marc.rb
@@ -11,6 +11,7 @@ require_relative 'electronic_access_link'
 require_relative 'electronic_access_link_factory'
 require_relative 'hierarchical_heading'
 require_relative 'iiif_manifest_url_builder'
+require_relative 'linked_fields_extractor'
 require_relative 'orangelight_url_builder'
 require_relative 'process_holdings_helpers'
 
@@ -817,10 +818,6 @@ def any_thesaurus_match?(field, thesauri)
   field.any? { |subfield| subfield.code == '2' && thesauri.include?(subfield.value) }
 end
 
-# The regular expression /99[0-9]+6421/ ensures that an mms id is present in a $w
 def valid_linked_fields(record, field_tag, accumulator)
-  fields = record.fields(field_tag).select { |f| f["w"] =~ /99[0-9]+6421/ }
-  fields.each do |field|
-    accumulator << field["w"] if field["w"].start_with?("99") && field["w"].end_with?("06421")
-  end
+  accumulator.concat LinkedFieldsExtractor.new(record, field_tag).mms_ids
 end

--- a/spec/marc_to_solr/lib/linked_field_extractor_spec.rb
+++ b/spec/marc_to_solr/lib/linked_field_extractor_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe LinkedFieldsExtractor do
+  let(:extractor) { described_class.new(MARC::Record.new_from_hash('fields' => fields), '773') }
+  describe 'when the subfield w is an alma MMS ID' do
+    let(:fields) do
+      [
+        { '773' => { 'subfields' => [{ 'w' => '9923506421' }] } }
+      ]
+    end
+    it 'returns an array containing the MMS ID' do
+      expect(extractor.mms_ids).to eq(['9923506421'])
+    end
+  end
+  describe 'when the subfield w is not an alma MMS ID' do
+    let(:fields) do
+      [
+        { '773' => { 'subfields' => [{ 'w' => '(OCoLC)15390917' }] } }
+      ]
+    end
+    it 'returns an empty array' do
+      expect(extractor.mms_ids).to be_empty
+    end
+  end
+
+  describe 'when the subfield w could be an alma MMS ID, but the prefix is wrong' do
+    let(:fields) do
+      [
+        { '773' => { 'subfields' => [{ 'w' => '(OCoLC)9923506421' }] } }
+      ]
+    end
+    it 'returns an empty array' do
+      expect(extractor.mms_ids).to be_empty
+    end
+  end
+
+  describe 'when the subfield w is an alma MMS ID with an NjP prefix' do
+    let(:fields) do
+      [
+        { '773' => { 'subfields' => [{ 'w' => '(NjP)9923506421' }] } }
+      ]
+    end
+    it 'returns an array containing the MMS ID' do
+      expect(extractor.mms_ids).to eq(['9923506421'])
+    end
+  end
+end


### PR DESCRIPTION
Also, refactor 773 and 774 indexing into its own class so that it's a little easier to reason about and test in isolation.