### PR TITLE
Don't require rest-client gem on Rails startup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem 'pg'
 gem 'rack'
 gem 'rails', '~> 7.2'
 gem 'responders'
-gem 'rest-client'
+gem 'rest-client', require: false
 gem 'rsolr', '~> 2.5.0'
 gem 'rubyzip'
 gem 'sass-rails'


### PR DESCRIPTION
This gem is only used in a test script within this repo, not in any production code or our test suite.  Therefore, there is no need to load it every time we start Rails or run a test.