### PR TITLE
Move Numismatics indexing to background job

### DIFF
--- a/app/jobs/index/numismatics_batch_job.rb
+++ b/app/jobs/index/numismatics_batch_job.rb
@@ -1,0 +1,10 @@
+module Index
+  class NumismaticsBatchJob
+    include Sidekiq::Worker
+
+    def perform(solr_url, solr_docs)
+      indexer = NumismaticsIndexer.new(solr_connection: RSolr.connect(url: solr_url), progressbar: false, logger: Rails.logger)
+      indexer.index_in_chunks(solr_docs)
+    end
+  end
+end

--- a/app/jobs/index/numismatics_job.rb
+++ b/app/jobs/index/numismatics_job.rb
@@ -1,0 +1,19 @@
+module Index
+  class NumismaticsJob
+    include Sidekiq::Worker
+
+    def perform(solr_url = IndexManager.rebuild_solr_url, chunk_size = 500)
+      batch = Sidekiq::Batch.new
+      batch.description = 'Numismatics indexing batch'
+      batch.jobs do
+        NumismaticsIndexer.new(
+          solr_connection: RSolr.connect(url: solr_url),
+          progressbar: false,
+          logger: Rails.logger
+        ).solr_documents.each_slice(chunk_size) do |docs|
+          NumismaticsBatchJob.perform_async(solr_url, docs)
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/index/numismatics_job.rb
+++ b/app/jobs/index/numismatics_job.rb
@@ -5,6 +5,7 @@ module Index
     def perform(solr_url = IndexManager.rebuild_solr_url, chunk_size = 500)
       batch = Sidekiq::Batch.new
       batch.description = 'Numismatics indexing batch'
