### PR TITLE
Refactor solr format from a string to an enum

### DIFF
--- a/lib/bibdata_rs/src/ephemera/ephemera_folder_item.rs
+++ b/lib/bibdata_rs/src/ephemera/ephemera_folder_item.rs
@@ -1,3 +1,5 @@
+use crate::solr;
+
 use super::{
     ephemera_folder_item_builder::EphemeraFolderItemBuilder,
     ephemera_folders::ephemera_folders_iterator,
@@ -24,6 +26,13 @@ pub struct EphemeraFolderItem {
 impl EphemeraFolderItem {
     pub fn builder() -> EphemeraFolderItemBuilder {
         EphemeraFolderItemBuilder::new()
+    }
+
+    pub fn solr_formats(&self) -> Vec<solr::Format> {
+        match &self.format {
+            Some(formats) => formats.iter().filter_map(|f| f.pref_label).collect(),
+            _ => vec![],
+        }
     }
 }
 
@@ -59,6 +68,7 @@ pub fn json_ephemera_document(url: String) -> Result<String, magnus::Error> {
 mod tests {
     use crate::{
         ephemera::CatalogClient,
+        solr,
         testing_support::{preserving_envvar, preserving_envvar_async},
     };
 
@@ -106,8 +116,8 @@ mod tests {
 
         let ephemera_folder_item: EphemeraFolderItem = serde_json::from_reader(reader).unwrap();
         assert_eq!(
-            ephemera_folder_item.format.unwrap()[0].rename_format(),
-            Some("Book".to_string())
+            ephemera_folder_item.format.unwrap()[0].pref_label,
+            Some(solr::Format::Book)
         );
     }
 

--- a/lib/bibdata_rs/src/ephemera/ephemera_folder_item/format.rs
+++ b/lib/bibdata_rs/src/ephemera/ephemera_folder_item/format.rs
@@ -1,19 +1,9 @@
+use crate::solr;
 use serde::Deserialize;
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Copy, Clone, Deserialize, Debug)]
 pub struct Format {
-    pub pref_label: Option<String>,
-}
-
-impl Format {
-    pub fn rename_format(&self) -> Option<String> {
-        match &self.pref_label {
-            Some(f) if f == "Books" => Some("Book".to_string()),
-            Some(f) if f == "Serials" => Some("Journal".to_string()),
-            Some(f) if f == "Reports" => Some("Report".to_string()),
-            _ => None,
-        }
-    }
+    pub pref_label: Option<solr::Format>,
 }
 
 #[cfg(test)]
@@ -40,6 +30,6 @@ mod tests {
             }
           ]"#;
         let formats: Vec<Format> = serde_json::from_str(json_ld).unwrap();
-        assert_eq!(formats[0].rename_format(), Some("Book".to_string()));
+        assert_eq!(formats[0].pref_label, Some(solr::Format::Book));
     }
 }

--- a/lib/bibdata_rs/src/solr.rs
+++ b/lib/bibdata_rs/src/solr.rs
@@ -4,7 +4,10 @@ use serde::{Deserialize, Serialize};
 mod builder;
 mod dataspace_solr_mapping;
 mod ephemera_solr_mapping;
+mod format;
 pub mod index;
