### PR TITLE
Deploy and test orangetheses 6a37e8d12ba9b942ba4c8305e6fb92a4062c506f

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'oj'
 gem 'omniauth-cas'
 gem 'omniauth-rails_csrf_protection'
 gem 'open3'
-gem 'orangetheses', github: 'pulibrary/orangetheses', ref: '4ac8dc2bd04b10db764fc37df3261531c9937061'
+gem 'orangetheses', github: 'pulibrary/orangetheses', ref: '6a37e8d12ba9b942ba4c8305e6fb92a4062c506f'
 gem 'pg'
 gem "rack"
 gem 'rails', '~> 7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/pulibrary/orangetheses.git
-  revision: 4ac8dc2bd04b10db764fc37df3261531c9937061
-  ref: 4ac8dc2bd04b10db764fc37df3261531c9937061
+  revision: 6a37e8d12ba9b942ba4c8305e6fb92a4062c506f
+  ref: 6a37e8d12ba9b942ba4c8305e6fb92a4062c506f
   specs:
     orangetheses (1.4.2)
       chronic
@@ -19,6 +19,7 @@ GIT
       iso-639
       nokogiri
       oai
+      psych (~> 5.1)
       retriable
       rsolr
       yaml


### PR DESCRIPTION
[Orangetheses 6a37e8d12ba9b942ba4c8305e6fb92a4062c506f](https://github.com/pulibrary/orangetheses/commit/6a37e8d12ba9b942ba4c8305e6fb92a4062c506f)

Removes holdings from Embargoes. Removes the red unavailable badge display. 

In review by @LynnDurgin 