### PR TITLE
[#2434] Add constraint in Dumps table not to be null

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,10 @@ Rails/RakeEnvironment:
   Exclude:
     - lib/tasks/*
 
+Rails/RedundantPresenceValidationOnBelongsTo:
+  Exclude:
+    - 'app/models/dump.rb'
+
 Rails/TimeZone:
   Enabled: false
 

--- a/app/jobs/scsb_import_full_job.rb
+++ b/app/jobs/scsb_import_full_job.rb
@@ -3,7 +3,8 @@ class ScsbImportFullJob < ApplicationJob
     delete_stale_files
 
     Event.record do |event|
-      event.dump = created_dump
+      event.save
+      event.dump = created_dump(event)
       event.save!
 
       Scsb::PartnerUpdates.full(dump: event.dump)
@@ -12,8 +13,8 @@ class ScsbImportFullJob < ApplicationJob
 
   private
 
-    def created_dump
-      Dump.create!(dump_type: :partner_recap_full)
+    def created_dump(event)
+      Dump.create!(dump_type: :partner_recap_full, event_id: event.id)
     end
 
     def delete_stale_files

--- a/app/models/dump.rb
+++ b/app/models/dump.rb
@@ -14,6 +14,7 @@ class Dump < ActiveRecord::Base
   serialize :delete_ids
   serialize :update_ids
   serialize :recap_barcodes
+  validates :event_id, presence: true
 
   before_destroy do
     self.dump_files.each do |df|

--- a/db/migrate/20240731183705_add_constraint_event_id_dump.rb
+++ b/db/migrate/20240731183705_add_constraint_event_id_dump.rb
@@ -1,0 +1,9 @@
+class AddConstraintEventIdDump < ActiveRecord::Migration[7.1]
+  def up
+    change_column_null :dumps, :event_id, false
+  end
+
+  def down
+    change_column_null :dumps, :event_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_29_225210) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_31_183705) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -58,7 +58,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_29_225210) do
   end
 
   create_table "dumps", id: :serial, force: :cascade do |t|
-    t.integer "event_id"
+    t.integer "event_id", null: false
     t.text "delete_ids"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -60,6 +60,7 @@ FactoryBot.define do
         association(:dump_file, path: 'spec/fixtures/files/alma/full_dump/2.xml.tar.gz')
       ]
     end
+    event_id { 1 }
   end
 
   factory :incremental_dump, class: "Dump" do
@@ -72,6 +73,7 @@ FactoryBot.define do
         association(:incremental_dump_file, path: 'spec/fixtures/files/alma/incremental_dump/2.tar.gz')
       ]
     end
+    event_id { 1 }
   end
 
   factory :partner_recap_daily_dump, class: "Dump" do
@@ -84,6 +86,7 @@ FactoryBot.define do
         association(:partner_recap_daily_dump_file, path: 'spec/fixtures/scsb_updates/scsb_update_20240108_183400_1.xml.gz')
       ]
     end
+    event_id { 1 }
   end
 
   factory :partner_recap_full_dump, class: "Dump" do
@@ -95,6 +98,7 @@ FactoryBot.define do
         association(:partner_recap_full_dump_file, path: 'spec/fixtures/scsb_updates/scsbfull_nypl_20240101_150000_1.xml.gz')
       ]
     end
+    event_id { 1 }
   end
 
   factory :full_dump_event, class: "Event" do

--- a/spec/support/scsb_partner_updates_incremental.rb
+++ b/spec/support/scsb_partner_updates_incremental.rb
@@ -2,10 +2,12 @@
 
 RSpec.shared_context 'scsb_partner_updates_incremental' do
   include_context 'scsb_partner_updates'
-  let(:dump) { Dump.create(dump_type: :partner_recap) }
+  let(:event) { FactoryBot.build(:event) }
+  let(:dump) { Dump.create(dump_type: :partner_recap, event_id: event.id) }
   let(:timestamp) { Dump.send(:incremental_update_timestamp) }
   let(:scsb_file) { file_fixture("scsb/scsb_leaderd.xml").to_s }
   before do
+    event.save
     allow(s3_bucket).to receive(:list_files)
     FileUtils.cp(Rails.root.join(fixture_paths, 'updates.zip'), update_directory_path.join("CUL-NYPL-HL_20210622_183200.zip"))
     FileUtils.cp(Rails.root.join(fixture_paths, 'deletes.zip'), update_directory_path.join("CUL-NYPL-HL_20210622_183300.zip"))


### PR DESCRIPTION
closes #2434 

Add constraint in Dumps table not to be null
in the model add validate presence: true
Update event factory where dump with id 1
Add additional spec in dump_spec.rb