### PR TITLE
Create new fields for pipe delimited hierarchical facets

### DIFF
--- a/marc_to_solr/translation_maps/marc_countries_hierarchical_pipe.yaml
+++ b/marc_to_solr/translation_maps/marc_countries_hierarchical_pipe.yaml
@@ -1,0 +1,386 @@
+# Scraped from http://www.loc.gov/marc/countries/countries_code.html at 2025-03-18
+# Intentionally includes discontinued codes, except -ai Anguilla, which is used for Armenia.
+# Also includes hierarchies for available countries (currently Australia, Canada, the United Kingdom, the United States, and the historical USSR).
+
+'aa': 'Albania'
+'abc': ['Canada', 'Canada|Alberta']
+'ac': 'Ashmore and Cartier Islands'
+'aca': ['Australia', 'Australia|Australian Capital Territory']
+'ae': 'Algeria'
+'af': 'Afghanistan'
+'ag': 'Argentina'
+'ai': 'Armenia (Republic)'
+'air': ['Soviet Union', 'Soviet Union|Armenian S.S.R.']
+'aj': 'Azerbaijan'
+'ajr': ['Soviet Union', 'Soviet Union|Azerbaijan S.S.R.']
+'aku': ['United States', 'United States|Alaska']
+'alu': ['United States', 'United States|Alabama']
+'am': 'Anguilla'
+'an': 'Andorra'
+'ao': 'Angola'
+'aq': 'Antigua and Barbuda'
+'aru': ['United States', 'United States|Arkansas']
+'as': 'American Samoa'
+'at': 'Australia'
+'au': 'Austria'
+'aw': 'Aruba'
+'ay': 'Antarctica'
+'azu': ['United States', 'United States|Arizona']
+'ba': 'Bahrain'
+'bb': 'Barbados'
+'bcc': ['Canada', 'Canada|British Columbia']
+'bd': 'Burundi'
+'be': 'Belgium'
+'bf': 'Bahamas'
+'bg': 'Bangladesh'
+'bh': 'Belize'
+'bi': 'British Indian Ocean Territory'
+'bl': 'Brazil'
+'bm': 'Bermuda Islands'
+'bn': 'Bosnia and Herzegovina'
+'bo': 'Bolivia'
+'bp': 'Solomon Islands'
+'br': 'Burma'
+'bs': 'Botswana'
+'bt': 'Bhutan'
+'bu': 'Bulgaria'
+'bv': 'Bouvet Island'
+'bw': 'Belarus'
+'bwr': ['Soviet Union', 'Soviet Union|Byelorussian S.S.R.']
+'bx': 'Brunei'
+'ca': 'Caribbean Netherlands'
+'cau': ['United States', 'United States|California']
+'cb': 'Cambodia'
+'cc': 'China'
+'cd': 'Chad'
+'ce': 'Sri Lanka'
+'cf': 'Congo (Brazzaville)'
+'cg': 'Congo (Democratic Republic)'
+'ch': 'China (Republic : 1949- )'
+'ci': 'Croatia'
+'cj': 'Cayman Islands'
+'ck': 'Colombia'
+'cl': 'Chile'
+'cm': 'Cameroon'
+'cn': 'Canada'
+'co': 'Curaçao'
+'cou': ['United States', 'United States|Colorado']
+'cp': 'Canton and Enderbury Islands'
+'cq': 'Comoros'
+'cr': 'Costa Rica'
+'cs': 'Czechoslovakia'
+'ctu': ['United States', 'United States|Connecticut']
+'cu': 'Cuba'
+'cv': 'Cabo Verde'
+'cw': 'Cook Islands'
+'cx': 'Central African Republic'
+'cy': 'Cyprus'
+'cz': 'Canal Zone'
+'dcu': ['United States', 'United States|District of Columbia']
+'deu': ['United States', 'United States|Delaware']
+'dk': 'Denmark'
+'dm': 'Benin'
+'dq': 'Dominica'
+'dr': 'Dominican Republic'
+'ea': 'Eritrea'
+'ec': 'Ecuador'
+'eg': 'Equatorial Guinea'
+'em': 'Timor-Leste'
+'enk': ['United Kingdom', 'United Kingdom|England']
+'er': 'Estonia'
+'err': ['Soviet Union', 'Soviet Union|Estonia']
+'es': 'El Salvador'
+'et': 'Ethiopia'
+'fa': 'Faroe Islands'
+'fg': 'French Guiana'
+'fi': 'Finland'
+'fj': 'Fiji'
+'fk': 'Falkland Islands'
+'flu': ['United States', 'United States|Florida']
+'fm': 'Micronesia (Federated States)'
+'fp': 'French Polynesia'
+'fr': 'France'
+'fs': 'Terres australes et antarctiques françaises'
+'ft': 'Djibouti'
+'gau': ['United States', 'United States|Georgia']
+'gb': 'Kiribati'
+'gd': 'Grenada'
+'ge': 'Germany (East)'
+'gg': 'Guernsey'
+'gh': 'Ghana'
+'gi': 'Gibraltar'
+'gl': 'Greenland'
+'gm': 'Gambia'
+'gn': 'Gilbert and Ellice Islands'
+'go': 'Gabon'
+'gp': 'Guadeloupe'
+'gr': 'Greece'
+'gs': 'Georgia (Republic)'
+'gsr': ['Soviet Union', 'Soviet Union|Georgian S.S.R.']
+'gt': 'Guatemala'
+'gu': 'Guam'
+'gv': 'Guinea'
+'gw': 'Germany'
+'gy': 'Guyana'
+'gz': 'Gaza Strip'
+'hiu': ['United States', 'United States|Hawaii']
+'hk': 'Hong Kong'
+'hm': 'Heard and McDonald Islands'
+'ho': 'Honduras'
+'ht': 'Haiti'
+'hu': 'Hungary'
+'iau': ['United States', 'United States|Iowa']
+'ic': 'Iceland'
+'idu': ['United States', 'United States|Idaho']
+'ie': 'Ireland'
+'ii': 'India'
+'ilu': ['United States', 'United States|Illinois']
+'im': 'Isle of Man'
+'inu': ['United States', 'United States|Indiana']
+'io': 'Indonesia'
+'iq': 'Iraq'
+'ir': 'Iran'
+'is': 'Israel'
+'it': 'Italy'
+'iu': 'Israel-Syria Demilitarized Zones'
+'iv': 'Côte d''Ivoire'
+'iw': 'Israel-Jordan Demilitarized Zones'
+'iy': 'Iraq-Saudi Arabia Neutral Zone'
+'ja': 'Japan'
+'je': 'Jersey'
+'ji': 'Johnston Atoll'
+'jm': 'Jamaica'
+'jn': 'Jan Mayen'
+'jo': 'Jordan'
+'ke': 'Kenya'
+'kg': 'Kyrgyzstan'
+'kgr': ['Soviet Union', 'Soviet Union|Kirghiz S.S.R.']
+'kn': 'Korea (North)'
+'ko': 'Korea (South)'
+'ksu': ['United States', 'United States|Kansas']
+'ku': 'Kuwait'
+'kv': 'Kosovo'
+'kyu': ['United States', 'United States|Kentucky']
+'kz': 'Kazakhstan'
+'kzr': ['Soviet Union', 'Soviet Union|Kazakh S.S.R.']
+'lau': ['United States', 'United States|Louisiana']
+'lb': 'Liberia'
+'le': 'Lebanon'
+'lh': 'Liechtenstein'
+'li': 'Lithuania'
+'lir': ['Soviet Union', 'Soviet Union|Lithuania']
+'ln': 'Central and Southern Line Islands'
+'lo': 'Lesotho'
+'ls': 'Laos'
+'lu': 'Luxembourg'
+'lv': 'Latvia'
+'lvr': ['Soviet Union', 'Soviet Union|Latvia']
+'ly': 'Libya'
+'mau': ['United States', 'United States|Massachusetts']
+'mbc': ['Canada', 'Canada|Manitoba']
+'mc': 'Monaco'
+'mdu': ['United States', 'United States|Maryland']
+'meu': ['United States', 'United States|Maine']
+'mf': 'Mauritius'
+'mg': 'Madagascar'
+'mh': 'Macao'
+'miu': ['United States', 'United States|Michigan']
+'mj': 'Montserrat'
+'mk': 'Oman'
+'ml': 'Mali'
+'mm': 'Malta'
+'mnu': ['United States', 'United States|Minnesota']
+'mo': 'Montenegro'
+'mou': ['United States', 'United States|Missouri']
+'mp': 'Mongolia'
+'mq': 'Martinique'
+'mr': 'Morocco'
+'msu': ['United States', 'United States|Mississippi']
+'mtu': ['United States', 'United States|Montana']
+'mu': 'Mauritania'
+'mv': 'Moldova'
+'mvr': ['Soviet Union', 'Soviet Union|Moldavian S.S.R.']
+'mw': 'Malawi'
+'mx': 'Mexico'
+'my': 'Malaysia'
+'mz': 'Mozambique'
+'na': 'Netherlands Antilles'
+'nbu': ['United States', 'United States|Nebraska']
+'ncu': ['United States', 'United States|North Carolina']
+'ndu': ['United States', 'United States|North Dakota']
+'ne': 'Netherlands'
+'nfc': ['Canada', 'Canada|Newfoundland and Labrador']
+'ng': 'Niger'
+'nhu': ['United States', 'United States|New Hampshire']
+'nik': ['United Kingdom', 'United Kingdom|Northern Ireland']
+'nju': ['United States', 'United States|New Jersey']
+'nkc': ['Canada', 'Canada|New Brunswick']
+'nl': 'New Caledonia'
+'nm': 'Northern Mariana Islands'
+'nmu': ['United States', 'United States|New Mexico']
+'nn': 'Vanuatu'
+'no': 'Norway'
+'np': 'Nepal'
+'nq': 'Nicaragua'
+'nr': 'Nigeria'
+'nsc': ['Canada', 'Canada|Nova Scotia']
+'ntc': ['Canada', 'Canada|Northwest Territories']
+'nu': 'Nauru'
+'nuc': ['Canada', 'Canada|Nunavut']
+'nvu': ['United States', 'United States|Nevada']
+'nw': 'Northern Mariana Islands'
+'nx': 'Norfolk Island'
+'nyu': ['United States', 'United States|New York (State)']
+'nz': 'New Zealand'
+'ohu': ['United States', 'United States|Ohio']
+'oku': ['United States', 'United States|Oklahoma']
+'onc': ['Canada', 'Canada|Ontario']
+'oru': ['United States', 'United States|Oregon']
+'ot': 'Mayotte'
+'pau': ['United States', 'United States|Pennsylvania']
+'pc': 'Pitcairn Island'
+'pe': 'Peru'
+'pf': 'Paracel Islands'
+'pg': 'Guinea-Bissau'
+'ph': 'Philippines'
+'pic': ['Canada', 'Canada|Prince Edward Island']
+'pk': 'Pakistan'
+'pl': 'Poland'
+'pn': 'Panama'
+'po': 'Portugal'
+'pp': 'Papua New Guinea'
+'pr': 'Puerto Rico'
+'pt': 'Portuguese Timor'
+'pw': 'Palau'
+'py': 'Paraguay'
+'qa': 'Qatar'
+'qea': ['Australia', 'Australia|Queensland']
+'quc': ['Canada', 'Canada|Québec (Province)']
+'rb': 'Serbia'
+'re': 'Réunion'
+'rh': 'Zimbabwe'
+'riu': ['United States', 'United States|Rhode Island']
+'rm': 'Romania'
+'ru': 'Russia (Federation)'
+'rur': ['Soviet Union', 'Soviet Union|Russian S.F.S.R.']
+'rw': 'Rwanda'
+'ry': 'Ryukyu Islands, Southern'
+'sa': 'South Africa'
+'sb': 'Svalbard'
+'sc': 'Saint-Barthélemy'
+'scu': ['United States', 'United States|South Carolina']
+'sd': 'South Sudan'
+'sdu': ['United States', 'United States|South Dakota']
+'se': 'Seychelles'
+'sf': 'Sao Tome and Principe'
+'sg': 'Senegal'
+'sh': 'Spanish North Africa'
+'si': 'Singapore'
+'sj': 'Sudan'
+'sk': 'Sikkim'
+'sl': 'Sierra Leone'
+'sm': 'San Marino'
+'sn': 'Sint Maarten'
+'snc': ['Canada', 'Canada|Saskatchewan']
+'so': 'Somalia'
+'sp': 'Spain'
+'sq': 'Swaziland'
+'sr': 'Surinam'
+'ss': 'Western Sahara'
+'st': 'Saint-Martin'
+'stk': ['United Kingdom', 'United Kingdom|Scotland']
+'su': 'Saudi Arabia'
+'sv': 'Swan Islands'
+'sw': 'Sweden'
+'sx': 'Namibia'
+'sy': 'Syria'
+'sz': 'Switzerland'
+'ta': 'Tajikistan'
+'tar': ['Soviet Union', 'Soviet Union|Tajik S.S.R.']
+'tc': 'Turks and Caicos Islands'
+'tg': 'Togo'
+'th': 'Thailand'
+'ti': 'Tunisia'
+'tk': 'Turkmenistan'
+'tkr': ['Soviet Union', 'Soviet Union|Turkmen S.S.R.']
+'tl': 'Tokelau'
+'tma': ['Australia', 'Australia|Tasmania']
+'tnu': ['United States', 'United States|Tennessee']
+'to': 'Tonga'
+'tr': 'Trinidad and Tobago'
+'ts': 'United Arab Emirates'
+'tt': 'Trust Territory of the Pacific Islands'
+'tu': 'Turkey'
+'tv': 'Tuvalu'
+'txu': ['United States', 'United States|Texas']
+'tz': 'Tanzania'
+'ua': 'Egypt'
+'uc': 'United States Misc. Caribbean Islands'
+'ug': 'Uganda'
+'ui': 'United Kingdom Misc. Islands'
+'uik': ['United Kingdom', 'United Kingdom|United Kingdom Misc. Islands']
+'uk': 'United Kingdom'
+'un': 'Ukraine'
+'unr': ['Soviet Union', 'Soviet Union|Ukraine']
+'up': 'United States Misc. Pacific Islands'
+'ur': 'Soviet Union'
+'us': 'United States'
+'utu': ['United States', 'United States|Utah']
+'uv': 'Burkina Faso'
+'uy': 'Uruguay'
+'uz': 'Uzbekistan'
+'uzr': ['Soviet Union', 'Soviet Union|Uzbek S.S.R.']
+'vau': ['United States', 'United States|Virginia']
+'vb': 'British Virgin Islands'
+'vc': 'Vatican City'
+'ve': 'Venezuela'
+'vi': 'Virgin Islands of the United States'
+'vm': 'Vietnam'
+'vn': 'Vietnam, North'
+'vp': 'Various places'
+'vra': ['Australia', 'Australia|Victoria']
+'vs': 'Vietnam, South'
+'vtu': ['United States', 'United States|Vermont']
+'wau': ['United States', 'United States|Washington (State)']
+'wb': 'West Berlin'
+'wea': ['Australia', 'Australia|Western Australia']
+'wf': 'Wallis and Futuna'
+'wiu': ['United States', 'United States|Wisconsin']
+'wj': 'West Bank of the Jordan River'
+'wk': 'Wake Island'
+'wlk': ['United Kingdom', 'United Kingdom|Wales']
+'ws': 'Samoa'
+'wvu': ['United States', 'United States|West Virginia']
+'wyu': ['United States', 'United States|Wyoming']
+'xa': 'Christmas Island (Indian Ocean)'
+'xb': 'Cocos (Keeling) Islands'
+'xc': 'Maldives'
+'xd': 'Saint Kitts-Nevis'
+'xe': 'Marshall Islands'
+'xf': 'Midway Islands'
+'xga': ['Australia', 'Australia|Coral Sea Islands Territory']
+'xh': 'Niue'
+'xi': 'Saint Kitts-Nevis-Anguilla'
+'xj': 'Saint Helena'
+'xk': 'Saint Lucia'
+'xl': 'Saint Pierre and Miquelon'
+'xm': 'Saint Vincent and the Grenadines'
+'xn': 'Macedonia'
+'xna': ['Australia', 'Australia|New South Wales']
+'xo': 'Slovakia'
+'xoa': ['Australia', 'Australia|Northern Territory']
+'xp': 'Spratly Island'
+'xr': 'Czech Republic'
+'xra': ['Australia', 'Australia|South Australia']
+'xs': 'South Georgia and the South Sandwich Islands'
+'xv': 'Slovenia'
+'xx': 'No place, unknown, or undetermined'
+'xxc': ['Canada', 'Canada|Canada']
+'xxk': ['United Kingdom', 'United Kingdom|United Kingdom']
+'xxr': 'Soviet Union'
+'xxu': ['United States', 'United States|United States']
+'ye': 'Yemen'
+'ykc': ['Canada', 'Canada|Yukon Territory']
+'ys': 'Yemen (People''s Democratic Republic)'
+'yu': 'Serbia and Montenegro'
+'za': 'Zambia'

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -609,6 +609,17 @@ describe 'From traject_config.rb', indexing: true do
       end
     end
 
