### PR TITLE
Add new lc_subject_facet field.

### DIFF
--- a/marc_to_solr/lib/princeton_marc.rb
+++ b/marc_to_solr/lib/princeton_marc.rb
@@ -287,6 +287,13 @@ def process_hierarchy(record, fields)
   end.compact
 end
 
+def accumulate_subheading(heading_split_on_separator)
+  heading_split_on_separator.reduce([]) do |accumulator, subheading|
+    # accumulator.last ? "#{accumulator.last}#{SEPARATOR}#{subsubject}" : subsubject
+    accumulator.append([accumulator.last, subheading].compact.join(SEPARATOR))
+  end
+end
+
 # for the split subject facet
 # split with em dash along x,z
 def process_subject_topic_facet record

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -935,6 +935,19 @@ to_field 'subject_facet' do |record, accumulator|
   accumulator.replace([subjects, additional_subject_thesauri, genres].flatten)
 end
 
+# used for the Browse lists and hierarchical subject facet
+# used on the Details section in the record page to search for LC subject headings and their subdivisions using
+# the facet[lc_subject_facet] field
+to_field 'lc_subject_facet' do |record, accumulator|
+  lc_subjects = process_hierarchy(record, '600|*0|abcdfklmnopqrtvxyz:610|*0|abfklmnoprstvxyz:611|*0|abcdefgklnpqstvxyz:630|*0|adfgklmnoprstvxyz:650|*0|abcvxyz:651|*0|avxyz')
+  lc_subjects = augment_the_subject.add_indigenous_studies(lc_subjects)
+  lc_subjects = ChangeTheSubject.fix(subject_terms: lc_subjects)
+  lc_subjects_split_on_separator = lc_subjects.join.split(SEPARATOR)
+  lc_subjects_with_subheadings = accumulate_subheading(lc_subjects_split_on_separator)
+
+  accumulator.replace(lc_subjects_with_subheadings)
+end
+
 # See https://github.com/traject/traject/blob/main/lib/traject/macros/marc21_semantics.rb#L435
 to_field 'geographic_facet', marc_geo_facet
 

