### PR TITLE
Update alma gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://gems.contribsys.com/" do
   gem 'sidekiq-pro'
 end
 
-gem 'alma', github: 'tulibraries/alma_rb', branch: 'main'
+gem 'alma'
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sqs'
 gem 'bcrypt_pbkdf'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,16 +30,6 @@ GIT
   specs:
     stringex (2.5.2)
 
-GIT
-  remote: https://github.com/tulibraries/alma_rb.git
-  revision: ced77a9280053aab65dd51f2ddfa647fb859693d
-  branch: main
-  specs:
-    alma (0.5.0)
-      activesupport
-      httparty
-      xml-simple
-
 GEM
   remote: https://gems.contribsys.com/
   specs:
@@ -127,6 +117,10 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     airbrussh (1.5.2)
       sshkit (>= 1.6.1, != 1.7.0)
+    alma (0.6.1)
+      activesupport
+      httparty
+      xml-simple
     ast (2.4.2)
     autoprefixer-rails (10.4.16.0)
       execjs (~> 2)
@@ -207,7 +201,7 @@ GEM
     chronic (0.10.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     coveralls_reborn (0.28.0)
       simplecov (~> 0.22.0)
@@ -217,6 +211,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    csv (3.3.0)
     datadog-ci (0.8.3)
       msgpack
     date (3.3.4)
@@ -312,12 +307,13 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    httparty (0.21.0)
+    httparty (0.22.0)
+      csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     human_languages (0.7.0)
-    i18n (1.14.5)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     io-console (0.7.2)
@@ -378,11 +374,12 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
     minitar (0.9)
-    minitest (5.24.1)
+    minitest (5.25.1)
     mize (0.5.0)
     msgpack (1.7.2)
     multi_json (1.15.0)
-    multi_xml (0.6.0)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     multipart-post (2.3.0)
     mutex_m (0.2.0)
     net-imap (0.4.14)
@@ -500,8 +497,7 @@ GEM
     retriable (3.1.2)
     reverse_markdown (2.1.1)
       nokogiri
-    rexml (3.3.6)
-      strscan
+    rexml (3.3.8)
     rsolr (2.5.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
@@ -612,7 +608,6 @@ GEM
       sshkit (~> 1.12)
     stomp (1.4.10)
     stringio (3.1.1)
-    strscan (3.1.0)
     sync (0.5.0)
     term-ansicolor (1.10.4)
       mize (~> 0.5)
@@ -677,7 +672,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  alma!
+  alma
   aws-sdk-s3
   aws-sdk-sqs
   axe-core-api


### PR DESCRIPTION
[Recent changes break our temp location logic](https://github.com/tulibraries/alma_rb/commit/4c62bc5f521b1c64f0f1e6ae9012331d4a9d66b6#diff-1b1dc7d4180724e0b578755089331af65aee86ad4c8b1550e5b6388fd03c351bR22). We need to adrees this before updating the alma gem to 0.6.1