### PR TITLE
[#2602] Lewis Library holding locations 'lewis$..' should ship to only the Engineering Location PT

### DIFF
--- a/config/locations/holding_locations.json
+++ b/config/locations/holding_locations.json
@@ -2884,7 +2884,7 @@
             "order": 0
         },
         "delivery_locations": [
-            "PN"
+            "PT"
         ]
     },
     {
@@ -2910,7 +2910,7 @@
             "order": 0
         },
         "delivery_locations": [
-            "PN"
+            "PT"
         ]
     },
     {
@@ -2932,7 +2932,7 @@
         },
         "holding_library": null,
         "delivery_locations": [
-            "PN"
+            "PT"
         ]
     },
     {
@@ -2994,7 +2994,7 @@
         },
         "holding_library": null,
         "delivery_locations": [
-            "PN"
+            "PT"
         ]
     },
     {
@@ -3196,24 +3196,7 @@
         },
         "holding_library": null,
         "delivery_locations": [
-            "PQ",
-            "PW",
-            "PL",
-            "PT",
-            "PF",
-            "PJ",
-            "PK",
-            "PH",
-            "PM",
-            "PG",
-            "PN",
-            "PA",
-            "IL",
-            "QL",
-            "PS",
-            "PZ",
-            "QK",
-            "PB"
+            "PT"
         ]
     },
     {
@@ -3281,7 +3264,7 @@
         "delivery_locations": [
             "QT",
             "QA",
-            "PN",
+            "PT",
             "QC",
             "QP"
         ]
@@ -3313,7 +3296,8 @@
             "QA",
             "QC",
             "PS",
-            "QP"
+            "QP",
+            "PT"
         ]
     },
     {
@@ -3335,7 +3319,7 @@
         },
         "holding_library": null,
         "delivery_locations": [
-            "PN"
+            "PT"
         ]
     },
     {
@@ -3417,7 +3401,7 @@
         },
         "holding_library": null,
         "delivery_locations": [
-            "PN"
+            "PT"
         ]
     },
     {
@@ -3439,7 +3423,7 @@
         },
         "holding_library": null,
         "delivery_locations": [
-            "PN"
+            "PT"
         ]
     },
     {
@@ -3481,7 +3465,7 @@
         },
         "holding_library": null,
         "delivery_locations": [
-            "PN"
+            "PT"
         ]
     },
     {


### PR DESCRIPTION
closes #2602 


@kevinreiss can you please:

1.  review the lewis locations that have no delivery locations if we need to add 'PT' there as well?
2. Also: 
      - [`lewis$nb`](https://github.com/pulibrary/bibdata/pull/2609#discussion_r1927139441) has more than one delivery locations. I'm assuming this stays the same and only PN is removed and PT is added?
      - Same question for [`lewis$pn`](https://github.com/pulibrary/bibdata/pull/2609#discussion_r1927138061)