+      batch.on(:success, NumismaticsJob, solr_url:)
       batch.jobs do
         NumismaticsIndexer.new(
           solr_connection: RSolr.connect(url: solr_url),
@@ -14,6 +15,12 @@ module Index
           NumismaticsBatchJob.perform_async(solr_url, docs)
         end
       end
+    end
+
+    def on_success(_status, options)
+      solr_connection = RSolr.connect(url: options['solr_url'])
+      # soft commit to avoid timeouts
+      solr_connection.commit(commit_attributes: { waitSearcher: false })
     end
   end
 end

--- a/app/services/numismatics_indexer.rb
+++ b/app/services/numismatics_indexer.rb
@@ -15,6 +15,12 @@ class NumismaticsIndexer
 
   def full_index
     solr_documents.each_slice(500) do |docs|
+      index_in_chunks(docs)
+    end
+  end
+
+  def index_in_chunks(docs)
+    begin
       solr_connection.add(docs)
     rescue RSolr::Error::Http => e
       logger.warn("Failed to index batch, retrying individually, error was: #{e.class}: #{e.message.strip}")

--- a/app/services/numismatics_indexer.rb
+++ b/app/services/numismatics_indexer.rb
@@ -17,17 +17,15 @@ class NumismaticsIndexer
     solr_documents.each_slice(500) do |docs|
       index_in_chunks(docs)
     end
+    # soft commit to avoid timeouts
+    solr_connection.commit(commit_attributes: { waitSearcher: false })
   end
 
   def index_in_chunks(docs)
-    begin
-      solr_connection.add(docs)
-    rescue RSolr::Error::Http => e
-      logger.warn("Failed to index batch, retrying individually, error was: #{e.class}: #{e.message.strip}")
-      index_individually(docs)
-    end
-    # soft commit to avoid timeouts
-    solr_connection.commit(commit_attributes: { waitSearcher: false })
+    solr_connection.add(docs)
+  rescue RSolr::Error::Http => e
+    logger.warn("Failed to index batch, retrying individually, error was: #{e.class}: #{e.message.strip}")
+    index_individually(docs)
   end
 
   # index a batch of records one at a time, logging and continuing on error

--- a/lib/tasks/orangeindex.rake
+++ b/lib/tasks/orangeindex.rake
@@ -161,7 +161,7 @@ namespace :numismatics do
     desc 'Index all the complete, open numismatic coins from figgy'
     task full: :environment do
       solr_url = ENV.fetch('SET_URL', nil) || default_solr_url
-      NumismaticsIndexer.full_index(solr_url:, progressbar: true)
+      Index::NumismaticsJob.perform_async(solr_url)
     end
   end
 end

--- a/spec/jobs/index/numismatics_job_spec.rb
+++ b/spec/jobs/index/numismatics_job_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe Index::NumismaticsJob do
+  let(:solr_url) { ENV.fetch('SOLR_URL', nil) || "http://#{ENV.fetch('lando_bibdata_test_solr_conn_host', nil)}:#{ENV.fetch('lando_bibdata_test_solr_conn_port', nil)}/solr/bibdata-core-test" }
+
+  before do
+    stub_search_page(page: 1)
+    stub_search_page(page: 2)
+    stub_figgy_record(id: '8be8980d-20b8-454e-9431-1aa5bcb89fde')
+    stub_figgy_record(id: 'bfd72e8a-817f-4412-a7fa-e38047e17c29')
+    stub_figgy_record(id: '92fa663d-5758-4b20-8945-cf5a34458e6e')
+    stub_figgy_record(id: '62b33c0d-d43a-44fd-a035-6490d25a2132')
+    stub_figgy_record(id: 'd827dc9f-e857-4868-b056-34fc92894e4e')
+    stub_figgy_record(id: '84220cd5-0815-4f01-82a3-704a15835e77')
+  end
+
+  around do |example|
+    Sidekiq::Testing.inline! do
+      Sidekiq::Testing.server_middleware do |chain|
+        chain.add Sidekiq::Batch::Server
+      end
+      example.run
+      Sidekiq::Testing.server_middleware do |chain|
+        chain.remove Sidekiq::Batch::Server
+      end
+    end
+  end
+
+  context 'with many Solr documents' do
+    let(:numismatics_indexer) { NumismaticsIndexer.new(solr_connection: RSolr.connect(url: solr_url), progressbar: false, logger: Rails.logger) }
+
+    before do
+      allow(NumismaticsIndexer).to receive(:new).and_return(numismatics_indexer)
+    end
+
+    it 'enqueues a job for each batch of Solr documents' do
+      allow(Index::NumismaticsBatchJob).to receive(:perform_async).and_call_original
+      allow(numismatics_indexer).to receive(:index_in_chunks).and_call_original
+      described_class.perform_async(solr_url, 2)
+      expect(Index::NumismaticsBatchJob).to have_received(:perform_async).exactly(3).times
+      expect(numismatics_indexer).to have_received(:index_in_chunks).exactly(3).times
+    end
+  end
+
+  it 'logs to the rails logger' do
+    stub_figgy_record_error(id: '92fa663d-5758-4b20-8945-cf5a34458e6e')
+
+    allow(Rails.logger).to receive(:warn)
+    described_class.perform_async(solr_url)
+    expect(Rails.logger).to have_received(:warn)
+  end
+
+  def stub_figgy_record(id:)
+    url = "https://figgy.princeton.edu/concern/numismatics/coins/#{id}/orangelight"
+    stub_request(:get, url).to_return(body: file_fixture("numismatics/#{id}.json"))
+  end
+
+  def stub_figgy_record_error(id:)
+    url = "https://figgy.princeton.edu/concern/numismatics/coins/#{id}/orangelight"
+    stub_request(:get, url).to_return(status: 502)
+  end
+
+  def stub_search_page(page:)
+    url = "https://figgy.princeton.edu/catalog.json?f%5Bhuman_readable_type_ssim%5D%5B%5D=Coin&f%5Bstate_ssim%5D%5B%5D=complete&f%5Bvisibility_ssim%5D%5B%5D=open&per_page=100&q=&page=#{page}"
+    stub_request(:get, url).to_return(body: file_fixture("numismatics/search_page_#{page}.json"))
+  end
+end

--- a/spec/services/numismatics_indexer_spec.rb
+++ b/spec/services/numismatics_indexer_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe NumismaticsIndexer do
         solr_connection.commit
 
         # raise for the first set, allow the first individual retry, raise for
-        # the second in dividual retry, allow all the rest
+        # the second individual retry, allow all the rest
         responses = %i[raise call raise]
         allow(solr_connection).to receive(:add).and_wrap_original do |original, *args|
           v = responses.shift


### PR DESCRIPTION
Create a batch of background jobs to index Solr documents, commit after all documents have been added to Solr.

Making sure RabbitMQ is turned off / back on for production will still have to be done manually.

Closes #2543