### PR TITLE
[#2238] Updates orangetheses gem to v1.4.4.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'oj'
 gem 'omniauth-cas'
 gem 'omniauth-rails_csrf_protection'
 gem 'open3'
-gem 'orangetheses', github: 'pulibrary/orangetheses', ref: '4ac8dc2bd04b10db764fc37df3261531c9937061'
+gem 'orangetheses', github: 'pulibrary/orangetheses', tag: 'v1.4.4'
 gem 'pg'
 gem "rack"
 gem 'rails', '~> 7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/pulibrary/orangetheses.git
-  revision: 4ac8dc2bd04b10db764fc37df3261531c9937061
-  ref: 4ac8dc2bd04b10db764fc37df3261531c9937061
+  revision: 467ce444cd8fc5ee0d8abae4cfecfe11f54543b0
+  tag: v1.4.4
   specs:
     orangetheses (1.4.2)
       chronic
@@ -19,6 +19,7 @@ GIT
       iso-639
       nokogiri
       oai
+      psych (~> 5.1)
       retriable
       rsolr
       yaml


### PR DESCRIPTION
closes #2238 
closes #2237 


[#2238] Updates orangetheses gem to v1.4.4.
See release notes https://github.com/pulibrary/orangetheses/releases/tag/v1.4.4 
[#2237] Theses should not be requestable in the catalog. Remove holdings from embargoes too.