### PR TITLE
Add new facet fields that will be used for the subject browse table and the facet search

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -892,8 +892,32 @@ to_field 'siku_subject_display' do |record, accumulator|
   accumulator.replace(subjects)
 end
 
+# used for the Browse lists and hierarchical subject facet
+# used in the record page -> Details section to search for Siku subject headings and their subdivisions using
+# the facet[siku_subject_facet] field
+to_field 'siku_subject_facet' do |record, accumulator|
+  subjects = accumulate_hierarchy_per_field(record, '650|*7|abcvxyz') { |field| siku_heading? field }
+  accumulator.replace(subjects)
+end
+
 to_field 'local_subject_display' do |record, accumulator|
   subjects = process_hierarchy(record, '650|*7|abcvxyz') { |field| local_heading? field }
+  accumulator.replace(subjects)
+end
+
+# used for the Browse lists and hierarchical subject facet
+# used in the record page -> Details section to search for Local subject headings and their subdivisions using
+# the facet[local_subject_facet] field
+to_field 'local_subject_facet' do |record, accumulator|
+  subjects = accumulate_hierarchy_per_field(record, '650|*7|abcvxyz') { |field| local_heading? field }
+  accumulator.replace(subjects)
+end
+
+# used for the Browse lists and hierarchical subject facet
+# used in the record page -> Details section to search for homoit subject headings and their subdivisions using
+# the facet[homoit_subject_facet] field
+to_field 'homoit_subject_facet' do |record, accumulator|
+  subjects = accumulate_hierarchy_per_field(record, '650|*7|avxyz') { |field| any_thesaurus_match?(field, %w[homoit]) }
   accumulator.replace(subjects)
 end
 
@@ -936,7 +960,7 @@ to_field 'subject_facet' do |record, accumulator|
 end
 
 # used for the Browse lists and hierarchical subject facet
-# used on the Details section in the record page to search for LC subject headings and their subdivisions using
+# used in the record page -> Details section to search for LC subject headings and their subdivisions using
 # the facet[lc_subject_facet] field
 to_field 'lc_subject_facet' do |record, accumulator|
   lc_subjects = accumulate_hierarchy_per_field(record, '600|*0|abcdfklmnopqrtvxyz:610|*0|abfklmnoprstvxyz:611|*0|abcdefgklnpqstvxyz:630|*0|adfgklmnoprstvxyz:650|*0|abcvxyz:651|*0|avxyz')
@@ -954,8 +978,24 @@ to_field 'homoit_genre_s' do |record, accumulator|
   accumulator.replace(genres)
 end
 
+# used for the Browse lists and hierarchical subject facet
+# used in the record page -> Details section to search for homoit genre headings and their subdivisions using
+# the facet[homoit_genre_facet] field
+to_field 'homoit_genre_facet' do |record, accumulator|
+  genres = accumulate_hierarchy_per_field(record, '655|*7|avxyz') { |field| any_thesaurus_match? field, %w[homoit] }
+  accumulator.replace(genres)
+end
+
 to_field 'lcgft_s' do |record, accumulator|
   genres = process_hierarchy(record, '655|*7|avxyz') { |field| any_thesaurus_match? field, %w[lcgft] }
+  accumulator.replace(genres)
+end
+
+# used for the Browse lists and hierarchical subject facet
+# used in the record page -> Details section to search for LC genre headings and their subdivisions using
+# the facet[lcgft_genre_facet] field
+to_field 'lcgft_genre_facet' do |record, accumulator|
+  genres = accumulate_hierarchy_per_field(record, '655|*7|avxyz') { |field| any_thesaurus_match? field, %w[lcgft] }
   accumulator.replace(genres)
 end
 
@@ -964,8 +1004,24 @@ to_field 'aat_s' do |record, accumulator|
   accumulator.replace(genres)
 end
 
+# used for the Browse lists and hierarchical subject facet
+# used in the record page -> Details section to search for AAT genre headings and their subdivisions using
+# the facet[aat_genre_facet] field
+to_field 'aat_genre_facet' do |record, accumulator|
+  genres = accumulate_hierarchy_per_field(record, '655|*7|avxyz') { |field| any_thesaurus_match? field, %w[aat] }
+  accumulator.replace(genres)
+end
+
 to_field 'rbgenr_s' do |record, accumulator|
   genres = process_hierarchy(record, '655|*7|avxyz') { |field| any_thesaurus_match? field, %w[rbbin rbgenr rbmscv rbpap rbpri rbprov rbpub rbtyp] }
+  accumulator.replace(genres)
+end
+
+# used for the Browse lists and hierarchical subject facet
+# used in the record page -> Details section to search for Rare Books genre headings and their subdivisions using
+# the facet[rbgenr_genre_facet] field
+to_field 'rbgenr_genre_facet' do |record, accumulator|
+  genres = accumulate_hierarchy_per_field(record, '655|*7|avxyz') { |field| any_thesaurus_match? field, %w[rbbin rbgenr rbmscv rbpap rbpri rbprov rbpub rbtyp] }
   accumulator.replace(genres)
 end
 

