### PR TITLE
Replace deprecated rspec-mock should syntax

### DIFF
--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -12,8 +12,11 @@ RSpec.describe Users::OmniauthCallbacksController do
       it 'alerts the user on failure' do
         controller = described_class.new
         controller.request = ActionDispatch::TestRequest.new('omniauth.origin' => '/')
-        controller.should_receive(:redirect_to).with('/', alert: 'Unauthorized user')
+        allow(controller).to receive(:redirect_to)
+
         controller.cas
+
+        expect(controller).to have_received(:redirect_to).with('/', alert: 'Unauthorized user')
       end
     end
   end


### PR DESCRIPTION
This resolves the deprecation warning:

    Using `should_receive` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated