### PR TITLE
Move Partner import out of Event.record

### DIFF
--- a/app/jobs/import/partner/full.rb
+++ b/app/jobs/import/partner/full.rb
@@ -3,25 +3,31 @@ module Import
     class Full
       include Sidekiq::Job
       def perform
+        FileUtils.mkdir_p(update_directory)
         delete_stale_files
-
-        Event.record do |event|
-          event.save
-          event.dump = created_dump(event)
-          event.save!
-
-          Scsb::PartnerUpdates.full(dump: event.dump)
-        end
+        event = Event.new
+        event.start = Time.now.utc
+        event.success = true
+        event.save!
+        event.dump = created_dump(event)
+        event.save!
+        Scsb::PartnerUpdates.full(dump: event.dump)
+      ensure
+        event.finish = Time.now.utc
+        event.save!
       end
 
       private
+
+        def update_directory
+          ENV.fetch('SCSB_PARTNER_UPDATE_DIRECTORY', '/tmp/updates')
+        end
 
         def created_dump(event)
           Dump.create!(dump_type: :partner_recap_full, event_id: event.id)
         end
 
         def delete_stale_files
-          update_directory = ENV.fetch('SCSB_PARTNER_UPDATE_DIRECTORY', '/tmp/updates')
           files_to_delete = Dir.glob("#{update_directory}/*.zip")
                                .concat(Dir.glob("#{update_directory}/*.xml"))
                                .concat(Dir.glob("#{update_directory}/*.csv"))

--- a/app/models/scsb/partner_updates/full.rb
+++ b/app/models/scsb/partner_updates/full.rb
@@ -37,7 +37,8 @@ module Scsb
             add_error(message: "Metadata file indicates that dump for #{inst} does not include the correct Group IDs, not processing. Group ids: #{csv['Collection Group Id(s)'].first}")
           end
           filename = File.basename(file)
-          destination_filepath = "#{@scsb_file_dir}/#{filename}"
+          scsb_file_dir = ENV['SCSB_FILE_DIR']
+          destination_filepath = "#{scsb_file_dir}/#{filename}"
           FileUtils.move(file, destination_filepath)
           attach_dump_file(destination_filepath, dump_file_type: :recap_records_full_metadata)
           File.unlink(destination_filepath) if File.exist?(destination_filepath)

--- a/spec/models/scsb/partner_updates_spec.rb
+++ b/spec/models/scsb/partner_updates_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Scsb::PartnerUpdates, type: :model do
-  include ActiveJob::TestHelper
-
   describe '.full' do
     include_context 'scsb_partner_updates_full'
     it 'maintains the same api' do

--- a/spec/services/alma/indexer_spec.rb
+++ b/spec/services/alma/indexer_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Alma::Indexer, indexing: true do
-  include ActiveJob::TestHelper
-
   let(:solr_url) { ENV.fetch('SOLR_URL', nil) || "http://#{ENV.fetch('lando_bibdata_test_solr_conn_host', nil)}:#{ENV.fetch('lando_bibdata_test_solr_conn_port', nil)}/solr/bibdata-core-test" }
 
   describe '#index_file' do

--- a/spec/services/aws_sqs_poller_spec.rb
+++ b/spec/services/aws_sqs_poller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe AwsSqsPoller do
-  include ActiveJob::TestHelper
-
   let(:poller_mock) do
     Aws::SQS::QueuePoller.new(
       'https://example.com',


### PR DESCRIPTION
- Rescuing from all errors can hide issues, also messes with Sidekiq retries
- We eventually want to mark the Event as finished and successful within the Sidekiq::Batch api using a callback, so don't want to do that in the Event.record
- Use shared setup for testing - errors are more obvious now that we've taken it out of Event.record