--- a/spec/fixtures/marc_to_solr/99120508103506421.mrx
+++ b/spec/fixtures/marc_to_solr/99120508103506421.mrx
@@ -1,0 +1,575 @@
+<record>
+    <leader>06243cam a2201297 i 4500</leader>
+    <controlfield tag="005">20250206030149.0</controlfield>
+    <controlfield tag="008">180320t20182018caua   j b    001 1 eng c</controlfield>
+    <controlfield tag="001">99120508103506421</controlfield>
+    <datafield ind1=" " ind2=" " tag="010">
+      <subfield code="a">  2018011856</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="019">
+      <subfield code="a">1029056543</subfield>
+      <subfield code="a">1030284092</subfield>
+      <subfield code="a">1031420006</subfield>
+      <subfield code="a">1031439546</subfield>
+      <subfield code="a">1031439942</subfield>
+      <subfield code="a">1031477108</subfield>
+      <subfield code="a">1031920500</subfield>
+      <subfield code="a">1031922621</subfield>
+      <subfield code="a">1032236607</subfield>
+      <subfield code="a">1033550818</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9781452173801</subfield>
+      <subfield code="q">(hardcover ;</subfield>
+      <subfield code="q">alk. paper)</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">145217380X</subfield>
+      <subfield code="q">(hardcover ;</subfield>
+      <subfield code="q">alk. paper)</subfield>
+    </datafield>
+    <datafield ind1="3" ind2=" " tag="024">
+      <subfield code="a">9781452173801</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(NjP)12050810-princetondb</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="z">(OCoLC)1029056543</subfield>
+      <subfield code="z">(OCoLC)1030284092</subfield>
+      <subfield code="z">(OCoLC)1031420006</subfield>
+      <subfield code="z">(OCoLC)1031439546</subfield>
+      <subfield code="z">(OCoLC)1031439942</subfield>
+      <subfield code="z">(OCoLC)1031477108</subfield>
+      <subfield code="z">(OCoLC)1031920500</subfield>
+      <subfield code="z">(OCoLC)1031922621</subfield>
+      <subfield code="z">(OCoLC)1032236607</subfield>
+      <subfield code="z">(OCoLC)1033550818</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="z">(NjP)Voyager12050810</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="z">(NjP)Voyager12050810</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCoLC)on1032290997</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="a">NJQ/DLC</subfield>
+      <subfield code="b">eng</subfield>
+      <subfield code="e">rda</subfield>
+      <subfield code="c">DLC</subfield>
+      <subfield code="d">KSU</subfield>
+      <subfield code="d">MDB</subfield>
+      <subfield code="d">LNC</subfield>
+      <subfield code="d">CZA</subfield>
+      <subfield code="d">TCH</subfield>
+      <subfield code="d">WAU</subfield>
+      <subfield code="d">YDX</subfield>
+      <subfield code="d">VP@</subfield>
+      <subfield code="d">DLC</subfield>
+      <subfield code="d">WAU</subfield>
+      <subfield code="d">LLCLS</subfield>
+      <subfield code="d">WAU</subfield>
+      <subfield code="d">TME</subfield>
+      <subfield code="d">CTB</subfield>
+      <subfield code="d">OCLCF</subfield>
+      <subfield code="d">OCLCQ</subfield>
+      <subfield code="d">T7R</subfield>
+      <subfield code="d">OCL</subfield>
+      <subfield code="d">YUS</subfield>
+      <subfield code="d">OCLCQ</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">POISA</subfield>
+      <subfield code="d">JEZ</subfield>
+      <subfield code="d">LMJ</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">XOL</subfield>
+      <subfield code="d">WAU</subfield>
+      <subfield code="d">NZHWP</subfield>
+      <subfield code="d">UTP</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">NJB</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">IDU</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">BYV</subfield>
+      <subfield code="d">OCLCQ</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">IQW</subfield>
+      <subfield code="d">HLS</subfield>
+      <subfield code="d">GZN</subfield>
+      <subfield code="d">BDX</subfield>
+      <subfield code="d">QQ3</subfield>
+      <subfield code="d">NYP</subfield>
+      <subfield code="d">ZLM</subfield>
+      <subfield code="d">IUK</subfield>
+      <subfield code="d">CGP</subfield>
+      <subfield code="d">AZD</subfield>
+      <subfield code="d">EZB</subfield>
+      <subfield code="d">TXKYL</subfield>
+      <subfield code="d">JTO</subfield>
+      <subfield code="d">IDV</subfield>
+      <subfield code="d">XFF</subfield>
+      <subfield code="d">TU2</subfield>
+      <subfield code="d">TL4</subfield>
+      <subfield code="d">NZBAL</subfield>
+      <subfield code="d">LKC</subfield>
+      <subfield code="d">CNCBE</subfield>
+      <subfield code="d">B@L</subfield>
+      <subfield code="d">DYJ</subfield>
+      <subfield code="d">JX9</subfield>
+      <subfield code="d">ILM</subfield>
+      <subfield code="d">SFB</subfield>
+      <subfield code="d">VVB</subfield>
+      <subfield code="d">UNITY</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">CFS</subfield>
+      <subfield code="d">MNE</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">YBM</subfield>
+      <subfield code="d">EMRUN</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="042">
+      <subfield code="a">pcc</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="043">
+      <subfield code="a">n-us---</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="0" tag="050">
+      <subfield code="a">PN6231.P3</subfield>
+      <subfield code="b">B83 2018</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="4" tag="055">
+      <subfield code="a">PZ7.1.B863</subfield>
+      <subfield code="b">Day 2018</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="0" tag="055">
+      <subfield code="a">PN6231.P3</subfield>
+      <subfield code="b">B83 2018</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="0" tag="082">
+      <subfield code="a">818/.607</subfield>
+      <subfield code="2">23</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="084">
+      <subfield code="a">JUV060000</subfield>
+      <subfield code="a">JUV002210</subfield>
+      <subfield code="a">JUV013020</subfield>
+      <subfield code="a">JUV061000</subfield>
+      <subfield code="2">bisacsh</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Bundo, Marlon</subfield>
+      <subfield code="c">(Rabbit),</subfield>
+      <subfield code="e">author.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="2" tag="245">
+      <subfield code="a">A day in the life of Marlon Bundo /</subfield>
+      <subfield code="c">written by Marlon Bundo with Jill Twiss ; illustrated by EG Keller.</subfield>
+    </datafield>
+    <datafield ind1="3" ind2=" " tag="246">
+      <subfield code="a">Last week tonight with John Oliver presents A day in the life of Marlon Bundo</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="1" tag="264">
+      <subfield code="a">San Francisco :</subfield>
+      <subfield code="b">Chronicle Books,</subfield>
+      <subfield code="c">[2018]</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="4" tag="264">
+      <subfield code="c">&#xA9;2018</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">1 volume (unpaged) :</subfield>
+      <subfield code="b">color illustrations ;</subfield>
+      <subfield code="c">27 cm</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="336">
+      <subfield code="a">text</subfield>
+      <subfield code="b">txt</subfield>
+      <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="337">
+      <subfield code="a">unmediated</subfield>
+      <subfield code="b">n</subfield>
+      <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="338">
+      <subfield code="a">volume</subfield>
+      <subfield code="b">nc</subfield>
+      <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="380">
+      <subfield code="a">Fiction</subfield>
+      <subfield code="2">marcgt</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="385">
+      <subfield code="a">Children</subfield>
+      <subfield code="2">lcdgt</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="504">
+      <subfield code="a">Includes bibliographical references and index.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="520">
+      <subfield code="a">A gentle parody of Charlotte Pence's "Marlon Bundo's A day in the life of the vice president" that stresses lessons of love, democracy and acceptance.</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="541">
+      <subfield code="3">Princeton copy 1</subfield>
+      <subfield code="c">Gift;</subfield>
+      <subfield code="a">Andrea Immel;</subfield>
+      <subfield code="d">2024.</subfield>
+      <subfield code="5">NjP</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="586">
+      <subfield code="a">Rainbow Book List, 2019</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">"Last week tonight with John Oliver presents" --At head of title.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">"What makes A Day in the Life of Marlon Bundo particularly strong is that, while an unabashed political parody, it also stands on its own as a children's book. It would have been easy for John Oliver's team to lean heavily on the gimmick of satirizing a loathed figure in American politics, but they instead focused on developing a charming story with genuinely funny jokes..." --The Globe &amp; Mail.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Rabbits</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Same-sex marriage</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Friendship</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Toleration</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Democracy</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="1" tag="650">
+      <subfield code="a">Rabbits</subfield>
+      <subfield code="v">Fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="1" tag="650">
+      <subfield code="a">Same-sex marriage</subfield>
+      <subfield code="v">Fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="1" tag="650">
+      <subfield code="a">Friendship</subfield>
+      <subfield code="v">Fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="1" tag="650">
+      <subfield code="a">Toleration</subfield>
+      <subfield code="v">Fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="1" tag="650">
+      <subfield code="a">Democracy</subfield>
+      <subfield code="v">Fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="6" tag="650">
+      <subfield code="a">Homosexuels</subfield>
+      <subfield code="x">Mariage</subfield>
+      <subfield code="v">Romans, nouvelles, etc. pour la jeunesse.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="6" tag="650">
+      <subfield code="a">Amitie&#x301;</subfield>
+      <subfield code="v">Romans, nouvelles, etc. pour la jeunesse.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">JUVENILE FICTION</subfield>
+      <subfield code="x">Animals</subfield>
+      <subfield code="x">Rabbits.</subfield>
+      <subfield code="2">bisacsh</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">JUVENILE FICTION</subfield>
+      <subfield code="x">Family</subfield>
+      <subfield code="x">Marriage &amp; Divorce.</subfield>
+      <subfield code="2">bisacsh</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">JUVENILE FICTION</subfield>
+      <subfield code="x">LGBT.</subfield>
+      <subfield code="2">bisacsh</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Public opinion</subfield>
+      <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Democracy</subfield>
+      <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Friendship</subfield>
+      <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Rabbits</subfield>
+      <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Same-sex marriage</subfield>
+      <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Toleration</subfield>
+      <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Same-sex marriage</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+      <subfield code="2">homoit</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Marriage</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+      <subfield code="2">homoit</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Friendships</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+      <subfield code="2">homoit</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Rabbits</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+      <subfield code="2">sears</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Presidents</subfield>
+      <subfield code="z">United States</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+      <subfield code="2">sears</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Friendship</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+      <subfield code="2">sears</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Romance fiction.</subfield>
+      <subfield code="2">sears</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Democracy</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+      <subfield code="2">sears</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Same-sex marriage</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+      <subfield code="2">sears</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Rabbits</subfield>
+      <subfield code="v">Fiction.</subfield>
+      <subfield code="2">sears</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Presidents</subfield>
+      <subfield code="z">United States</subfield>
+      <subfield code="v">Fiction.</subfield>
+      <subfield code="2">sears</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Friendship</subfield>
+      <subfield code="v">Fiction.</subfield>
+      <subfield code="2">sears</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Democracy</subfield>
+      <subfield code="v">Fiction.</subfield>
+      <subfield code="2">sears</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Same-sex marriage</subfield>
+      <subfield code="v">Fiction.</subfield>
+      <subfield code="2">sears</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Presidents</subfield>
+      <subfield code="v">Fiction.</subfield>
+      <subfield code="2">sears</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="600">
+      <subfield code="a">Bundo, Marlon</subfield>
+      <subfield code="c">(Rabbit)</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="1" tag="600">
+      <subfield code="a">Bundo, Marlon</subfield>
+      <subfield code="c">(Rabbit)</subfield>
+      <subfield code="v">Fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="655">
+      <subfield code="a">Picture books for children.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">picture books.</subfield>
+      <subfield code="2">aat</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">parody.</subfield>
+      <subfield code="2">aat</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Political fiction</subfield>
+      <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Parodies (Literature)</subfield>
+      <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Animal fiction</subfield>
+      <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Gay fiction</subfield>
+      <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Juvenile works</subfield>
+      <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Picture books</subfield>
+      <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Romance fiction</subfield>
+      <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Children's stories</subfield>
+      <subfield code="v">Pictorial works.</subfield>
+      <subfield code="2">gsafd</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Gay romance fiction</subfield>
+      <subfield code="2">homoit</subfield>
+      <subfield code="0">https://homosaurus.org/v3/homoit0001593</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">LGBTQ+ relationships</subfield>
+      <subfield code="2">homoit</subfield>
+      <subfield code="0">https://homosaurus.org/v3/homoit0001237</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Picture books.</subfield>
+      <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Political fiction.</subfield>
+      <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Animal fiction.</subfield>
+      <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Romance fiction.</subfield>
+      <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Gay fiction.</subfield>
+      <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Parodies (Literature)</subfield>
+      <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Livres d'images.</subfield>
+      <subfield code="2">rvmgf</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Romans homosexuels.</subfield>
+      <subfield code="2">rvmgf</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Parodies.</subfield>
+      <subfield code="2">rvmgf</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Juvenile literature.</subfield>
+      <subfield code="2">rbmscv</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="730">
+      <subfield code="a">Last week tonight with John Oliver (Television program)</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Twiss, Jill,</subfield>
+      <subfield code="e">author.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Keller, E. G.</subfield>
+      <subfield code="c">(Illustrator)</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="i">Parody of (work):</subfield>
+      <subfield code="a">Pence, Charlotte,</subfield>
+      <subfield code="d">1993-</subfield>
+      <subfield code="t">Marlon Bundo's A day in the life of the vice president.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="902">
+      <subfield code="a">jba</subfield>
+      <subfield code="b">o</subfield>
+      <subfield code="6">a</subfield>
+      <subfield code="7">m</subfield>
+      <subfield code="d">v</subfield>
+      <subfield code="f">1</subfield>
+      <subfield code="e">20200817</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="914">
+      <subfield code="a">(OCoLC)on1032290997</subfield>
+      <subfield code="b">OCoLC</subfield>
+      <subfield code="c">match</subfield>
+      <subfield code="d">20250205</subfield>
+      <subfield code="e">processed</subfield>
+      <subfield code="f">1032290997</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="950">
+      <subfield code="c">2024-01-24 07:43:30 US/Eastern</subfield>
+      <subfield code="b">2021-07-12 08:41:38 US/Eastern</subfield>
+      <subfield code="a">false</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="950">
+      <subfield code="c">2025-02-06 03:01:49 US/Eastern</subfield>
+      <subfield code="b">2021-07-12 08:41:38 US/Eastern</subfield>
+      <subfield code="a">false</subfield>
+    </datafield>
+    <datafield ind1="8" ind2=" " tag="852">
+      <subfield code="b">rare</subfield>
+      <subfield code="c">ctsn</subfield>
+      <subfield code="h">Q-001835</subfield>
+      <subfield code="k">Eng 21Q /</subfield>
+      <subfield code="8">22483367710006421</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="866">
+      <subfield code="z">Princeton copy 1</subfield>
+      <subfield code="8">22483367710006421</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="952">
+      <subfield code="d">2025-02-06 13:29:25</subfield>
+      <subfield code="8">22483367710006421</subfield>
+      <subfield code="a">2021-07-12 12:41:38</subfield>
+      <subfield code="b">Special Collections</subfield>
+      <subfield code="c">ctsn: Cotsen Children's Library</subfield>
+      <subfield code="e">false</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="876">
+      <subfield code="0">22483367710006421</subfield>
+      <subfield code="a">231041742350006421</subfield>
+      <subfield code="j">1</subfield>
+      <subfield code="z">ctsn</subfield>
+      <subfield code="d">2025-02-03 10:18:12 US/Eastern</subfield>
+      <subfield code="p">32101103309165</subfield>
+      <subfield code="y">rare</subfield>
+    </datafield>
+  </record>

