### PR TITLE
Add content_advice_display field

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -638,7 +638,11 @@ to_field 'biographical_historical_note_display', extract_marc('545ab')
 
 # Summary note:
 #    520 XX 3ab
-to_field 'summary_note_display', extract_marc('5203abc')
+to_field 'summary_note_display', extract_marc('520| *|3abc:520|0*|3abc:520|1*|3abc:520|2*|3abc:520|3*|3abc:520|8*|3abc')
+
+# Content advice:
+#    520 4X 3ab
+to_field 'content_advice_display', extract_marc('520|4*|3abc')
 
 # Notes:
 #    500 XX 3a


### PR DESCRIPTION
- For all indicators other than 4, use summary_note_display, when the indicator is 4 for "Content advice" use content_advice_display
- See also https://www.loc.gov/marc/bibliographic/bd520.html

Closes #2414