### PR TITLE
Only load global indexer service for tests that need it

### DIFF
--- a/config/initializers/traject_initializer.rb
+++ b/config/initializers/traject_initializer.rb
@@ -1,3 +1,7 @@
+def create_global_indexer_service
+  TRAJECT_INDEXER ||= IndexerService.build
+end
+
 Rails.application.reloader.to_prepare do
   if Rails.env.test? || Rails.env.development?
     LocationMapsGeneratorService.generate_from_templates
@@ -5,5 +9,5 @@ Rails.application.reloader.to_prepare do
     LocationMapsGeneratorService.generate
   end
   
-  TRAJECT_INDEXER ||= IndexerService.build  
+  create_global_indexer_service unless Rails.env.test?
 end

--- a/spec/marc_to_solr/lib/augment_the_subject_spec.rb
+++ b/spec/marc_to_solr/lib/augment_the_subject_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+create_global_indexer_service
 
 ##
 # When our catalog records contain subject headings, that should be classified as

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,7 @@ RSpec.configure do |config|
 
   config.infer_spec_type_from_file_location!
   config.when_first_matching_example_defined(:axe) { require 'axe-rspec' }
+  config.when_first_matching_example_defined(:indexing) { create_global_indexer_service }
 
   WebMock.disable_net_connect!(Rails.application.config.webmock_disable_opts)
 end


### PR DESCRIPTION
Building this service can be somewhat expensive, since it reads through the entire traject configuration.