--- a/spec/fixtures/marc_to_solr/99129068748706421.mrx
+++ b/spec/fixtures/marc_to_solr/99129068748706421.mrx
@@ -1,0 +1,211 @@
+ <record>
+    <leader>02053nec a2200385Ia 4500</leader>
+    <controlfield tag="005">20231026041617.0</controlfield>
+    <controlfield tag="007">aj#aafb|</controlfield>
+    <controlfield tag="008">940111s18522000nju       a     0   eng d</controlfield>
+    <controlfield tag="001">99129068748706421</controlfield>
+    <datafield ind1="1" ind2=" " tag="034">
+      <subfield code="a">a</subfield>
+      <subfield code="b">4800</subfield>
+      <subfield code="d">-074.671175</subfield>
+      <subfield code="e">-074.637615</subfield>
+      <subfield code="f">040.373122</subfield>
+      <subfield code="g">040.342006</subfield>
+      <subfield code="2">bound</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCoLC)on1405896033</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="a">NjP</subfield>
+      <subfield code="b">eng</subfield>
+      <subfield code="c">NjP</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="043">
+      <subfield code="a">n-us-nj</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="090">
+      <subfield code="a">X129874870</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Bevan, John</subfield>
+      <subfield code="c">(Surveyor),</subfield>
+      <subfield code="e">surveyor.</subfield>
+      <subfield code="0">http://id.loc.gov/authorities/names/n2010039939</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="a">[Map of Princeton, Mercer County, New Jersey] /</subfield>
+      <subfield code="c">[surveyed and published by John Bevan, city surveyor, Commercial Building, Jersey City, N.J.]</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="255">
+      <subfield code="a">Scale [ca. 1:4,800]. 400 feet to the inch.</subfield>
+      <subfield code="c">(W 74&#xB0;40&#x2B9;16&#x2BA;--W 74&#xB0;38&#x2B9;15&#x2BA;/N 40&#xB0;22&#x2B9;23&#x2BA;--N 40&#xB0;20&#x2B9;31&#x2BA;).</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">[Jersey City] :</subfield>
+      <subfield code="b">John Bevan,</subfield>
+      <subfield code="c">1852, c1851</subfield>
+      <subfield code="e">(N.Y. :</subfield>
+      <subfield code="f">Lith. of Sarony &amp; Co.)</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">2 maps :</subfield>
+      <subfield code="b">photocopies,</subfield>
+      <subfield code="c">on sheets 44 x 61 cm or smaller.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="336">
+      <subfield code="a">cartographic image</subfield>
+      <subfield code="b">cri</subfield>
+      <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="337">
+      <subfield code="a">unmediated</subfield>
+      <subfield code="b">n</subfield>
+      <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="338">
+      <subfield code="a">sheet</subfield>
+      <subfield code="b">nb</subfield>
+      <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">Two photocopies of the original lithographed map, one positive and one negative.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">Includes names of property owners, list of subscribers, and views of buildings.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">"Entered according to Act of Congress in the year 1851 by John Bevan ... "</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Real property</subfield>
+      <subfield code="z">New Jersey</subfield>
+      <subfield code="z">Princeton</subfield>
+      <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="651">
+      <subfield code="a">Princeton (N.J.)</subfield>
+      <subfield code="y">19th century</subfield>
+      <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Maps</subfield>
+      <subfield code="z">New Jersey</subfield>
+      <subfield code="z">Princeton</subfield>
+      <subfield code="y">19th century.</subfield>
+      <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Cadastral maps</subfield>
+      <subfield code="z">New Jersey</subfield>
+      <subfield code="z">Princeton</subfield>
+      <subfield code="y">1852.</subfield>
+      <subfield code="2">aat</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">City maps</subfield>
+      <subfield code="z">New Jersey</subfield>
+      <subfield code="z">Princeton</subfield>
+      <subfield code="y">1852.</subfield>
+      <subfield code="2">aat</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Wall maps</subfield>
+      <subfield code="z">New Jersey</subfield>
+      <subfield code="z">Princeton</subfield>
+      <subfield code="y">1852.</subfield>
+      <subfield code="2">local</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Maps.</subfield>
+      <subfield code="2">lcgft</subfield>
+      <subfield code="0">http://id.loc.gov/authorities/genreForms/gf2011026387</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="710">
+      <subfield code="a">Sarony &amp; Co.,</subfield>
+      <subfield code="e">lithographer.</subfield>
+      <subfield code="0">http://id.loc.gov/authorities/names/nr89018451</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="902">
+      <subfield code="a">110106599</subfield>
+      <subfield code="w">original</subfield>
+      <subfield code="1">20231024152716.0</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="914">
+      <subfield code="a">(OCoLC)on1405896033</subfield>
+      <subfield code="b">OCoLC</subfield>
+      <subfield code="c">create</subfield>
+      <subfield code="d">20231025</subfield>
+      <subfield code="e">processed</subfield>
+      <subfield code="f">1405896033</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="950">
+      <subfield code="c">2023-10-27 07:25:15 US/Eastern</subfield>
+      <subfield code="b">2023-10-24 15:27:16 US/Eastern</subfield>
+      <subfield code="a">false</subfield>
+    </datafield>
+    <datafield ind1="8" ind2=" " tag="852">
+      <subfield code="b">rare</subfield>
+      <subfield code="c">map</subfield>
+      <subfield code="h">HMC01.3423.2</subfield>
+      <subfield code="k">D-Alcove 4, Drawer 19,</subfield>
+      <subfield code="8">22994414640006421</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="866">
+      <subfield code="a">negative image</subfield>
+      <subfield code="8">22994414640006421</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="866">
+      <subfield code="z">Princeton copy 2</subfield>
+      <subfield code="8">22994414640006421</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="952">
+      <subfield code="d">2023-10-24 19:31:33</subfield>
+      <subfield code="8">22994414640006421</subfield>
+      <subfield code="a">2023-10-24 19:31:29</subfield>
+      <subfield code="b">Special Collections</subfield>
+      <subfield code="c">map: Rare Books Historic Map Collection</subfield>
+      <subfield code="e">false</subfield>
+    </datafield>
+    <datafield ind1="8" ind2=" " tag="852">
+      <subfield code="b">rare</subfield>
+      <subfield code="c">map</subfield>
+      <subfield code="h">HMC01.3423.1</subfield>
+      <subfield code="k">D-Alcove 4, Drawer 19,</subfield>
+      <subfield code="8">22994414700006421</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="866">
+      <subfield code="a">positive image</subfield>
+      <subfield code="8">22994414700006421</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="866">
+      <subfield code="z">Princeton copy 1</subfield>
+      <subfield code="8">22994414700006421</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="952">
+      <subfield code="d">2023-10-24 19:31:04</subfield>
+      <subfield code="8">22994414700006421</subfield>
+      <subfield code="a">2023-10-24 19:30:06</subfield>
+      <subfield code="b">Special Collections</subfield>
+      <subfield code="c">map: Rare Books Historic Map Collection</subfield>
+      <subfield code="e">false</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="876">
+      <subfield code="0">22994414700006421</subfield>
+      <subfield code="a">23994414660006421</subfield>
+      <subfield code="j">1</subfield>
+      <subfield code="z">map</subfield>
+      <subfield code="d">2023-10-24 15:30:27 US/Eastern</subfield>
+      <subfield code="p">32101113815904</subfield>
+      <subfield code="y">rare</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="876">
+      <subfield code="0">22994414640006421</subfield>
+      <subfield code="a">23994414630006421</subfield>
+      <subfield code="j">1</subfield>
+      <subfield code="z">map</subfield>
+      <subfield code="d">2023-10-24 15:31:50 US/Eastern</subfield>
+      <subfield code="p">32101113815912</subfield>
+      <subfield code="y">rare</subfield>
+    </datafield>
+  </record>

--- a/spec/fixtures/marc_to_solr/99131369793306421.mrx
+++ b/spec/fixtures/marc_to_solr/99131369793306421.mrx
@@ -1,0 +1,466 @@
+<record>
+    <leader>04857cam a2201021 i 4500</leader>
+    <controlfield tag="005">20250213054213.0</controlfield>
+    <controlfield tag="008">121212s2013    nyua   b      000 1 eng  </controlfield>
+    <controlfield tag="001">99131369793306421</controlfield>
+    <datafield ind1=" " ind2=" " tag="010">
+      <subfield code="a">  2012046025</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="019">
+      <subfield code="a">821203422</subfield>
+      <subfield code="a">857568995</subfield>
+      <subfield code="a">859307227</subfield>
+      <subfield code="a">859738614</subfield>
+      <subfield code="a">880954062</subfield>
+      <subfield code="a">936051338</subfield>
+      <subfield code="a">966047490</subfield>
+      <subfield code="a">999539842</subfield>
+      <subfield code="a">1005272164</subfield>
+      <subfield code="a">1018170112</subfield>
+      <subfield code="a">1183341319</subfield>
+      <subfield code="a">1304509785</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9780618756612</subfield>
+      <subfield code="q">(hardcover)</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">0618756612</subfield>
+      <subfield code="q">(hardcover)</subfield>
+    </datafield>
+    <datafield ind1="3" ind2=" " tag="024">
+      <subfield code="a">9780618756612</subfield>
+      <subfield code="d">51799</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCoLC)ocn858777860</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="037">
+      <subfield code="b">Houghton Mifflin Harcourt, 6277 Sea Harbor Dr 5th Fl, Orlando, FL, USA, 32887</subfield>
+      <subfield code="n">SAN 215-3793</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="a">DLC</subfield>
+      <subfield code="b">eng</subfield>
+      <subfield code="e">rda</subfield>
+      <subfield code="c">DLC</subfield>
+      <subfield code="d">YDXCP</subfield>
+      <subfield code="d">BTCTA</subfield>
+      <subfield code="d">BDX</subfield>
+      <subfield code="d">UPZ</subfield>
+      <subfield code="d">ABG</subfield>
+      <subfield code="d">XFF</subfield>
+      <subfield code="d">ZR1</subfield>
+      <subfield code="d">ITD</subfield>
+      <subfield code="d">FUG</subfield>
+      <subfield code="d">VP@</subfield>
+      <subfield code="d">TWTCL</subfield>
+      <subfield code="d">CZL</subfield>
+      <subfield code="d">OCLCF</subfield>
+      <subfield code="d">ZCU</subfield>
+      <subfield code="d">IPU</subfield>
+      <subfield code="d">OCLCQ</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">CGN</subfield>
+      <subfield code="d">OCLCQ</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">TDS</subfield>
+      <subfield code="d">CNGUL</subfield>
+      <subfield code="d">OCL</subfield>
+      <subfield code="d">ZGV</subfield>
+      <subfield code="d">CALHP</subfield>
+      <subfield code="d">ALROG</subfield>
+      <subfield code="d">BYV</subfield>
+      <subfield code="d">CHILD</subfield>
+      <subfield code="d">OCLCQ</subfield>
+      <subfield code="d">PX9</subfield>
+      <subfield code="d">KL6</subfield>
+      <subfield code="d">KJ6</subfield>
+      <subfield code="d">OCLCQ</subfield>
+      <subfield code="d">CCH</subfield>
+      <subfield code="d">O2C</subfield>
+      <subfield code="d">OCLCQ</subfield>
+      <subfield code="d">FWR</subfield>
+      <subfield code="d">NZ1</subfield>
+      <subfield code="d">ROB</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">CSA</subfield>
+      <subfield code="d">CBA</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">TL4</subfield>
+      <subfield code="d">GZW</subfield>
+      <subfield code="d">NZAUC</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">NJT</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">OCL</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">OCLCQ</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">OCL</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">BUF</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">JABUK</subfield>
+      <subfield code="d">MSO</subfield>
+      <subfield code="d">VJ2</subfield>
+      <subfield code="d">OCLCO</subfield>
+      <subfield code="d">OCLCQ</subfield>
+      <subfield code="d">IAZ</subfield>
+      <subfield code="d">OCLCL</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="042">
+      <subfield code="a">cyac</subfield>
+      <subfield code="a">pcc</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="0" tag="050">
+      <subfield code="a">PZ7.W6367</subfield>
+      <subfield code="b">Mr 2013</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="0" tag="055">
+      <subfield code="a">PZ7.W6367</subfield>
+      <subfield code="b">Mr 2013</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="0" tag="082">
+      <subfield code="a">[E]</subfield>
+      <subfield code="2">23</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="084">
+      <subfield code="a">JUV002050</subfield>
+      <subfield code="a">JUV002140</subfield>
+      <subfield code="a">JUV019000</subfield>
+      <subfield code="a">JUV053000</subfield>
+      <subfield code="a">JUV008000</subfield>
+      <subfield code="2">bisacsh</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="084">
+      <subfield code="a">I712.85</subfield>
+      <subfield code="2">clc</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Wiesner, David,</subfield>
+      <subfield code="e">author,</subfield>
+      <subfield code="e">illustrator.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="a">Mr. Wuffles! /</subfield>
+      <subfield code="c">David Wiesner.</subfield>
+    </datafield>
+    <datafield ind1="3" ind2=" " tag="246">
+      <subfield code="a">Mister Wuffles!</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="1" tag="264">
+      <subfield code="a">New York :</subfield>
+      <subfield code="b">Clarion Books, Houghton Mifflin Harcourt,</subfield>
+      <subfield code="c">2013.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">1 volume (unpaged) :</subfield>
+      <subfield code="b">color illustrations ;</subfield>
+      <subfield code="c">24 x 29 cm</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="336">
+      <subfield code="a">text</subfield>
+      <subfield code="b">txt</subfield>
+      <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="336">
+      <subfield code="a">still image</subfield>
+      <subfield code="b">sti</subfield>
+      <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="337">
+      <subfield code="a">unmediated</subfield>
+      <subfield code="b">n</subfield>
+      <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="338">
+      <subfield code="a">volume</subfield>
+      <subfield code="b">nc</subfield>
+      <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="520">
+      <subfield code="a">"Mr. Wuffles ignores all his cat toys but one, which turns out to be a spaceship piloted by small green aliens. When Mr. Wuffles plays rough with the little ship, the aliens must venture into the cat's territory to make emergency repairs."--Publisher information.</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="541">
+      <subfield code="3">Princeton copy 1</subfield>
+      <subfield code="c">Gift;</subfield>
+      <subfield code="a">Andrea Immel;</subfield>
+      <subfield code="d">2024.</subfield>
+      <subfield code="5">NjP</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="521">
+      <subfield code="a">Ages: 4-8.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="521">
+      <subfield code="a">Grades: PreS-3.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="586">
+      <subfield code="a">2014 ALA Notable Children's Books List</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="586">
+      <subfield code="a">Caldecott Honor book, 2014.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Toys</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Extraterrestrial beings</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Cats</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Curiosity</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Friendship</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Stories without words.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="1" tag="650">
+      <subfield code="a">Cats</subfield>
+      <subfield code="v">Fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="1" tag="650">
+      <subfield code="a">Toys</subfield>
+      <subfield code="v">Fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="1" tag="650">
+      <subfield code="a">Extraterrestrial beings</subfield>
+      <subfield code="v">Fiction.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="6" tag="650">
+      <subfield code="a">Jouets</subfield>
+      <subfield code="v">Romans, nouvelles, etc. pour la jeunesse.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="6" tag="650">
+      <subfield code="a">Extraterrestres</subfield>
+      <subfield code="v">Romans, nouvelles, etc. pour la jeunesse.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="6" tag="650">
+      <subfield code="a">Curiosite&#x301;</subfield>
+      <subfield code="v">Romans, nouvelles, etc. pour la jeunesse.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="6" tag="650">
+      <subfield code="a">Amitie&#x301;</subfield>
+      <subfield code="v">Romans, nouvelles, etc. pour la jeunesse.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="6" tag="650">
+      <subfield code="a">Histoires sans paroles.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">stories without words.</subfield>
+      <subfield code="2">aat</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Cats</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+      <subfield code="2">cct</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Curiosity</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+      <subfield code="2">cct</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Extraterrestrial beings</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+      <subfield code="2">cct</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Friendship</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+      <subfield code="2">cct</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Stories without words.</subfield>
+      <subfield code="2">cct</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Toys</subfield>
+      <subfield code="v">Juvenile fiction.</subfield>
+      <subfield code="2">cct</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Cats.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">(OCoLC)fst00849374</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Curiosity.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">(OCoLC)fst00885290</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Extraterrestrial beings.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">(OCoLC)fst01742248</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Friendship.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">(OCoLC)fst00935174</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Stories without words.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">(OCoLC)fst01134080</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Toys.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">(OCoLC)fst01153487</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Cats</subfield>
+      <subfield code="v">Fiction.</subfield>
+      <subfield code="2">sears</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Toys</subfield>
+      <subfield code="v">Fiction.</subfield>
+      <subfield code="2">sears</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Extraterrestrial beings</subfield>
+      <subfield code="v">Fiction.</subfield>
+      <subfield code="2">sears</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="655">
+      <subfield code="a">Stories without words.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="4" tag="655">
+      <subfield code="a">Caldecott Medal : Honor book</subfield>
+      <subfield code="y">2014.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">stories without words.</subfield>
+      <subfield code="2">aat</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">picture books.</subfield>
+      <subfield code="2">aat</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="7" tag="655">
+      <subfield code="c">FIC016000</subfield>
+      <subfield code="a">FICTION / Humorous.</subfield>
+      <subfield code="2">bisacsh</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="7" tag="655">
+      <subfield code="c">JUV002000</subfield>
+      <subfield code="a">FICTION / Animals / General.</subfield>
+      <subfield code="2">bisacsh</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Picture books.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">(OCoLC)fst01726789</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Wordless picture books.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">(OCoLC)fst01726751</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Fiction.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">(OCoLC)fst01423787</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Juvenile works.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">(OCoLC)fst01411637</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Wordless picture books.</subfield>
+      <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Picture books.</subfield>
+      <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">NP.</subfield>
+      <subfield code="2">lexile</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Dust jackets (Bindings)</subfield>
+      <subfield code="y">2013.</subfield>
+      <subfield code="2">rbbin</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Dust jackets (Binding)</subfield>
+      <subfield code="y">2013.</subfield>
+      <subfield code="2">rbbin</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Histoires sans paroles.</subfield>
+      <subfield code="2">rvmgf</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Livres d'images.</subfield>
+      <subfield code="2">rvmgf</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="758">
+      <subfield code="i">has work:</subfield>
+      <subfield code="a">Mr Wuffles! (Text)</subfield>
+      <subfield code="1">https://id.oclc.org/worldcat/entity/E39PCFW3TBdp9tGKbyJFKY9BCP</subfield>
+      <subfield code="4">https://id.oclc.org/worldcat/ontology/hasWork</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="902">
+      <subfield code="a">960223597</subfield>
+      <subfield code="w">copy</subfield>
+      <subfield code="1">20250211103504.0</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="914">
+      <subfield code="a">(OCoLC)ocn858777860</subfield>
+      <subfield code="b">OCoLC</subfield>
+      <subfield code="c">match</subfield>
+      <subfield code="d">20250212</subfield>
+      <subfield code="e">processed</subfield>
+      <subfield code="f">858777860</subfield>
+    </datafield>
+    <datafield ind1="4" ind2=" " tag="956">
+      <subfield code="u">http://www.hmhbooks.com</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="950">
+      <subfield code="c">2025-02-13 05:42:13 US/Eastern</subfield>
+      <subfield code="b">2025-02-11 10:37:27 US/Eastern</subfield>
+      <subfield code="a">false</subfield>
+    </datafield>
+    <datafield ind1="8" ind2=" " tag="852">
+      <subfield code="b">rare</subfield>
+      <subfield code="c">ctsn</subfield>
+      <subfield code="h">Alma-96536</subfield>
+      <subfield code="k">Eng 21Q unprocessed</subfield>
+      <subfield code="8">221042801910006421</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="866">
+      <subfield code="z">Princeton copy 1</subfield>
+      <subfield code="8">221042801910006421</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="952">
+      <subfield code="d">2025-02-11 15:38:54</subfield>
+      <subfield code="8">221042801910006421</subfield>
+      <subfield code="a">2025-02-11 15:38:09</subfield>
+      <subfield code="b">Special Collections</subfield>
+      <subfield code="c">ctsn: Cotsen Children's Library</subfield>
+      <subfield code="e">false</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="876">
+      <subfield code="0">221042801910006421</subfield>
+      <subfield code="a">231042801890006421</subfield>
+      <subfield code="j">1</subfield>
+      <subfield code="z">ctsn</subfield>
+      <subfield code="d">2025-02-11 10:38:47 US/Eastern</subfield>
+      <subfield code="p">32101103309728</subfield>
+      <subfield code="y">rare</subfield>
+    </datafield>
+  </record>

