### PR TITLE
Update indexing.md

### DIFF
--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -118,7 +118,7 @@ as deploy user, in `/opt/bibdata/current`
 $ tmux attach-session -t full-index
 $ cd /opt/bibdata/current
 $ mv /home/deploy/theses.json /home/deploy/theses-<date>.json 
-$ FILEPATH=/home/deploy/theses.json bundle exec rake orangetheses:cache_theses
+$ FILEPATH=/home/deploy/theses.json RAILS_ENV=production bundle exec rake orangetheses:cache_theses
 CTRL+b d (to detach from tmux)
 ```
 


### PR DESCRIPTION
Latest changes in orangetheses, set the RAILS_ENV that points to a dspace domain accordingly.  Even though the RAILS_ENV in bibdata production is production . It is a good practice to set it when we run the rake task. 
For example when testing theses in bidbata-staging we should still run the theses rake task with RAILS_ENV=production so that it will retrieve theses from the production dspace and not the staging one.