### PR TITLE
[#2604] Rename Delivery location Engineering Library to STEM Circulation Services

### DIFF
--- a/config/locations/delivery_locations.json
+++ b/config/locations/delivery_locations.json
@@ -69,7 +69,7 @@
     },
     {
         "id": 5,
-        "label": "Engineering Library",
+        "label": "STEM Circulation Services",
         "address": "Friend Center for Engineering Education Princeton, NJ 08544",
         "phone_number": "609-258-3200",
         "contact_email": "englib@princeton.edu",


### PR DESCRIPTION
closes #2604 

Keep this in draft until @kevinreiss confirms we can proceed with this change.