--- a/spec/fixtures/marc_to_solr/9918309193506421.mrx
+++ b/spec/fixtures/marc_to_solr/9918309193506421.mrx
@@ -1,2 +1,189 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<record xmlns='http://www.loc.gov/MARC21/slim'><leader>02984cam a2200493 i 4500</leader><controlfield tag='001'>9918309193506421</controlfield><controlfield tag='005'>20220602140647.0</controlfield><controlfield tag='008'>060127s1852    cc            000 0 chi d</controlfield><datafield ind1=' ' ind2=' ' tag='035'><subfield code='a'>(OCoLC)63184220</subfield></datafield><datafield ind1=' ' ind2=' ' tag='035'><subfield code='a'>(OCoLC)ocm63184220</subfield></datafield><datafield ind1=' ' ind2=' ' tag='035'><subfield code='a'>(NjP)1830919-princetondb</subfield></datafield><datafield ind1=' ' ind2=' ' tag='040'><subfield code='a'>PULEA</subfield><subfield code='b'>eng</subfield><subfield code='e'>cgcrb</subfield><subfield code='c'>PULEA</subfield><subfield code='d'>OCLCQ</subfield><subfield code='d'>PUL</subfield></datafield><datafield ind1=' ' ind2=' ' tag='084'><subfield code='a'>9315/4228</subfield><subfield code='2'>cscjb</subfield></datafield><datafield ind1='1' ind2=' ' tag='100'><subfield code='6'>880-01</subfield><subfield code='a'>Ball, Dyer,</subfield><subfield code='d'>1796-1866.</subfield></datafield><datafield ind1='1' ind2=' ' tag='880'><subfield code='6'>100-01</subfield><subfield code='a'>波乃耶,</subfield><subfield code='d'>1796-1866.</subfield></datafield><datafield ind1='1' ind2='0' tag='245'><subfield code='6'>880-02</subfield><subfield code='a'>Hua fan he he tong shu.</subfield></datafield><datafield ind1='1' ind2='0' tag='880'><subfield code='6'>245-02</subfield><subfield code='a'>華番和合通書.</subfield></datafield><datafield ind1='3' ind2='0' tag='246'><subfield code='6'>880-03</subfield><subfield code='a'>He he tong shu</subfield></datafield><datafield ind1='3' ind2='0' tag='880'><subfield code='6'>246-03</subfield><subfield code='a'>和合通書</subfield></datafield><datafield ind1=' ' ind2=' ' tag='250'><subfield code='6'>880-04</subfield><subfield code='a'>Ke ben, xian zhuang.</subfield></datafield><datafield ind1=' ' ind2=' ' tag='880'><subfield code='6'>250-04</subfield><subfield code='a'>刻本, 綫裝.</subfield></datafield><datafield ind1=' ' ind2='1' tag='264'><subfield code='6'>880-05</subfield><subfield code='a'>[China]:</subfield><subfield code='b'>[bonaiye],</subfield><subfield code='c'>Qing Xianfeng 2 nian [1852]</subfield></datafield><datafield ind1=' ' ind2='1' tag='880'><subfield code='6'>264-05</subfield><subfield code='a'>[China]:</subfield><subfield code='b'>[波乃耶],</subfield><subfield code='c'>清咸豐2年 [1852]</subfield></datafield><datafield ind1=' ' ind2=' ' tag='300'><subfield code='a'>1 volume :</subfield><subfield code='b'>illustrations, maps ;</subfield><subfield code='c'>27 cm</subfield></datafield><datafield ind1=' ' ind2=' ' tag='336'><subfield code='a'>text</subfield><subfield code='b'>txt</subfield><subfield code='2'>rdacontent</subfield></datafield><datafield ind1=' ' ind2=' ' tag='337'><subfield code='a'>unmediated</subfield><subfield code='b'>n</subfield><subfield code='2'>rdamedia</subfield></datafield><datafield ind1=' ' ind2=' ' tag='338'><subfield code='a'>volume</subfield><subfield code='b'>nc</subfield><subfield code='2'>rdacarrier</subfield></datafield><datafield ind1=' ' ind2='0' tag='650'><subfield code='a'>Theology, Doctrinal.</subfield></datafield><datafield ind1=' ' ind2='0' tag='650'><subfield code='a'>Almanacs, Chinese.</subfield></datafield><datafield ind1=' ' ind2='7' tag='650'><subfield code='6'>880-06</subfield><subfield code='a'>Zi bu</subfield><subfield code='x'>Zhu jia lei</subfield><subfield code='x'>Jidu jiao zhi shu</subfield><subfield code='2'>skbb</subfield></datafield><datafield ind1=' ' ind2='7' tag='880'><subfield code='6'>650-06</subfield><subfield code='a'>子部</subfield><subfield code='x'>諸家類</subfield><subfield code='x'>基督教之屬</subfield><subfield code='2'>skbb</subfield></datafield><datafield ind1=' ' ind2='7' tag='650'><subfield code='6'>880-07</subfield><subfield code='a'>Zi bu</subfield><subfield code='x'>Tian wen suan fa lei</subfield><subfield code='x'>Li fa.</subfield><subfield code='2'>sk</subfield></datafield><datafield ind1=' ' ind2='7' tag='880'><subfield code='6'>650-07</subfield><subfield code='a'>子部</subfield><subfield code='x'>天文算法類</subfield><subfield code='x'>曆法.</subfield><subfield code='2'>sk</subfield></datafield><datafield ind1='2' ind2=' ' tag='710'><subfield code='a'>Chinese Rare Books Project</subfield><subfield code='g'>Post-1795 books</subfield><subfield code='5'>NjP</subfield></datafield><datafield ind1=' ' ind2=' ' tag='880'><subfield code='6'>500-00</subfield><subfield code='a'>封面題：&quot;咸豐二年 番自耶穌降生至今一千八百五十二年 華蕃和合通書&quot;.</subfield></datafield><datafield ind1=' ' ind2=' ' tag='880'><subfield code='6'>500-00</subfield><subfield code='a'>&quot;Dyer Ball (1796-1866), between 1843 and 1854, Dyer compiled and published one Chinese almanc every year&quot; --本舘《唐番和合通書》（BT65T364 1861）所附購書介紹. 維基百科&quot;波乃耶 (傳教士)&quot;</subfield></datafield><datafield ind1=' ' ind2=' ' tag='880'><subfield code='6'>500-00</subfield><subfield code='a'>&quot;棄假歸真論&quot;首葉框18.5 x 13.5公分, 10行24字, 白口, 四周雙邊, 單黑魚尾. 版心上鐫篇名.</subfield></datafield><datafield ind1='4' ind2=' ' tag='880'><subfield code='6'>510-00</subfield><subfield code='a'>波乃耶(Dyer Ball), 參見維基百科</subfield><subfield code='c'>&quot;波乃耶 (傳教士)&quot;條目--2022年5月5日查看.</subfield></datafield><datafield ind1='4' ind2='1' tag='856'><subfield code='3'>Selected images</subfield><subfield code='u'>http://arks.princeton.edu/ark:/88435/dccf95jp00m</subfield></datafield><datafield ind1=' ' ind2=' ' tag='902'><subfield code='a'>010006123</subfield><subfield code='w'>original</subfield></datafield><datafield ind1=' ' ind2=' ' tag='910'><subfield code='a'>rcp3415</subfield></datafield><datafield ind1=' ' ind2=' ' tag='946'><subfield code='a'>1830919</subfield></datafield><datafield ind1=' ' ind2=' ' tag='987'><subfield code='a'>PINYIN</subfield><subfield code='b'>NjP-G</subfield><subfield code='d'>c</subfield></datafield><datafield ind1=' ' ind2=' ' tag='994'><subfield code='a'>02</subfield><subfield code='b'>MAI</subfield></datafield><datafield ind1=' ' ind2=' ' tag='AVA'><subfield code='0'>9918309193506421</subfield><subfield code='8'>22645461280006421</subfield><subfield code='a'>01PRI_INST</subfield><subfield code='b'>eastasian</subfield><subfield code='c'>Remote Storage (ReCAP): East Asian Library Use Only</subfield><subfield code='d'>9315/4228</subfield><subfield code='e'>unavailable</subfield><subfield code='f'>1</subfield><subfield code='g'>1</subfield><subfield code='j'>pl</subfield><subfield code='k'>8</subfield><subfield code='p'>1</subfield><subfield code='q'>East Asian Library</subfield></datafield></record>
+<record>
+    <leader>02984cam a2200493 i 4500</leader>
+    <controlfield tag='001'>9918309193506421</controlfield>
+    <controlfield tag='005'>20220602140647.0</controlfield>
+    <controlfield tag='008'>060127s1852 cc 000 0 chi d</controlfield>
+    <datafield ind1=' ' ind2=' ' tag='035'>
+        <subfield code='a'>(OCoLC)63184220</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='035'>
+        <subfield code='a'>(OCoLC)ocm63184220</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='035'>
+        <subfield code='a'>(NjP)1830919-princetondb</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='040'>
+        <subfield code='a'>PULEA</subfield>
+        <subfield code='b'>eng</subfield>
+        <subfield code='e'>cgcrb</subfield>
+        <subfield code='c'>PULEA</subfield>
+        <subfield code='d'>OCLCQ</subfield>
+        <subfield code='d'>PUL</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='084'>
+        <subfield code='a'>9315/4228</subfield>
+        <subfield code='2'>cscjb</subfield>
+    </datafield>
+    <datafield ind1='1' ind2=' ' tag='100'>
+        <subfield code='6'>880-01</subfield>
+        <subfield code='a'>Ball, Dyer,</subfield>
+        <subfield code='d'>1796-1866.</subfield>
+    </datafield>
+    <datafield ind1='1' ind2=' ' tag='880'>
+        <subfield code='6'>100-01</subfield>
+        <subfield code='a'>波乃耶,</subfield>
+        <subfield code='d'>1796-1866.</subfield>
+    </datafield>
+    <datafield ind1='1' ind2='0' tag='245'>
+        <subfield code='6'>880-02</subfield>
+        <subfield code='a'>Hua fan he he tong shu.</subfield>
+    </datafield>
+    <datafield ind1='1' ind2='0' tag='880'>
+        <subfield code='6'>245-02</subfield>
+        <subfield code='a'>華番和合通書.</subfield>
+    </datafield>
+    <datafield ind1='3' ind2='0' tag='246'>
+        <subfield code='6'>880-03</subfield>
+        <subfield code='a'>He he tong shu</subfield>
+    </datafield>
+    <datafield ind1='3' ind2='0' tag='880'>
+        <subfield code='6'>246-03</subfield>
+        <subfield code='a'>和合通書</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='250'>
+        <subfield code='6'>880-04</subfield>
+        <subfield code='a'>Ke ben, xian zhuang.</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='880'>
+        <subfield code='6'>250-04</subfield>
+        <subfield code='a'>刻本, 綫裝.</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2='1' tag='264'>
+        <subfield code='6'>880-05</subfield>
+        <subfield code='a'>[China]:</subfield>
+        <subfield code='b'>[bonaiye],</subfield>
+        <subfield code='c'>Qing Xianfeng 2 nian [1852]</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2='1' tag='880'>
+        <subfield code='6'>264-05</subfield>
+        <subfield code='a'>[China]:</subfield>
+        <subfield code='b'>[波乃耶],</subfield>
+        <subfield code='c'>清咸豐2年 [1852]</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='300'>
+        <subfield code='a'>1 volume :</subfield>
+        <subfield code='b'>illustrations, maps ;</subfield>
+        <subfield code='c'>27 cm</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='336'>
+        <subfield code='a'>text</subfield>
+        <subfield code='b'>txt</subfield>
+        <subfield code='2'>rdacontent</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='337'>
+        <subfield code='a'>unmediated</subfield>
+        <subfield code='b'>n</subfield>
+        <subfield code='2'>rdamedia</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='338'>
+        <subfield code='a'>volume</subfield>
+        <subfield code='b'>nc</subfield>
+        <subfield code='2'>rdacarrier</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2='0' tag='650'>
+        <subfield code='a'>Theology, Doctrinal.</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2='0' tag='650'>
+        <subfield code='a'>Almanacs, Chinese.</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2='7' tag='650'>
+        <subfield code='6'>880-06</subfield>
+        <subfield code='a'>Zi bu</subfield>
+        <subfield code='x'>Zhu jia lei</subfield>
+        <subfield code='x'>Jidu jiao zhi shu</subfield>
+        <subfield code='2'>skbb</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2='7' tag='880'>
+        <subfield code='6'>650-06</subfield>
+        <subfield code='a'>子部</subfield>
+        <subfield code='x'>諸家類</subfield>
+        <subfield code='x'>基督教之屬</subfield>
+        <subfield code='2'>skbb</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2='7' tag='650'>
+        <subfield code='6'>880-07</subfield>
+        <subfield code='a'>Zi bu</subfield>
+        <subfield code='x'>Tian wen suan fa lei</subfield>
+        <subfield code='x'>Li fa.</subfield>
+        <subfield code='2'>sk</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2='7' tag='880'>
+        <subfield code='6'>650-07</subfield>
+        <subfield code='a'>子部</subfield>
+        <subfield code='x'>天文算法類</subfield>
+        <subfield code='x'>曆法.</subfield>
+        <subfield code='2'>sk</subfield>
+    </datafield>
+    <datafield ind1='2' ind2=' ' tag='710'>
+        <subfield code='a'>Chinese Rare Books Project</subfield>
+        <subfield code='g'>Post-1795 books</subfield>
+        <subfield code='5'>NjP</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='880'>
+        <subfield code='6'>500-00</subfield>
+        <subfield code='a'>封面題：&quot;咸豐二年 番自耶穌降生至今一千八百五十二年 華蕃和合通書&quot;.</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='880'>
+        <subfield code='6'>500-00</subfield>
+        <subfield code='a'>&quot;Dyer Ball (1796-1866), between 1843 and 1854, Dyer compiled and
+            published one Chinese almanc every year&quot; --本舘《唐番和合通書》（BT65T364 1861）所附購書介紹.
+            維基百科&quot;波乃耶 (傳教士)&quot;</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='880'>
+        <subfield code='6'>500-00</subfield>
+        <subfield code='a'>&quot;棄假歸真論&quot;首葉框18.5 x 13.5公分, 10行24字, 白口, 四周雙邊, 單黑魚尾. 版心上鐫篇名.</subfield>
+    </datafield>
+    <datafield ind1='4' ind2=' ' tag='880'>
+        <subfield code='6'>510-00</subfield>
+        <subfield code='a'>波乃耶(Dyer Ball), 參見維基百科</subfield>
+        <subfield code='c'>&quot;波乃耶 (傳教士)&quot;條目--2022年5月5日查看.</subfield>
+    </datafield>
+    <datafield ind1='4' ind2='1' tag='856'>
+        <subfield code='3'>Selected images</subfield>
+        <subfield code='u'>http://arks.princeton.edu/ark:/88435/dccf95jp00m</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='902'>
+        <subfield code='a'>010006123</subfield>
+        <subfield code='w'>original</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='910'>
+        <subfield code='a'>rcp3415</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='946'>
+        <subfield code='a'>1830919</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='987'>
+        <subfield code='a'>PINYIN</subfield>
+        <subfield code='b'>NjP-G</subfield>
+        <subfield code='d'>c</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='994'>
+        <subfield code='a'>02</subfield>
+        <subfield code='b'>MAI</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='AVA'>
+        <subfield code='0'>9918309193506421</subfield>
+        <subfield code='8'>22645461280006421</subfield>
+        <subfield code='a'>01PRI_INST</subfield>
+        <subfield code='b'>eastasian</subfield>
+        <subfield code='c'>Remote Storage (ReCAP): East Asian Library Use Only</subfield>
+        <subfield code='d'>9315/4228</subfield>
+        <subfield code='e'>unavailable</subfield>
+        <subfield code='f'>1</subfield>
+        <subfield code='g'>1</subfield>
+        <subfield code='j'>pl</subfield>
+        <subfield code='k'>8</subfield>
+        <subfield code='p'>1</subfield>
+        <subfield code='q'>East Asian Library</subfield>
+    </datafield>
+</record>

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -92,6 +92,10 @@ describe 'From traject_config.rb', indexing: true do
       @diary = @indexer.map_record(fixture_record('99117267623506421'))
       @lc_subject_facet = @indexer.map_record(fixture_record('9933506421'))
       @lc_subject_facet2 = @indexer.map_record(fixture_record('99125394249206421'))
