### PR TITLE
Remove deprecation warning related to cache_format_version

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,7 @@ Bundler.require(:default, Rails.env)
 
 module MarcLiberation
   class Application < Rails::Application
+    config.active_support.cache_format_version = 7.0
     config.encoding = 'utf-8'
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers


### PR DESCRIPTION
```
DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.
```

Fixed using the steps here: https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format