### PR TITLE
Rescue error in aws sqs_poller poll so that we delete the duplicate message and not enqueue it again

### DIFF
--- a/app/services/aws_sqs_poller.rb
+++ b/app/services/aws_sqs_poller.rb
@@ -27,7 +27,7 @@ class AwsSqsPoller
         job_id: message_body["job_instance"]["id"]
       )
     rescue AlmaDumpFactory::AlmaDuplicateEventError
-
+      Rails.logger.error("Rescue from AlmaDuplicateEventError with alma_process_id: #{message_body['job_instance']['id']}")
     end
   end
 end
@@ -48,7 +48,6 @@ class AlmaDumpFactory
   end
 
   class AlmaDuplicateEventError < StandardError
-    
   end
 
   def initialize(message)

--- a/app/services/aws_sqs_poller.rb
+++ b/app/services/aws_sqs_poller.rb
@@ -26,6 +26,8 @@ class AwsSqsPoller
         dump:,
         job_id: message_body["job_instance"]["id"]
       )
+    rescue AlmaDumpFactory::AlmaDuplicateEventError
+
     end
   end
 end
@@ -43,6 +45,10 @@ class AlmaDumpFactory
       status = alma_message["job_instance"]["status"]["value"]
       "Alma job completed with invalid status. Alma status: #{status}. Job id: #{alma_message['id']}"
     end
+  end
+
+  class AlmaDuplicateEventError < StandardError
+    
   end
 
   def initialize(message)
@@ -88,7 +94,7 @@ class AlmaDumpFactory
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.error("#{e.message} message_body: #{message.to_json}")
     Honeybadger.notify("#{e.message} message_body: #{message.to_json}")
-    raise e
+    raise AlmaDuplicateEventError
   end
 
   def event_start

--- a/spec/services/aws_sqs_poller_spec.rb
+++ b/spec/services/aws_sqs_poller_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe AwsSqsPoller do
     let(:message_body) { JSON.parse(File.read(Rails.root.join('spec', 'fixtures', 'aws', 'sqs_incremental_dump.json'))).to_json }
     context "with a duplicate event" do
       before do
-        described_class.poll
+        Event.create!(message_body:)
       end
 
       it "doesn't raise an error or kicks off a background job" do
@@ -92,7 +92,7 @@ RSpec.describe AwsSqsPoller do
         expect { described_class.poll }.not_to have_enqueued_job(
         AlmaDumpTransferJob
       )
-        expect(Rails.logger).to have_received(:error)
+        expect(Rails.logger).to have_received(:error).with("Rescue from AlmaDuplicateEventError with alma_process_id: 6587815790006421")
       end
     end
 
@@ -103,7 +103,6 @@ RSpec.describe AwsSqsPoller do
         job_id:,
         dump: instance_of(Dump)
       )
-
       expect(Dump.all.count).to eq 1
       expect(Dump.first.dump_type).to eq 'changed_records'
       event = Dump.first.event


### PR DESCRIPTION
Rescue error in aws sqs_poller poll so that we delete the duplicate message and not enqueue it again