### PR TITLE
Remove log of record fixes

### DIFF
--- a/app/models/scsb/partner_updates/full.rb
+++ b/app/models/scsb/partner_updates/full.rb
@@ -11,7 +11,6 @@ module Scsb
         download_and_process_full(inst: 'CUL', prefix: 'scsbfull_cul_')
         download_and_process_full(inst: 'HL', prefix: 'scsbfull_hl_')
         set_generated_date
-        log_record_fixes
       end
 
       def download_and_process_full(inst:, prefix:)

--- a/app/models/scsb/partner_updates/incremental.rb
+++ b/app/models/scsb/partner_updates/incremental.rb
@@ -6,7 +6,6 @@ module Scsb
         update_files = download_partner_updates
         process_partner_updates(files: update_files)
         set_generated_date
-        log_record_fixes
         delete_files = download_partner_deletes
         process_partner_deletes(files: delete_files)
       end

--- a/spec/models/scsb/partner_updates/full_spec.rb
+++ b/spec/models/scsb/partner_updates/full_spec.rb
@@ -62,12 +62,10 @@ RSpec.describe Scsb::PartnerUpdates::Full, type: :model do
 
         # attaches marcxml and log files
         expect(dump.dump_files.where(dump_file_type: :recap_records_full).length).to eq(2)
-        expect(dump.dump_files.where(dump_file_type: :log_file).length).to eq(1)
         expect(dump.dump_files.map(&:path)).to contain_exactly(
           File.join(scsb_file_dir, 'scsbfull_nypl_20210430_015000_1.xml.gz'),
           File.join(scsb_file_dir, 'scsbfull_nypl_20210430_015000_2.xml.gz'),
-          File.join(scsb_file_dir, 'ExportDataDump_Full_NYPL_20210430_015000.csv.gz'),
-          a_string_matching(/#{scsb_file_dir}\/fixes_\d{4}_\d{2}_\d{2}.json.gz/)
+          File.join(scsb_file_dir, 'ExportDataDump_Full_NYPL_20210430_015000.csv.gz')
         )
         expect(dump.event.error).to eq 'No metadata files found matching CUL; No metadata files found matching HL'
         # cleans up

--- a/spec/models/scsb/partner_updates/incremental_spec.rb
+++ b/spec/models/scsb/partner_updates/incremental_spec.rb
@@ -14,11 +14,9 @@ RSpec.describe Scsb::PartnerUpdates::Incremental, type: :model do
 
       # attaches marcxml and log files
       expect(dump.dump_files.where(dump_file_type: :recap_records).length).to eq(2)
-      expect(dump.dump_files.where(dump_file_type: :log_file).length).to eq(1)
       expect(dump.dump_files.map(&:path)).to contain_exactly(
         File.join(scsb_file_dir, 'scsb_update_20210622_183200_1.xml.gz'),
-        File.join(scsb_file_dir, 'scsb_update_20210622_183200_2.xml.gz'),
-        a_string_matching(/#{scsb_file_dir}\/fixes_\d{4}_\d{2}_\d{2}.json.gz/)
+        File.join(scsb_file_dir, 'scsb_update_20210622_183200_2.xml.gz')
       )
 
       expect(dump.generated_date).to eq DateTime.parse('2021-06-22')


### PR DESCRIPTION
These files consist of a JSON document that lists the type of fix and the ID of the record where the fix was made and no other context.

- As far as I can tell, we never use these, and it complicates breaking the updates into separate background jobs
- rubocop