+      @homoit_subject_facet = @indexer.map_record(fixture_record('99120508103506421'))
+      @record_99129068748706421 = @indexer.map_record(fixture_record('99129068748706421'))
+      @record_99131369793306421 = @indexer.map_record(fixture_record('99131369793306421'))
+      @siku_subject_facet = @indexer.map_record(fixture_record('9918309193506421'))
     end
 
     describe 'alma loading' do
@@ -1316,6 +1320,63 @@ describe 'From traject_config.rb', indexing: true do
           expect(@lc_subject_facet2['lc_subject_facet']).to include('Conductors (Music)—Soviet Union—Biography')
           expect(@lc_subject_facet2['lc_subject_facet']).to include('Musicians, Russian')
           expect(@lc_subject_facet2['lc_subject_facet']).to include('Musicians, Russian—Biography')
+        end
+      end
+
+      describe 'homoit_subject_facet' do
+        it 'includes all homoit subjects in homoit_subject_facet' do
+          expect(@homoit_subject_facet['homoit_subject_facet']).to include('Same-sex marriage')
+          expect(@homoit_subject_facet['homoit_subject_facet']).to include('Same-sex marriage—Juvenile fiction')
+          expect(@homoit_subject_facet['homoit_subject_facet']).to include('Marriage')
+          expect(@homoit_subject_facet['homoit_subject_facet']).to include('Marriage—Juvenile fiction')
+          expect(@homoit_subject_facet['homoit_subject_facet']).to include('Friendships')
+          expect(@homoit_subject_facet['homoit_subject_facet']).to include('Friendships—Juvenile fiction')
+        end
+      end
+
+      describe 'aat_genre_facet' do
+        it 'includes all aat genres in aat_genre_facet' do
+          expect(@record_99129068748706421['aat_genre_facet']).to include('Cadastral maps')
+          expect(@record_99129068748706421['aat_genre_facet']).to include('Cadastral maps—New Jersey')
+          expect(@record_99129068748706421['aat_genre_facet']).to include('Cadastral maps—New Jersey—Princeton')
+          expect(@record_99129068748706421['aat_genre_facet']).to include('Cadastral maps—New Jersey—Princeton—1852')
+          expect(@record_99129068748706421['aat_genre_facet']).to include('City maps')
+          expect(@record_99129068748706421['aat_genre_facet']).to include('City maps—New Jersey')
+          expect(@record_99129068748706421['aat_genre_facet']).to include('City maps—New Jersey—Princeton')
+          expect(@record_99129068748706421['aat_genre_facet']).to include('City maps—New Jersey—Princeton—1852')
+        end
+      end
+
+      describe 'lcgft_genre_facet' do
+        it 'includes all lc genres subjects in lcgft_genre_facet' do
+          expect(@record_99129068748706421['lcgft_genre_facet']).to include('Maps')
+          expect(@record_99129068748706421['lcgft_genre_facet']).to include('Maps—New Jersey')
+          expect(@record_99129068748706421['lcgft_genre_facet']).to include('Maps—New Jersey—Princeton')
+          expect(@record_99129068748706421['lcgft_genre_facet']).to include('Maps—New Jersey—Princeton—19th century')
+        end
+      end
+
+      describe 'rbgenr_genre_facet' do
+        it 'includes all rare books genres in rbgenr_genre_facet' do
+          expect(@record_99131369793306421['rbgenr_genre_facet']).to include('Dust jackets (Bindings)')
+          expect(@record_99131369793306421['rbgenr_genre_facet']).to include('Dust jackets (Bindings)—2013')
+          expect(@record_99131369793306421['rbgenr_genre_facet']).to include('Dust jackets (Binding)')
+          expect(@record_99131369793306421['rbgenr_genre_facet']).to include('Dust jackets (Binding)—2013')
+        end
+      end
+
+      describe 'siku_subject_facet' do
+        it 'includes all siku subjects in siku_subject_facet' do
+          expect(@siku_subject_facet['siku_subject_facet']).to include('Zi bu')
+          expect(@siku_subject_facet['siku_subject_facet']).to include('Zi bu—Zhu jia lei')
+          expect(@siku_subject_facet['siku_subject_facet']).to include('Zi bu—Zhu jia lei—Jidu jiao zhi shu')
+          expect(@siku_subject_facet['siku_subject_facet']).to include('子部')
+          expect(@siku_subject_facet['siku_subject_facet']).to include('子部—諸家類')
+          expect(@siku_subject_facet['siku_subject_facet']).to include('子部—諸家類—基督教之屬')
+          expect(@siku_subject_facet['siku_subject_facet']).to include('Zi bu—Tian wen suan fa lei')
+          expect(@siku_subject_facet['siku_subject_facet']).to include('Zi bu—Tian wen suan fa lei—Li fa.')
+          expect(@siku_subject_facet['siku_subject_facet']).to include('子部—天文算法類')
+          expect(@siku_subject_facet['siku_subject_facet']).to include('子部—天文算法類—曆法.')
         end
       end
 


### PR DESCRIPTION

Helps with vocabulary work https://github.com/pulibrary/orangelight/pull/3386

rbgenr_genre_facet
aat_genre_facet
lcgft_genre_facet
homoit_genre_facet
homoit_subject_facet
local_subject_facet
siku_subject_facet


@mzelesky could not find a record with local subject vocabulary field. We will add a fixture when we have one. 