### PR TITLE
Create the event before creating the incremental SCSB and make sure the dump is connected to this event_id

### DIFF
--- a/app/models/dump.rb
+++ b/app/models/dump.rb
@@ -39,9 +39,9 @@ class Dump < ActiveRecord::Base
       dump = nil
       timestamp = incremental_update_timestamp
       Event.record do |event|
-        dump = Dump.create(dump_type: :partner_recap)
+        event.save
+        dump = Dump.create(dump_type: :partner_recap, event_id: event.id)
         ScsbImportJob.perform_later(dump.id, timestamp)
-        dump.event = event
         dump.save
       end
       dump

--- a/spec/models/dump_spec.rb
+++ b/spec/models/dump_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Dump, type: :model do
 
           created_dump = described_class.last
           expect(created_dump.dump_type).to eq "partner_recap"
-          expect(ScsbImportJob).to have_received(:perform_later).with(anything, (frozen_time - 1.day).strftime('%Y-%m-%d %H:%M:%S.%6N %z'))
+          expect(ScsbImportJob).to have_received(:perform_later).with(created_dump.id, (frozen_time - 1.day).strftime('%Y-%m-%d %H:%M:%S.%6N %z'))
         end
       end
     end


### PR DESCRIPTION
This is to fix an error we saw in the sidekiq logs, which was blocking SCSB incrementals from indexing.

```
[2024-08-14T15:05:14.414018 #873] ERROR -- : [ActiveJob] [ScsbImportJob] [ee5aab42-b9ba-4265-afe2-e10378594fd0] Error performing ScsbImportJob (Job ID: ee5aab42-b9ba-4265-afe2-e10378594fd0) from Sidekiq(default) in 0.56ms: ActiveRecord::RecordNotFound (Couldn't find Dump without an ID):
```