### PR TITLE
[#2415] Create column to save the alma jobs status in the events table/ Display the column in the events page

### DIFF
--- a/app/services/aws_sqs_poller.rb
+++ b/app/services/aws_sqs_poller.rb
@@ -54,11 +54,16 @@ class AlmaDumpFactory
     message["job_instance"]["name"]
   end
 
+  def alma_job_status
+    message["job_instance"]["status"]["value"]
+  end
+
   def dump_event
     @event ||= Event.create(
       start: event_start,
       finish: event_finish,
       success: true,
+      alma_job_status:,
       message_body: message.to_json
     )
   end

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -9,6 +9,7 @@
       <th>Start</th>
       <th>Finish</th>
       <th>Success</th>
+      <th>Alma Job Status</th>
       <th>Error</th>
       <th>Dump Type</th>
       <th>Bibs Updated</th>
@@ -23,9 +24,10 @@
     <% @events.each do |event| %>
       <tr class="table-striped<%= event.success ? '' : ' warning'%>">
         <td><%=event.id%></td>
-        <td class="nowrap"><%= event.start.localtime.to_fs(:db_twelve_hour) %></td>
-        <td class="nowrap "><%= event.finish.localtime.to_fs(:db_twelve_hour) if event.finish %></td>
+        <td class="nowrap"><%= event.start&.localtime&.to_fs(:db_twelve_hour) %></td>
+        <td class="nowrap "><%= event.finish&.localtime&.to_fs(:db_twelve_hour) if event.finish %></td>
         <td><%= event.success %></td>
+        <td><%= event.alma_job_status %></td>
         <td ><%= event.error %></td>
         <% if event.dump.nil? %>
           <td colspan="3" />

--- a/db/migrate/20240725133105_add_alma_job_to_events.rb
+++ b/db/migrate/20240725133105_add_alma_job_to_events.rb
@@ -1,0 +1,8 @@
+class AddAlmaJobToEvents < ActiveRecord::Migration[7.1]
+  def up
+    add_column :events, :alma_job_status, :string
+  end
+  def down
+    remove_column :events, :alma_job_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_27_003355) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_25_133105) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -78,6 +78,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_27_003355) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "message_body"
+    t.string "alma_job_status"
   end
 
   create_table "friendly_id_slugs", id: :serial, force: :cascade do |t|

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -102,6 +102,7 @@ FactoryBot.define do
     finish { Time.now - 100 }
     error { nil }
     success { true }
+    alma_job_status { "COMPLETED_SUCCESS" }
     created_at { finish }
     updated_at { finish }
     association :dump, factory: :full_dump
@@ -112,6 +113,7 @@ FactoryBot.define do
     finish { Time.now - 100 }
     error { nil }
     success { true }
+    alma_job_status { "COMPLETED_SUCCESS" }
     created_at { finish }
     updated_at { finish }
     association :dump, factory: :incremental_dump
@@ -122,6 +124,7 @@ FactoryBot.define do
     finish { Time.now - 100 }
     error { nil }
     success { true }
+    alma_job_status {}
     created_at { finish }
     updated_at { finish }
     association :dump, factory: :partner_recap_daily_dump
@@ -132,6 +135,7 @@ FactoryBot.define do
     finish { Time.now - 100 }
     error { nil }
     success { true }
+    alma_job_status {}
     created_at { finish }
     updated_at { finish }
     association :dump, factory: :partner_recap_full_dump

--- a/spec/fixtures/aws/sqs_incremental_dump_alma_job_failed.json
+++ b/spec/fixtures/aws/sqs_incremental_dump_alma_job_failed.json
@@ -1,0 +1,105 @@
+{
+    "id": "38205463100006421",
+    "action": "JOB_END",
+    "institution": {
+        "value": "01PRI_INST",
+        "desc": "Princeton University Library"
+    },
+    "time": "2024-06-11T18:27:10.961Z",
+    "job_instance": {
+        "id": "38205463100006421",
+        "name": "Publishing Platform Job Incremental Publishing",
+        "progress": 101.3,
+        "status": {
+            "value": "COMPLETED_FAILED",
+            "desc": "Completed with Errors"
+        },
+        "external_id": "38205728880006421",
+        "submitted_by": {
+            "value": "System"
+        },
+        "submit_time": "2024-06-11T17:00:11.594Z",
+        "start_time": "2024-06-11T17:20:13.584Z",
+        "end_time": "2024-06-11T18:27:10.961Z",
+        "status_date": "2024-06-11Z",
+        "alert": [
+            {
+                "value": "alert_general_error",
+                "desc": "The job completed with errors. For more information view the report details (or contact Support using the process ID)."
+            }
+        ],
+        "counter": [
+            {
+                "type": {
+                    "value": "label.new.records",
+                    "desc": "New Records"
+                },
+                "value": "66"
+            },
+            {
+                "type": {
+                    "value": "label.updated.records",
+                    "desc": "Updated Records"
+                },
+                "value": "3453"
+            },
+            {
+                "type": {
+                    "value": "label.deleted.records",
+                    "desc": "Deleted Records"
+                },
+                "value": "0"
+            },
+            {
+                "type": {
+                    "value": "c.jobs.publishing.failed.publishing",
+                    "desc": "Unpublished failed records"
+                },
+                "value": "0"
+            },
+            {
+                "type": {
+                    "value": "c.jobs.publishing.skipped",
+                    "desc": "Skipped records (update date changed but no data change)"
+                },
+                "value": "224"
+            },
+            {
+                "type": {
+                    "value": "c.jobs.publishing.filtered_out",
+                    "desc": "Filtered records (not published due to filter)"
+                },
+                "value": "0"
+            },
+            {
+                "type": {
+                    "value": "c.jobs.publishing.totalRecordsWrittenToFile",
+                    "desc": "Total records written to file"
+                },
+                "value": "0"
+            },
+            {
+                "type": {
+                    "value": "FTP has failed.",
+                    "desc": ""
+                },
+                "value": "Download zip file for manual FTP."
+            }
+        ],
+        "job_info": {
+            "id": "S32986800410006421",
+            "name": "Publishing Platform Job Incremental Publishing",
+            "description": "Publishing Platform Job",
+            "type": {
+                "value": "SCHEDULED",
+                "desc": "Scheduled"
+            },
+            "category": {
+                "value": "PUBLISHING",
+                "desc": "Publishing"
+            },
+            "link": "/almaws/v1/conf/jobs/S32986800410006421"
+        },
+        "link": "/almaws/v1/conf/jobs/S32986800410006421/instances/38205463100006421"
+    }
+}

--- a/spec/views/events.html.erb_spec.rb
+++ b/spec/views/events.html.erb_spec.rb
@@ -27,5 +27,11 @@ RSpec.describe "events/index", type: :view do
       render
       expect(rendered).to include "<th>Delete?</th>"
     end
+
+    it "includes Alma Job Status column" do
+      assign(:events, [FactoryBot.create(:event)])
+      render
+      expect(rendered).to include "<th>Alma Job Status</th>"
+    end
   end
 end


### PR DESCRIPTION
closes #2415 

Save the alma job status that is included in the AWS SQS poller message in the new events alma_job_status column
Include a fixture from an incremental alma job that completed with failures Update AWS sqs poller spec
The Events index page has column: Alma Job Status