+
+pub use format::Format;
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct SolrDocument {
@@ -55,7 +58,7 @@ pub struct SolrDocument {
     #[serde(skip_serializing_if = "Option::is_none")]
     electronic_portfolio_s: Option<String>,
 
-    format: Option<Vec<String>>,
+    format: Option<Vec<Format>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub holdings_1display: Option<String>,

--- a/lib/bibdata_rs/src/solr/builder.rs
+++ b/lib/bibdata_rs/src/solr/builder.rs
@@ -1,6 +1,6 @@
 // This module provides a convenient way to create a SolrDocument using the builder pattern
 
-use super::SolrDocument;
+use super::{Format, SolrDocument};
 
 #[derive(Debug, Default)]
 pub struct SolrDocumentBuilder {
@@ -10,7 +10,7 @@ pub struct SolrDocumentBuilder {
     author_roles_1display: Option<String>,
     author_citation_display: Option<Vec<String>>,
     advisor_display: Option<Vec<String>>,
-    format: Option<Vec<String>>,
+    format: Option<Vec<Format>>,
     id: String,
     title_t: Option<Vec<String>>,
     title_citation_display: Option<String>,
@@ -141,7 +141,7 @@ impl SolrDocumentBuilder {
         self
     }
 
-    pub fn with_format(&mut self, format: Vec<String>) -> &mut Self {
+    pub fn with_format(&mut self, format: Vec<Format>) -> &mut Self {
         self.format = Some(format);
         self
     }

--- a/lib/bibdata_rs/src/solr/dataspace_solr_mapping.rs
+++ b/lib/bibdata_rs/src/solr/dataspace_solr_mapping.rs
@@ -24,7 +24,7 @@ impl From<&DataspaceDocument> for SolrDocument {
             .with_certificate_display(doc.authorized_ceritificates())
             .with_contributor_display(doc.contributor.clone())
             .with_department_display(doc.authorized_departments())
-            .with_format(vec!["Senior thesis".to_string()])
+            .with_format(vec![super::Format::SeniorThesis])
             .with_holdings_1display(doc.physical_holding_string())
             .with_location(doc.location())
             .with_location_code_s(doc.location_code())
@@ -77,6 +77,8 @@ fn title_sort(titles: Option<&Vec<String>>) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use crate::solr::Format;
+
     use super::*;
 
     #[test]
@@ -148,7 +150,7 @@ mod tests {
     fn it_is_senior_thesis() {
         let document = DataspaceDocument::builder().build();
         let solr = SolrDocument::from(&document);
-        assert_eq!(solr.format, Some(vec!["Senior thesis".to_string()]));
+        assert_eq!(solr.format, Some(vec![Format::SeniorThesis]));
     }
 
     #[test]

--- a/lib/bibdata_rs/src/solr/ephemera_solr_mapping.rs
+++ b/lib/bibdata_rs/src/solr/ephemera_solr_mapping.rs
@@ -1,5 +1,3 @@
-use itertools::Itertools;
-
 use crate::ephemera::ephemera_folder_item::EphemeraFolderItem;
 
 use super::SolrDocument;
@@ -17,15 +15,7 @@ impl From<&EphemeraFolderItem> for SolrDocument {
             .with_author_citation_display(value.creator.clone())
             .with_notes(value.description.clone())
             .with_notes_display(value.description.clone())
-            .with_format(
-                value
-                    .format
-                    .clone()
-                    .unwrap_or_default()
-                    .iter()
-                    .filter_map(|format| format.rename_format())
-                    .collect(),
-            )
+            .with_format(value.solr_formats())
             .with_pub_created_display(value.publisher.clone())
             .with_publisher_no_display(value.publisher.clone())
             .with_publisher_citation_display(value.publisher.clone())
@@ -35,9 +25,9 @@ impl From<&EphemeraFolderItem> for SolrDocument {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs::File, io::BufReader};
+    use std::{fs::File, io::BufReader, str::FromStr};
 
-    use crate::ephemera::ephemera_folder_item::format::Format;
+    use crate::{ephemera::ephemera_folder_item::format::Format, solr};
 
     use super::*;
 
@@ -155,12 +145,12 @@ mod tests {
             .id("abc123".to_owned())
             .title(vec!["Our favorite book".to_owned()])
             .format(vec![Format {
-                pref_label: Some("Serials".to_string()),
+                pref_label: Some(solr::Format::from_str("Serials").unwrap()),
             }])
             .build()
             .unwrap();
         let solr_document = SolrDocument::from(&ephemera_item);
-        assert_eq!(solr_document.format, Some(vec!["Journal".to_string()]))
+        assert_eq!(solr_document.format, Some(vec![solr::Format::Journal]))
     }
 
     fn it_has_the_publisher_from_the_ephemera_folder_item() {

--- a/lib/bibdata_rs/src/solr/format.rs
+++ b/lib/bibdata_rs/src/solr/format.rs
@@ -1,0 +1,101 @@
+use serde::{Deserialize, Deserializer, Serialize};
+use std::str::FromStr;
+
+#[allow(dead_code)]
+#[derive(Copy, Clone, Debug, Serialize, PartialEq)]
+pub enum Format {
+    #[serde(rename = "Archival item")]
+    ArchivalItem,
+    Audio,
+    Book,
+    Coin,
+    #[serde(rename = "Data file")]
+    DataFile,
+    Databases,
+    Journal,
+    Manuscript,
+    Map,
+    Microform,
+    #[serde(rename = "Musical score")]
+    MusicalScore,
+    Report,
+    #[serde(rename = "Senior thesis")]
+    SeniorThesis,
+    #[serde(rename = "Video/Projected medium")]
+    VideoProjectedMedium,
+    #[serde(rename = "Visual material")]
+    VisualMaterial,
+}
+
+#[derive(Debug)]
+pub struct NoFormatMatches;
+
+impl FromStr for Format {
+    type Err = NoFormatMatches;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Book" => Ok(Self::Book),
+            "Books" => Ok(Self::Book),
+            "Reports" => Ok(Self::Report),
+            "Serials" => Ok(Self::Journal),
+            "Senior thesis" => Ok(Self::SeniorThesis),
+            _ => Err(NoFormatMatches),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Format {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        FromStr::from_str(&s).map_err(|_err| {
+            serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&s),
+                &"a valid catalog format",
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_serializes() {
+        assert_eq!(
+            serde_json::to_string(&Format::ArchivalItem).unwrap(),
+            r#""Archival item""#
+        );
+        assert_eq!(
+            serde_json::to_string(&Format::DataFile).unwrap(),
+            r#""Data file""#
+        );
+        assert_eq!(
+            serde_json::to_string(&Format::MusicalScore).unwrap(),
+            r#""Musical score""#
+        );
+        assert_eq!(
+            serde_json::to_string(&Format::SeniorThesis).unwrap(),
+            r#""Senior thesis""#
+        );
+        assert_eq!(
+            serde_json::to_string(&Format::VideoProjectedMedium).unwrap(),
+            r#""Video/Projected medium""#
+        );
+        assert_eq!(
+            serde_json::to_string(&Format::VisualMaterial).unwrap(),
+            r#""Visual material""#
+        );
+    }
+
+    #[test]
+    fn it_can_be_created_from_str() {
+        assert_eq!(Format::from_str("Books").unwrap(), Format::Book);
+        assert_eq!(Format::from_str("Reports").unwrap(), Format::Report);
+        assert_eq!(Format::from_str("Serials").unwrap(), Format::Journal);
+    }
+}


### PR DESCRIPTION
This means that the compiler can catch us if we try to index a document with an incorrect format.  It also removes a few calls to clone.