### PR TITLE
Move OpenSSH support gems to main group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,12 @@ end
 gem 'alma', '~> 0.5.0'
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sqs'
+gem 'bcrypt_pbkdf'
 gem 'bootstrap-sass', '~> 3.4.1'
 gem 'capybara'
 gem 'change_the_subject', '~> 0.4.0'
 gem 'devise'
+gem 'ed25519'
 gem 'faraday', '~> 1.0'
 gem 'faraday_middleware', '~> 1.0'
 gem 'ffi', '>= 1.9.25'
@@ -67,12 +69,10 @@ group :production do
 end
 
 group :development do
-  gem 'bcrypt_pbkdf'
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
   gem 'capistrano-rails-console', require: false
   gem 'dotenv-rails'
-  gem 'ed25519'
 end
 
 group :development, :test do


### PR DESCRIPTION
bcrypt_pbkdf and ed25519 gems are needed in production and so need to be in the main section of the gemfile.

See also [Honeybadger error](https://app.honeybadger.io/projects/54497/faults/118570109)
```
NotImplementedError: OpenSSH keys only supported if ED25519 is available
net-ssh requires the following gems for ed25519 support:
 * ed25519 (>= 1.2, < 2.0)
 * bcrypt_pbkdf (>= 1.0, < 2.0)
See https://github.com/net-ssh/net-ssh/issues/565 for more information
Gem::LoadError : "ed25519 is not part of the bundle. Add it to your Gemfile."
```