### PR TITLE
Re-enable https for `_url` helpers.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,7 +72,7 @@ Rails.application.configure do
   # config.action_mailer.default_options = {
   #   from: 'no-reply@princeton.edu'
   # }
-  # config.action_mailer.default_url_options = { host: ENV["APPLICATION_URL"] || "bibdata.princeton.edu", protocol: "https" }
+  config.action_mailer.default_url_options = { host: ENV["APPLICATION_URL"] || "bibdata.princeton.edu", protocol: "https" }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -87,5 +87,5 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  # config.action_mailer.default_url_options = { host: ENV["APPLICATION_URL"] || "bibdata-staging.lib.princeton.edu", protocol: "https" }
+  config.action_mailer.default_url_options = { host: ENV["APPLICATION_URL"] || "bibdata-staging.lib.princeton.edu", protocol: "https" }
 end


### PR DESCRIPTION
These action mailer defaults control the protocol for `_url` helpers, which are used in the JSON endpoints Figgy depends on. When they all changed to `http` it broke Figgy.