### PR TITLE
Rescue from error for development

### DIFF
--- a/db/migrate/20250502205347_build_translation_map.rb
+++ b/db/migrate/20250502205347_build_translation_map.rb
@@ -1,5 +1,7 @@
 class BuildTranslationMap < ActiveRecord::Migration[7.2]
   def change
     Rake::Task['figgy_mms_ids:build_translation_map'].invoke
+  rescue MmsRecordsReport::AuthenticationError
+    puts("Cannot authenticate to build figgy_mms_ids translation map, skipping.")
   end
 end


### PR DESCRIPTION
If the developer was off VPN and did not have the proper key in their environment the migrations would error. This file is not necessary for all developers, so rescue and output info for migrations.