### PR TITLE
Address rails deprecations

### DIFF
--- a/app/models/dump.rb
+++ b/app/models/dump.rb
@@ -10,9 +10,8 @@ class Dump < ActiveRecord::Base
   belongs_to :event
   has_many :dump_files
   # These only apply to change dumps (stored in db rather than text files)
-  serialize :delete_ids
-  serialize :update_ids
-  serialize :recap_barcodes
+  serialize :delete_ids, coder: YAML
+  serialize :update_ids, coder: YAML
   validates :event_id, presence: true
 
   before_destroy do
@@ -21,7 +20,7 @@ class Dump < ActiveRecord::Base
     end
   end
 
-  enum dump_type: {
+  enum :dump_type, {
     full_dump: 1,
     changed_records: 2,
     princeton_recap: 3,

--- a/app/models/dump_file.rb
+++ b/app/models/dump_file.rb
@@ -4,9 +4,9 @@ require 'rubygems/package'
 
 class DumpFile < ActiveRecord::Base
   belongs_to :dump
-  enum index_status: { enqueued: 0, started: 1, done: 2 }
+  enum :index_status, { enqueued: 0, started: 1, done: 2 }
 
-  enum dump_file_type: {
+  enum :dump_file_type, {
     bib_records: 1,
     updated_records: 2,
     recap_records: 3,


### PR DESCRIPTION
* enum has a slightly different API (see https://github.com/rails/rails/pull/50987)
* you now should specify a coder for serialized columns (see https://github.com/rails/rails/pull/47463).  Use YAML for backwards compatibility.
* we weren't actually using one of the serialized columns (`recap_barcodes`), and it doesn't even exist in the database.  Remove it from the model.