### PR TITLE
Do not run test that is flaky in CI

### DIFF
--- a/spec/jobs/import/partner/process_xml_file_job_spec.rb
+++ b/spec/jobs/import/partner/process_xml_file_job_spec.rb
@@ -15,16 +15,17 @@ RSpec.describe Import::Partner::ProcessXmlFileJob do
     allow(File).to receive(:unlink)
   end
 
-  if ENV['CI']
-    let(:performance_time) { 165 }
-  else
-    let(:performance_time) { 75 }
-  end
   let(:large_xml_file) { Rails.root.join('spec/fixtures/scsb_updates/several_records.xml').to_s }
 
-  it 'is reasonably performant' do
-    expect do
+  if ENV['CI']
+    it 'is can run the job' do
       described_class.perform_async(dump.id, large_xml_file)
-    end.to perform_under(performance_time).ms.sample(10).times
+    end
+  else
+    it 'is reasonably performant' do
+      expect do
+        described_class.perform_async(dump.id, large_xml_file)
+      end.to perform_under(75).ms.sample(10).times
+    end
   end
 end


### PR DESCRIPTION
- This test was originally for performance, and it is too dependent on uncontrolled factors on CircleCI for it to make sense to run in CI

Closes #2593