### PR TITLE
Add logging for patron controller authorization

### DIFF
--- a/app/controllers/patron_controller.rb
+++ b/app/controllers/patron_controller.rb
@@ -72,6 +72,12 @@ class PatronController < ApplicationController
         if ips.exclude?(request.remote_ip)
           deny_access
           Rails.logger.info("Denied patron request: IP #{request.remote_ip} is not in the list: #{ips.join(', ')}")
+          headers = {}.tap do |envs|
+            request.headers.each do |key, value|
+              envs[key] = value if key.downcase.starts_with?('http')
+            end
+          end
+          Rails.logger.info("Headers of the request: #{headers}")
         end
       end
     end

--- a/app/controllers/patron_controller.rb
+++ b/app/controllers/patron_controller.rb
@@ -63,11 +63,16 @@ class PatronController < ApplicationController
     end
 
     def protect
+      Rails.logger.info("Incoming patron request: IP is #{request.remote_ip}, User signed in is #{user_signed_in?}")
       if user_signed_in?
         deny_access unless current_user.catalog_admin?
       else
         ips = Rails.application.config.ip_allowlist
-        deny_access if ips.exclude?(request.remote_ip)
+        Rails.logger.info("Is IP address excluded from the allow list?: #{ips.exclude?(request.remote_ip)}")
+        if ips.exclude?(request.remote_ip)
+          deny_access
+          Rails.logger.info("Denied patron request: IP #{request.remote_ip} is not in the list: #{ips.join(', ')}")
+        end
       end
     end
 


### PR DESCRIPTION
This was in service of us better understanding an issue in which we were getting the load balancer IP addresses, rather than the catalog IP addresses, when the catalog made requests to bibdata.