### PR TITLE
Ensure we match indigenous languages from 650 with $v Texts.

### DIFF
--- a/marc_to_solr/lib/language_extractor.rb
+++ b/marc_to_solr/lib/language_extractor.rb
@@ -11,7 +11,7 @@ class LanguageExtractor
 
   def possible_language_subject_headings
     @marc_record.fields('650')
-                .select { |field| field['v'] == 'Texts' }
+                .select { |field| field['v']&.match(/^texts/i) }
                 .map { |field| field['a'] }
   end
 

--- a/spec/marc_to_solr/lib/indigenous_languages_spec.rb
+++ b/spec/marc_to_solr/lib/indigenous_languages_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe IndigenousLanguages do
     context 'when 650 has a relevant language and $v Texts' do
       let(:fields) do
         [
-          { '650' => { 'subfields' => [{ 'a' => 'Munsee language', 'v' => 'Texts' }] } }
+          { '650' => { 'subfields' => [{ 'a' => 'Munsee language', 'v' => 'Texts.' }] } }
         ]
       end
 


### PR DESCRIPTION
Match more loosely on subfield v, since many will end with a period.

Connected to #2187