### PR TITLE
Only measure code coverage in CI by default

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,23 @@
-require 'simplecov'
-require 'coveralls'
+def in_ci?
+  ENV.fetch('CI', nil) == 'true'
+end
+
+if in_ci?
+  require 'simplecov'
+  require 'coveralls'
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+    [
+      SimpleCov::Formatter::HTMLFormatter,
+      Coveralls::SimpleCov::Formatter
+    ]
+  )
+  SimpleCov.start('rails') do
+    add_filter '/spec'
+  end
+end
+
 require 'webmock/rspec'
 require 'traject'
 require 'support/required_environments'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..'))
-
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
-  [
-    SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter
-  ]
-)
-SimpleCov.start('rails') do
-  add_filter '/spec'
-end


### PR DESCRIPTION
This reduces performance overhead in TDD cycles, where measuring code coverage is not very useful.  This matches the Orangelight configuration.