### PR TITLE
Remove lazy_static dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,6 @@ dependencies = [
  "codes-iso-639",
  "env_logger",
  "itertools 0.14.0",
- "lazy_static",
  "log",
  "magnus",
  "mockito",

--- a/lib/bibdata_rs/Cargo.toml
+++ b/lib/bibdata_rs/Cargo.toml
@@ -16,7 +16,6 @@ serde_json = "1.0.140"
 reqwest = { version = "0.12.15", features = ["json", "blocking"] }
 tokio = { version = "1", features = ["full"] }
 itertools = "0.14.0"
-lazy_static = "1.5.0"
 codes-iso-639 = "0.1.5"
 parse_datetime = "0.9.0"
 chrono = "0.4.41"

--- a/lib/bibdata_rs/src/testing_support.rs
+++ b/lib/bibdata_rs/src/testing_support.rs
@@ -1,9 +1,7 @@
-use std::{env, future::Future, sync::Mutex};
+use std::{env, future::Future, sync::{LazyLock, Mutex}};
 
 // A mutex to ensure that the environment variable access is thread-safe
-lazy_static::lazy_static! {
-    static ref ENV_MUTEX: Mutex<()> = Mutex::new(());
-}
+static ENV_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 /// This function can be used to wrap your test functions that
 /// modify environment variables.  Since rust runs tests in


### PR DESCRIPTION
`LazyLock` from the standard library fulfills the same purpose.