### PR TITLE
Rewrite barcode tests

### DIFF
--- a/app/controllers/barcode_controller.rb
+++ b/app/controllers/barcode_controller.rb
@@ -1,14 +1,6 @@
 class BarcodeController < ApplicationController
   include FormattingConcern
 
-  def index
-    if params[:barcode]
-      redirect_to action: :barcode, barcode: sanitized_barcode, status: :moved_permanently
-    else
-      render plain: 'Please supply a barcode.', status: :not_found
-    end
-  end
-
   # Client: This endpoint is used by the ReCAP inventory management system, LAS,
   #   to pull data from our ILS when items are accessioned
   def scsb
@@ -56,10 +48,4 @@ class BarcodeController < ApplicationController
   rescue StandardError => e
     handle_alma_exception(exception: e, message: "Error for barcode: #{barcode}")
   end
-
-  private
-
-    def sanitized_barcode
-      CGI.escape(params[:barcode])
-    end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,6 @@ Rails.application.routes.draw do
   get '/bibliographic/:bib_id/items', to: 'bibliographic#bib_items', defaults: { format: :json }
   get '/availability', to: 'availability#index', defaults: { format: :json }
 
-  get '/barcode', to: 'barcode#index', defaults: { format: :txt }
   get '/barcode/:barcode/scsb', to: 'barcode#scsb', defaults: { format: :xml }
 
   get '/patron/:patron_id', to: 'patron#patron_info', format: false, defaults: { format: :json },

--- a/spec/requests/barcode_gets_spec.rb
+++ b/spec/requests/barcode_gets_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe 'Barcode Gets', type: :request do
 
   describe 'GET /barcode/32101037077862123456/scsb' do
     it 'returns a 404 when the barcode is not a valid form' do
-      stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/items?item_barcode=32101037077862123456")
-        .to_return(status: 404, body: "", headers: {})
+      stub_request(:get, 'https://api-na.hosted.exlibrisgroup.com/almaws/v1/items?item_barcode=32101037077862123456')
+        .to_return(status: 404, body: '', headers: {})
       get '/barcode/32101037077862123456/scsb'
       expect(response.status).to be(404)
     end

--- a/spec/requests/barcode_gets_spec.rb
+++ b/spec/requests/barcode_gets_spec.rb
@@ -2,23 +2,22 @@ require 'rails_helper'
 require 'marc'
 
 RSpec.describe 'Barcode Gets', type: :request do
-  describe 'GET /barcode/32101070300312' do
-    it 'returns a collection of bibliographic records', pending: 'Replace with Alma' do
-      get '/barcode/32101070300312'
+  describe 'GET /barcode/32101076720315/scsb' do
+    it 'returns a collection of bibliographic records' do
+      stub_alma_item_barcode(mms_id: '9958708973506421', item_id: '23178060180006421', holding_id: '22178060190006421', barcode: '32101076720315')
+      stub_sru('alma.mms_id=9958708973506421', '9958708973506421')
+      stub_alma_ids(ids: '9958708973506421', status: 200, fixture: '9958708973506421')
+      stub_alma_holding(mms_id: '9958708973506421', holding_id: '22178060190006421')
+      get '/barcode/32101076720315/scsb'
       expect(response.status).to be(200)
     end
   end
 
-  describe 'GET /barcode/321010702214' do
-    it 'returns a 404 when the barcode is not a valid form', pending: 'Replace with Alma' do
-      get '/barcode/321010702214'
-      expect(response.status).to be(404)
-    end
-  end
-
-  describe 'GET /barcode/' do
-    it 'returns an error when no barcode is supplied' do
-      get '/barcode/'
+  describe 'GET /barcode/32101037077862123456/scsb' do
+    it 'returns a 404 when the barcode is not a valid form' do
+      stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/items?item_barcode=32101037077862123456")
+        .to_return(status: 404, body: "", headers: {})
+      get '/barcode/32101037077862123456/scsb'
       expect(response.status).to be(404)
     end
   end


### PR DESCRIPTION
Resolves #2577 

The tests were for a no longer used endpoint /barcode/:barcode

The controller no longer had an action associated with the route so they were removed and the tests were rewritten for the /barcode/:barcode/scsb endpoint.