### PR TITLE
Rails 7.1 - The setter congig.autoloader= has been deleted

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,5 @@ module MarcLiberation
     config.authz = netids.split if netids
 
     config.alma = config_for(:alma).with_indifferent_access
-    config.autoloader = :zeitwerk
   end
 end


### PR DESCRIPTION
See https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#the-setter-config-autoloader-has-been-deleted

Run `bin/rails zeitwerk:check` to check. If all is good it should return:
`Hold on, I am eager loading the application.`
`All is good!