### PR TITLE
[#1827] Use the term "description", rather than "enumeration", for the combined enumeration and chronology

### DIFF
--- a/marc_to_solr/lib/process_holdings_helpers.rb
+++ b/marc_to_solr/lib/process_holdings_helpers.rb
@@ -141,7 +141,7 @@ class ProcessHoldingsHelpers
     is_scsb = scsb?(field_852)
     item = {}
     item[:holding_id] = field_876['0'] if field_876['0']
-    item[:enumeration] = field_876['3'] if field_876['3']
+    item[:description] = field_876['3'] if field_876['3']
     item[:id] = field_876['a'] if field_876['a']
     item[:status_at_load] = field_876['j'] if field_876['j']
     item[:barcode] = field_876['p'] if field_876['p']

--- a/spec/marc_to_solr/lib/princeton_marc_spec.rb
+++ b/spec/marc_to_solr/lib/princeton_marc_spec.rb
@@ -840,7 +840,7 @@ describe 'From princeton_marc.rb' do
         expect(@holdings_scsb_block['location_has']).to eq(["no. 107-112"])
       end
       it "indexes 876 for scsb" do
-        expect(@holdings_scsb_block['items'][0]['enumeration']).to eq("no. 107-112")
+        expect(@holdings_scsb_block['items'][0]['description']).to eq("no. 107-112")
         expect(@holdings_scsb_block['items'][0]['id']).to eq("15555520")
         expect(@holdings_scsb_block['items'][0]['use_statement']).to eq("In Library Use")
         expect(@holdings_scsb_block['items'][0]['status_at_load']).to eq("Available")


### PR DESCRIPTION
This makes the terminology consistent with the Alma availability response, and the Alma enrichment UI.

It also reduces some potential confusion, since we no longer imply that chronology is not included in this value.

Closes #1827