### PR TITLE
[#1929] Don't allow duplicate events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,6 @@
 class Event < ActiveRecord::Base
   has_one :dump
+  validates :message_body, uniqueness: { allow_blank: true }
 
   before_destroy do
     self.dump.destroy unless self.dump.nil?

--- a/db/migrate/20240729225210_change_column_message_body_events.rb
+++ b/db/migrate/20240729225210_change_column_message_body_events.rb
@@ -1,0 +1,9 @@
+class ChangeColumnMessageBodyEvents < ActiveRecord::Migration[7.1]
+  def up
+    add_index :events, :message_body, unique: true
+  end
+
+  def down
+    remove_index :events, :message_body
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_25_133105) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_29_225210) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -79,6 +79,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_25_133105) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "message_body"
     t.string "alma_job_status"
+    t.index ["message_body"], name: "index_events_on_message_body", unique: true
   end
 
   create_table "friendly_id_slugs", id: :serial, force: :cascade do |t|

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -2,23 +2,40 @@ require 'rails_helper'
 require 'fileutils'
 
 RSpec.describe Event, type: :model do
-  before(:all) do
-    bibs = './spec/fixtures/sample_bib_ids.txt'
-    10.times { dump_test_bib_ids(bibs) }
-    10.times { test_events(:changed_records) }
-    5.times { test_events(:full_dump) }
-  end
-
-  after(:all) do
+  after do
     described_class.destroy_all
   end
 
   describe 'Failed dump' do
+    before do
+      bibs = './spec/fixtures/sample_bib_ids.txt'
+      10.times { dump_test_bib_ids(bibs) }
+      10.times { test_events(:changed_records) }
+      5.times { test_events(:full_dump) }
+    end
     it 'creates an unsuccessful event' do
       expect(test_failed_event.success).to be false
     end
   end
 
+  context "When attempting to create duplicate events" do
+    let(:message_body) { JSON.parse(File.read(Rails.root.join('spec', 'fixtures', 'aws', 'sqs_incremental_dump.json'))).to_json }
+
+    before do
+      described_class.create(message_body:)
+    end
+    it "does not create a duplicate event" do
+      expect do
+        described_class.create(message_body:)
+      end.not_to change { Event.count }
+      expect(Event.count).to eq 1
+    end
+    it "does not create a duplicate event and raises an error" do
+      expect do
+        described_class.create!(message_body:)
+      end.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: Message body has already been taken')
+    end
+  end
   def dump_test_bib_ids(bibs)
     dump = nil
     Event.record do |event|


### PR DESCRIPTION
Add migration to change event message_body to be unique
Add Rails model validation to prevent creating a duplicate event