+    describe 'publication_place_hierarchical_pipe_facet field' do
+      it 'maps the 3-digit code in the 008[15-17] to a country and state' do
+        expect(@sample1['publication_place_hierarchical_pipe_facet']).to eq ['United States', 'United States|Michigan']
+      end
+
+      it 'maps the 2-digit code in the 008[15-17] to a country' do
+        expect(@added_title_246['publication_place_hierarchical_pipe_facet']).to eq ['Japan']
+      end
+    end
+
+    # TODO: Remove in favor of publication_place_hierarchical_pipe_facet once reindex complete
     describe 'publication_place_hierarchical_facet field' do
       it 'maps the 3-digit code in the 008[15-17] to a country and state' do
         expect(@sample1['publication_place_hierarchical_facet']).to eq ['United States', 'United States:Michigan']
@@ -1107,6 +1118,31 @@ describe 'From traject_config.rb', indexing: true do
         end
       end
     end
+
+    describe 'lc_pipe_facet' do
+      let(:t050) { { '050' => { 'ind1' => '0', 'ind2' => '0', 'subfields' => [{ 'a' => 'IN PROCESS' }] } } }
+      let(:record) { @indexer.map_record(MARC::Record.new_from_hash('fields' => [t050], 'leader' => leader)) }
+
+      it 'includes a field with data for the classification facet' do
+        lc_facet = @sample40['lc_pipe_facet']
+        expect(lc_facet).to match_array(['R - Medicine', 'R - Medicine|RA - Public Aspects of Medicine'])
+      end
+
+      it 'handles cases where the call number is a single letter' do
+        lc_facet = @sample44['lc_pipe_facet']
+        expect(lc_facet).to match_array(['Z - Bibliography, Library Science, Information Resources', 'Z - Bibliography, Library Science, Information Resources|Z - Bibliography, Library Science, Information Resources'])
+      end
+
+      it 'handles cases where there is no call number' do
+        lc_facet = @record_no_call_number['lc_pipe_facet']
+        expect(lc_facet).to be_nil
+      end
+
+      it 'does not index data into the lc_facet field if the call number is invalid' do
+        expect(record['lc_pipe_facet']).to be_nil
+      end
+    end
+    # TODO: Remove in favor of lc_pipe_facet once reindex complete
 
     describe 'lc_facet' do
       let(:t050) { { '050' => { 'ind1' => '0', 'ind2' => '0', 'subfields' => [{ 'a' => 'IN PROCESS' }] } } }


### PR DESCRIPTION
Since colons were present in the data, they did not make a good delimiter for hierarchical fields.

Connected to #2679