### PR TITLE
In db seeds, make sure that each dump also has an event

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@ end
 
 if Dump.count < 9 && Rails.env.development?
   Event.all.each do |event|
-    event.dump = Dump.create!(dump_type: :changed_records)
+    event.dump = Dump.create!(dump_type: :changed_records, event:)
     event.save
   end
 end


### PR DESCRIPTION
This is a new constraint introduced in #2435.  For me, it was causing the servers:start rake task to fail locally, so this commit makes our seed data matches our db constraints.