### PR TITLE
[#2528] Don't include genres in Primary Source facet if only part of the word matches

### DIFF
--- a/marc_to_solr/lib/genre.rb
+++ b/marc_to_solr/lib/genre.rb
@@ -81,7 +81,7 @@ class Genre
 
     def genre_term_indicates_primary_source?(genre)
       normalized_genre = genre.downcase.strip.delete_suffix('.')
-      primary_source_genres.any? { |primary_source_genre| normalized_genre.include? primary_source_genre }
+      primary_source_genres.any? { |primary_source_genre| normalized_genre.match?(/(^|\W)#{primary_source_genre}($|\W)/) }
     end
 
     def biography?

--- a/spec/marc_to_solr/lib/genre_spec.rb
+++ b/spec/marc_to_solr/lib/genre_spec.rb
@@ -120,6 +120,16 @@ RSpec.describe Genre do
         expect(genres).to include('Primary source')
       end
     end
+    context 'when the 650 subfield x has Computer network resources' do
+      let(:genres) do
+        g650 = { "650" => { "ind1" => " ", "ind2" => "0", "subfields" => [{ "a" => "Dating (Social customs)" }, { "x" => "Computer network resources." }] } }
+        sample_marc = MARC::Record.new_from_hash('fields' => [g650])
+        described_class.new(sample_marc).to_a
+      end
+      it 'does not include Primary Source in the list of genres' do
+        expect(genres).not_to include('Primary source')
+      end
+    end
     context 'when the 650 subfield a is Biography' do
       let(:genres) do
         g650 = { "650" => { "ind1" => " ", "ind2" => "0", "subfields" => [{ "a" => "Biography" }] } }


### PR DESCRIPTION
This fixes a bug in which a subdivision 'Computer network resources' matched against the genre 'Sources', since the word 'resources' contains the word 'sources'.

Closes #2528 