### PR TITLE
AWS SQS queue - Reduce the maxReceiveCount to 100

### DIFF
--- a/webhook_monitor/template.yml
+++ b/webhook_monitor/template.yml
@@ -40,7 +40,7 @@ Resources:
           Fn::GetAtt:
             - DeadLetterSqsQueue
             - Arn
-        maxReceiveCount: 1000
+        maxReceiveCount: 100
       ContentBasedDeduplication: true
       MessageRetentionPeriod: 1_209_600
   APIGateway:


### PR DESCRIPTION
Helps with https://github.com/pulibrary/bibdata/issues/2462

Helps with https://github.com/pulibrary/bibdata/issues/2462
Reduce the maxReceiveCount to 100. So that the duplicate message from the aws sqs rake task timeout
is requeued only for the next 60 mins
It's a workaround to avoid messages
piling up in the AWSBiBProduction.fifo queue for 8-9 hours because of the 1000 requeueing.