--- a/spec/fixtures/marc_to_solr/99125394249206421.mrx
+++ b/spec/fixtures/marc_to_solr/99125394249206421.mrx
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection>
+  <record>
+    <leader>02407nam a2200433 i 4500</leader>
+    <controlfield tag="005">20240718134414.0</controlfield>
+    <controlfield tag="008">210511s2021    ru a          000 0brus d</controlfield>
+    <controlfield tag="001">99125394249206421</controlfield>
+    <datafield tag="020" ind1=" " ind2=" ">
+      <subfield code="a">9785910224722</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="9">(RuMoNKB)1195770</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(OCoLC)on1252714400</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+      <subfield code="a">RuMoNKB</subfield>
+      <subfield code="b">eng</subfield>
+      <subfield code="e">rda</subfield>
+      <subfield code="c">RuMoNKB</subfield>
+    </datafield>
+    <datafield tag="041" ind1="0" ind2=" ">
+      <subfield code="a">rus</subfield>
+      <subfield code="b">eng</subfield>
+      <subfield code="b">dan</subfield>
+      <subfield code="b">ger</subfield>
+      <subfield code="b">ita</subfield>
+    </datafield>
+    <datafield tag="043" ind1=" " ind2=" ">
+      <subfield code="a">e-ur---</subfield>
+      <subfield code="a">e-ru---</subfield>
+    </datafield>
+    <datafield tag="050" ind1=" " ind2="4">
+      <subfield code="a">ML422.V43</subfield>
+      <subfield code="b">C44 2021</subfield>
+    </datafield>
+    <datafield tag="066" ind1=" " ind2=" ">
+      <subfield code="c">(N</subfield>
+    </datafield>
+    <datafield tag="100" ind1="1" ind2=" ">
+      <subfield code="6">880-01</subfield>
+      <subfield code="a">Cherëmushkin, Pëtr</subfield>
+      <subfield code="q">(Pëtr Germanovich),</subfield>
+      <subfield code="e">author.</subfield>
+    </datafield>
+    <datafield tag="880" ind1="1" ind2=" ">
+      <subfield code="6">100-01</subfield>
+      <subfield code="a">Черёмушкин, Пётр</subfield>
+      <subfield code="q">(Пётр Германович),</subfield>
+      <subfield code="e">author.</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="0">
+      <subfield code="6">880-02</subfield>
+      <subfield code="a">Aleksandr Vedernikov, glavnyĭ dirizher /</subfield>
+      <subfield code="c">Pëtr Cherëmushkin.</subfield>
+    </datafield>
+    <datafield tag="880" ind1="1" ind2="0">
+      <subfield code="6">245-02</subfield>
+      <subfield code="a">Александр Ведерников, главный дирижер /</subfield>
+      <subfield code="c">Пётр Черёмушкин.</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="1">
+      <subfield code="6">880-03</subfield>
+      <subfield code="a">Moskva :</subfield>
+      <subfield code="b">AIRO-XXI,</subfield>
+      <subfield code="c">2021.</subfield>
+    </datafield>
+    <datafield tag="880" ind1=" " ind2="1">
+      <subfield code="6">264-03</subfield>
+      <subfield code="a">Москва :</subfield>
+      <subfield code="b">АИРО-XXI,</subfield>
+      <subfield code="c">2021.</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+      <subfield code="a">183 pages :</subfield>
+      <subfield code="b">illustrations (chiefly color) ;</subfield>
+      <subfield code="c">30 cm</subfield>
+    </datafield>
+    <datafield tag="336" ind1=" " ind2=" ">
+      <subfield code="a">text</subfield>
+      <subfield code="b">txt</subfield>
+      <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield tag="336" ind1=" " ind2=" ">
+      <subfield code="a">still image</subfield>
+      <subfield code="b">sti</subfield>
+      <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield tag="337" ind1=" " ind2=" ">
+      <subfield code="a">unmediated</subfield>
+      <subfield code="b">n</subfield>
+      <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield tag="338" ind1=" " ind2=" ">
+      <subfield code="a">volume</subfield>
+      <subfield code="b">nc</subfield>
+      <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield tag="546" ind1=" " ind2=" ">
+      <subfield code="a">Summary in English, Danish, German and Italian.</subfield>
+    </datafield>
+    <datafield tag="600" ind1="1" ind2="0">
+      <subfield code="a">Vedernikov, A. (Aleksandr)</subfield>
+    </datafield>
+    <datafield tag="610" ind1="2" ind2="0">
+      <subfield code="a">Bolʹshoĭ teatr Rossii.</subfield>
+      <subfield code="b">Orkestr</subfield>
+    </datafield>
+    <datafield tag="610" ind1="2" ind2="0">
+      <subfield code="a">Bolshoĭ teatr Rossii</subfield>
+      <subfield code="x">History.</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="0">
+      <subfield code="a">Conductors (Music)</subfield>
+      <subfield code="z">Russia (Federation)</subfield>
+      <subfield code="v">Biography.</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="0">
+      <subfield code="a">Conductors (Music)</subfield>
+      <subfield code="z">Soviet Union</subfield>
+      <subfield code="v">Biography.</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="0">
+      <subfield code="a">Musicians, Russian</subfield>
+      <subfield code="v">Biography.</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+      <subfield code="c">F1301mon</subfield>
+    </datafield>
+    <datafield tag="914" ind1=" " ind2=" ">
+      <subfield code="a">(OCoLC)on1252714400</subfield>
+      <subfield code="b">OCoLC</subfield>
+      <subfield code="c">match</subfield>
+      <subfield code="d">20240717</subfield>
+      <subfield code="e">processed</subfield>
+      <subfield code="f">1252714400</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">20210811</subfield>
+      <subfield code="b">RuMoNKB</subfield>
+      <subfield code="f">NPRA1447</subfield>
+      <subfield code="i">39.00</subfield>
+      <subfield code="j">31.20</subfield>
+      <subfield code="n">11957701447</subfield>
+    </datafield>
+    <datafield tag="982" ind1=" " ind2=" ">
+      <subfield code="b">FY22</subfield>
+      <subfield code="c">rcppa</subfield>
+      <subfield code="n">2022</subfield>
+      <subfield code="q">32101108804400</subfield>
+    </datafield>
+    <datafield tag="986" ind1=" " ind2=" ">
+      <subfield code="h">ML422.V43</subfield>
+      <subfield code="i">C44 2021</subfield>
+    </datafield>
+    <datafield tag="950" ind1=" " ind2=" ">
+      <subfield code="c">2024-07-18 13:44:14 US/Eastern</subfield>
+      <subfield code="b">2021-09-22 20:51:56 US/Eastern</subfield>
+      <subfield code="a">false</subfield>
+    </datafield>
+    <datafield tag="852" ind1="0" ind2=" ">
+      <subfield code="b">recap</subfield>
+      <subfield code="c">pa</subfield>
+      <subfield code="h">ML422.V43</subfield>
+      <subfield code="i">C44 2021q</subfield>
+      <subfield code="8">22901505800006421</subfield>
+    </datafield>
+    <datafield tag="952" ind1=" " ind2=" ">
+      <subfield code="d">2021-11-01 14:24:25</subfield>
+      <subfield code="8">22901505800006421</subfield>
+      <subfield code="a">2021-09-23 00:52:11</subfield>
+      <subfield code="b">ReCAP</subfield>
+      <subfield code="c">rcppa: RECAP</subfield>
+      <subfield code="e">false</subfield>
+    </datafield>
+    <datafield tag="876" ind1=" " ind2=" ">
+      <subfield code="0">22901505800006421</subfield>
+      <subfield code="a">23901505790006421</subfield>
+      <subfield code="j">1</subfield>
+      <subfield code="z">pa</subfield>
+      <subfield code="d">2021-09-22 20:52:11 US/Eastern</subfield>
+      <subfield code="p">32101108804400</subfield>
+      <subfield code="y">recap</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/spec/fixtures/marc_to_solr/9933506421.mrx
+++ b/spec/fixtures/marc_to_solr/9933506421.mrx
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection>
+  <record>
+    <leader>01356cam a2200313Ia 4500</leader>
+    <controlfield tag="005">20240826143147.0</controlfield>
+    <controlfield tag="008">890815s1988    it       r    001 0 ita d</controlfield>
+    <controlfield tag="001">9933506421</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(NjP)3</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(CStRLIN)NJPGRRP-B</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(NjP)3-princetondb</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="z">(NjP)Voyager3</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(OCoLC)ocm19590730</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+      <subfield code="a">IUL</subfield>
+      <subfield code="b">eng</subfield>
+      <subfield code="c">IUL</subfield>
+      <subfield code="d">OCL</subfield>
+    </datafield>
+    <datafield tag="043" ind1=" " ind2=" ">
+      <subfield code="a">e-it---</subfield>
+    </datafield>
+    <datafield tag="050" ind1=" " ind2="4">
+      <subfield code="a">Z342</subfield>
+      <subfield code="b">.M47 1988</subfield>
+    </datafield>
+    <datafield tag="100" ind1="1" ind2=" ">
+      <subfield code="a">Messina, Claudio M.</subfield>
+      <subfield code="0">http://id.loc.gov/authorities/names/nr88005576</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="0">
+      <subfield code="a">Guida ragionata alle librerie antiquarie e d'occasione d'Italia, 1989 /</subfield>
+      <subfield code="c">Claudio M. Messina; con uno scritto di Umberto Eco.</subfield>
+    </datafield>
+    <datafield tag="250" ind1=" " ind2=" ">
+      <subfield code="a">2. ed.</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="a">Roma :</subfield>
+      <subfield code="b">Biblioteca del Vascello, Stampa Alternativa,</subfield>
+      <subfield code="c">1988.</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+      <subfield code="a">220 p. ;</subfield>
+      <subfield code="c">17 cm.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+      <subfield code="a">Includes index.</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="0">
+      <subfield code="a">Booksellers and bookselling</subfield>
+      <subfield code="z">Italy</subfield>
+      <subfield code="v">Directories.</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+      <subfield code="a">Directories.</subfield>
+      <subfield code="2">lcgft</subfield>
+      <subfield code="0">http://id.loc.gov/authorities/genreForms/gf2014026087</subfield>
+    </datafield>
+    <datafield tag="773" ind1="0" ind2=" ">
+      <subfield code="t">Multi-title collection including Alpaslanʾdan Atatürkʾe kadar Türk zaferlerleri ansiklopedisi and 12 other(s).</subfield>
+      <subfield code="w">99125040713506421</subfield>
+    </datafield>
+    <datafield tag="914" ind1=" " ind2=" ">
+      <subfield code="a">(OCoLC)ocm19590730</subfield>
+      <subfield code="b">OCoLC</subfield>
+      <subfield code="c">match</subfield>
+      <subfield code="d">20240306</subfield>
+      <subfield code="e">processed</subfield>
+      <subfield code="f">19590730</subfield>
+    </datafield>
+    <datafield tag="950" ind1=" " ind2=" ">
+      <subfield code="c">2023-11-18 21:46:00 US/Eastern</subfield>
+      <subfield code="b">2021-07-13 08:24:19 US/Eastern</subfield>
+      <subfield code="a">false</subfield>
+    </datafield>
+    <datafield tag="956" ind1="4" ind2="2">
+      <subfield code="u">http://d-nb.info/991834119/04</subfield>
+      <subfield code="3">Inhaltsverzeichnis</subfield>
+    </datafield>
+    <datafield tag="999" ind1=" " ind2=" ">
+      <subfield code="a">3</subfield>
+    </datafield>
+    <datafield tag="950" ind1=" " ind2=" ">
+      <subfield code="c">2024-11-11 18:57:02 US/Eastern</subfield>
+      <subfield code="b">2021-07-13 08:24:19 US/Eastern</subfield>
+      <subfield code="a">false</subfield>
+    </datafield>
+    <datafield tag="852" ind1="0" ind2=" ">
+      <subfield code="b">rare</subfield>
+      <subfield code="c">xc</subfield>
+      <subfield code="h">Z342</subfield>
+      <subfield code="i">.M48 1988</subfield>
+      <subfield code="8">22740186070006421</subfield>
+    </datafield>
+    <datafield tag="952" ind1=" " ind2=" ">
+      <subfield code="a">2021-07-13 12:24:19</subfield>
+      <subfield code="8">22740186070006421</subfield>
+      <subfield code="b">Special Collections</subfield>
+      <subfield code="c">rcpxc: Cotsen Remote Storage (ReCAP)</subfield>
+      <subfield code="e">false</subfield>
+    </datafield>
+    <datafield tag="852" ind1="0" ind2="0">
+      <subfield code="b">recap</subfield>
+      <subfield code="c">pa</subfield>
+      <subfield code="h">Z342</subfield>
+      <subfield code="i">.M48 1988</subfield>
+      <subfield code="8">22740186090006421</subfield>
+    </datafield>
+    <datafield tag="952" ind1=" " ind2=" ">
+      <subfield code="a">2021-07-13 12:24:19</subfield>
+      <subfield code="8">22740186090006421</subfield>
+      <subfield code="b">ReCAP</subfield>
+      <subfield code="c">rcppa: RECAP</subfield>
+      <subfield code="e">false</subfield>
+    </datafield>
+    <datafield tag="876" ind1=" " ind2=" ">
+      <subfield code="0">22740186070006421</subfield>
+      <subfield code="a">23740186060006421</subfield>
+      <subfield code="j">1</subfield>
+      <subfield code="z">xc</subfield>
+      <subfield code="d">2010-01-06 19:00:00 US/Eastern</subfield>
+      <subfield code="p">32101070543648</subfield>
+      <subfield code="t">1</subfield>
+      <subfield code="y">rare</subfield>
+    </datafield>
+    <datafield tag="876" ind1=" " ind2=" ">
+      <subfield code="0">22740186090006421</subfield>
+      <subfield code="a">23740186080006421</subfield>
+      <subfield code="j">1</subfield>
+      <subfield code="z">pa</subfield>
+      <subfield code="d">2000-06-12 20:00:00 US/Eastern</subfield>
+      <subfield code="p">32101085875258</subfield>
+      <subfield code="t">1</subfield>
+      <subfield code="y">recap</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -90,6 +90,8 @@ describe 'From traject_config.rb', indexing: true do
       @indigenous_studies_mexico = @indexer.map_record(fixture_record('99125398364906421'))
       @dissertation_with_embargo = @indexer.map_record(fixture_record('99127127233306421'))
       @diary = @indexer.map_record(fixture_record('99117267623506421'))
+      @lc_subject_facet = @indexer.map_record(fixture_record('9933506421'))
+      @lc_subject_facet2 = @indexer.map_record(fixture_record('99125394249206421'))
     end
 
     describe 'alma loading' do
@@ -1271,6 +1273,35 @@ describe 'From traject_config.rb', indexing: true do
           expect(@local_subject_heading['lc_subject_display']).to include("Undocumented immigrants#{SEPARATOR}Europe")
           expect(@local_subject_heading['local_subject_display']).to eq(["Undocumented immigrants#{SEPARATOR}Europe"])
           expect(@siku_subject_headings['siku_subject_display']).to match_array(['Zi bu—Zhu jia lei—Jidu jiao zhi shu', '子部—諸家類—基督教之屬', 'Zi bu—Tian wen suan fa lei—Li fa.', '子部—天文算法類—曆法.'])
+        end
+      end
+
+      describe 'lc_subject_facet' do
+        # @lc_subject_facet "lc_subject_facet": [
+        #     "Booksellers and bookselling—Italy—Directories",
+        #     "Booksellers and bookselling-Italy",
+        #     "Booksellers and bookselling"
+        #   ]
+
+        # @lc_subject_facet2 "lc_subject_facet": [
+        # ["Vedernikov, A. (Aleksandr)Bolʹshoĭ teatr Rossii OrkestrBolshoĭ teatr Rossii",
+        # "Vedernikov, A. (Aleksandr)Bolʹshoĭ teatr Rossii OrkestrBolshoĭ teatr Rossii—HistoryConductors (Music)",
+        # "Vedernikov, A. (Aleksandr)Bolʹshoĭ teatr Rossii OrkestrBolshoĭ teatr Rossii—HistoryConductors (Music)—Russia (Federation)",
+        # "Vedernikov, A. (Aleksandr)Bolʹshoĭ teatr Rossii OrkestrBolshoĭ teatr Rossii—HistoryConductors (Music)—Russia (Federation)—BiographyConductors (Music)",
+        # "Vedernikov, A. (Aleksandr)Bolʹshoĭ teatr Rossii OrkestrBolshoĭ teatr Rossii—HistoryConductors (Music)—Russia (Federation)—BiographyConductors (Music)—Soviet Union",
+        # "Vedernikov, A. (Aleksandr)Bolʹshoĭ teatr Rossii OrkestrBolshoĭ teatr Rossii—HistoryConductors (Music)—Russia (Federation)—BiographyConductors (Music)—Soviet Union—BiographyMusicians, Russian",
+        #  "Vedernikov, A. (Aleksandr)Bolʹshoĭ teatr Rossii OrkestrBolshoĭ teatr Rossii—HistoryConductors (Music)—Russia (Federation)—BiographyConductors (Music)—Soviet Union—BiographyMusicians, Russian—Biography"]
+        it 'includes all lc subjects in lc_subject_facet' do
+          expect(@lc_subject_facet['lc_subject_facet']).to include('Booksellers and bookselling—Italy—Directories')
+        end
+
+        it 'includes the subdivisions in the lc_subject_facet' do
+          expect(@lc_subject_facet['lc_subject_facet']).to include('Booksellers and bookselling—Italy')
+          expect(@lc_subject_facet['lc_subject_facet']).to include('Booksellers and bookselling')
+          expect(@lc_subject_facet2['lc_subject_facet']).to include('Vedernikov, A. (Aleksandr)Bolʹshoĭ teatr Rossii OrkestrBolshoĭ teatr Rossii')
+          expect(@lc_subject_facet2['lc_subject_facet']).to include('Vedernikov, A. (Aleksandr)Bolʹshoĭ teatr Rossii OrkestrBolshoĭ teatr Rossii—HistoryConductors (Music)')
+          expect(@lc_subject_facet2['lc_subject_facet']).to include('Vedernikov, A. (Aleksandr)Bolʹshoĭ teatr Rossii OrkestrBolshoĭ teatr Rossii—HistoryConductors (Music)—Russia (Federation)')
+          expect(@lc_subject_facet2['lc_subject_facet']).to include('Vedernikov, A. (Aleksandr)Bolʹshoĭ teatr Rossii OrkestrBolshoĭ teatr Rossii—HistoryConductors (Music)—Russia (Federation)—BiographyConductors (Music)')
         end
       end
 


### PR DESCRIPTION
Helps with the vocabulary work https://github.com/pulibrary/orangelight/pull/3386 In this new field we index only the lc subject heading and the subdivisions So that when the user searches using the Details section, they can query solr for all the subject headings and their divisions.

This is needed for the Subject browse Vocabulary work.

example:
"lc_subject_facet": [
             "Booksellers and bookselling—Italy—Directories",
             "Booksellers and bookselling-Italy",
             "Booksellers and bookselling"
              ]