### PR TITLE
Remove redundant require

### DIFF
--- a/spec/support/system_specs.rb
+++ b/spec/support/system_specs.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'capybara/rspec'
-require 'selenium-webdriver'
 
 Capybara.default_max_wait_time = 60
 Capybara.server = :puma, { Silent: true }


### PR DESCRIPTION
Rails requires gems by default, so there is no need to require it again.