### PR TITLE
Update Mockito to a more recent version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +430,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -792,20 +799,26 @@ dependencies = [
 
 [[package]]
 name = "mockito"
-version = "0.31.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f9fece9bd97ab74339fe19f4bcaf52b76dcc18e5364c7977c1838f76b38de9"
+checksum = "7760e0e418d9b7e5777c0374009ca4c93861b9066f18cb334a20ce50ab63aa48"
 dependencies = [
  "assert-json-diff",
+ "bytes",
  "colored",
- "httparse",
- "lazy_static",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "log",
  "rand",
  "regex",
  "serde_json",
  "serde_urlencoded",
  "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -976,20 +989,19 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -997,11 +1009,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.3.2",
 ]
 
 [[package]]

--- a/lib/bibdata_rs/Cargo.toml
+++ b/lib/bibdata_rs/Cargo.toml
@@ -17,4 +17,4 @@ itertools = "0.14.0"
 lazy_static = "1.5.0"
 
 [dev-dependencies]
-mockito = "0.31"
+mockito = "1.7.0"

--- a/lib/bibdata_rs/src/ephemera/ephemera_folder.rs
+++ b/lib/bibdata_rs/src/ephemera/ephemera_folder.rs
@@ -39,71 +39,74 @@ pub async fn ephemera_folders_iterator() -> Vec<Vec<String>> {
 
 #[cfg(test)]
 mod tests {
-
-    use mockito::mock;
     use std::path::PathBuf;
 
-    use crate::ephemera::ephemera_folder::read_ephemera_folders;
+    use crate::{ephemera::ephemera_folder::read_ephemera_folders, testing_support::preserving_envvar_async};
 
     #[tokio::test]
     async fn test_read_ephemera_folders() {
-        let mock_url = mockito::server_url();
-        std::env::set_var("FIGGY_BORN_DIGITAL_EPHEMERA_URL", &mock_url);
+        preserving_envvar_async("FIGGY_BORN_DIGITAL_EPHEMERA_URL", || async {
+            let mut server = mockito::Server::new_async().await;
+            std::env::set_var("FIGGY_BORN_DIGITAL_EPHEMERA_URL", &server.url());
+    
+            let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            d.push("../../spec/fixtures/files/ephemera/ephemera_folders.json");
+    
+            let mock = server.mock("GET", "/")
+                .with_status(200)
+                .with_header("content-type", "application/json")
+                .with_body_from_file(d.to_string_lossy().to_string())
+                .create_async().await;
+    
+            let result = read_ephemera_folders().await.unwrap();
+            assert!(!result.is_empty());
+            assert!(result.contains(
+                &"https://figgy-staging.princeton.edu/catalog/af4a941d-96a4-463e-9043-cfa511e5eddd"
+                    .to_string()
+            ));
+    
+            mock.assert_async().await;
+        }).await;
 
-        let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        d.push("../../spec/fixtures/files/ephemera/ephemera_folders.json");
-
-        let mock = mock("GET", "/")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body_from_file(d.to_string_lossy().to_string())
-            .create();
-
-        let result = read_ephemera_folders().await.unwrap();
-        assert!(!result.is_empty());
-        assert!(result.contains(
-            &"https://figgy-staging.princeton.edu/catalog/af4a941d-96a4-463e-9043-cfa511e5eddd"
-                .to_string()
-        ));
-
-        mock.assert();
     }
 
     #[tokio::test]
     async fn test_ephemera_folders_iterator() {
-        let mock_url = mockito::server_url();
-        std::env::set_var("FIGGY_BORN_DIGITAL_EPHEMERA_URL", &mock_url);
-
-        let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        d.push("../../spec/fixtures/files/ephemera/ephemera_folders.json");
-        let mock = mock("GET", "/")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body_from_file(d.to_string_lossy().to_string())
-            .create();
-
-        let data = read_ephemera_folders().await.unwrap();
-        assert!(!data.is_empty());
-        let chunk_size = 3;
-        let mut result: Vec<Vec<String>> = Vec::new();
-        for chunk in data.chunks(chunk_size) {
-            result.push(chunk.to_vec());
-        }
-
-        assert!(!result.is_empty());
-        assert_eq!(result.len(), 4); // Total chunks should be 4
-        assert_eq!(result[0].len(), 3); // First chunk should have 3 items
-        assert_eq!(result[1].len(), 3); // Second chunk should have 3 items
-        assert_eq!(result[2].len(), 3); // Third chunk should have 3 items
-        assert_eq!(result[3].len(), 3); // Forth chunk should have 3 items
-        assert_eq!(
-            result[1],
-            [
-                "https://figgy-staging.princeton.edu/catalog/602ebba6-1bae-4ba0-9266-0360c27537fe",
-                "https://figgy-staging.princeton.edu/catalog/af4a941d-96a4-463e-9055-cfa512e5eddd",
-                "https://figgy-staging.princeton.edu/catalog/33fc03db-3bca-4388-84gg-6b48092199d6"
-            ]
-        );
-        mock.assert();
+        preserving_envvar_async("FIGGY_BORN_DIGITAL_EPHEMERA_URL", || async {
+            let mut server = mockito::Server::new_async().await;
+            std::env::set_var("FIGGY_BORN_DIGITAL_EPHEMERA_URL", &server.url());
+    
+            let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            d.push("../../spec/fixtures/files/ephemera/ephemera_folders.json");
+            let mock = server.mock("GET", "/")
+                .with_status(200)
+                .with_header("content-type", "application/json")
+                .with_body_from_file(d.to_string_lossy().to_string())
+                .create_async().await;
+    
+            let data = read_ephemera_folders().await.unwrap();
+            assert!(!data.is_empty());
+            let chunk_size = 3;
+            let mut result: Vec<Vec<String>> = Vec::new();
+            for chunk in data.chunks(chunk_size) {
+                result.push(chunk.to_vec());
+            }
+    
+            assert!(!result.is_empty());
+            assert_eq!(result.len(), 4); // Total chunks should be 4
+            assert_eq!(result[0].len(), 3); // First chunk should have 3 items
+            assert_eq!(result[1].len(), 3); // Second chunk should have 3 items
+            assert_eq!(result[2].len(), 3); // Third chunk should have 3 items
+            assert_eq!(result[3].len(), 3); // Forth chunk should have 3 items
+            assert_eq!(
+                result[1],
+                [
+                    "https://figgy-staging.princeton.edu/catalog/602ebba6-1bae-4ba0-9266-0360c27537fe",
+                    "https://figgy-staging.princeton.edu/catalog/af4a941d-96a4-463e-9055-cfa512e5eddd",
+                    "https://figgy-staging.princeton.edu/catalog/33fc03db-3bca-4388-84gg-6b48092199d6"
+                ]
+            );
+            mock.assert_async().await;
+        }).await;
     }
 }


### PR DESCRIPTION
Also includes the commit from #2712

Changes needed to get the tests passing with the new Mockito version:

- adding a call to `mockito::Server::new_async().await`
- Changing `mockito::server_url()` to `server.url()`
- Changing `mock` to `server.mock`
- Changing `mock.assert()` to `mock.assert_async().await`
- Wrapping the tests in a new `preserving_envvar_async` helper, to avoid test flakiness when tests attempt to modify the `FIGGY_BORN_DIGITAL_EPHEMERA_URL` environment variable simultaneously