### PR TITLE
Refactor facet value enums

### DIFF
--- a/lib/bibdata_rs/src/ephemera/ephemera_folder_item.rs
+++ b/lib/bibdata_rs/src/ephemera/ephemera_folder_item.rs
@@ -33,7 +33,7 @@ impl EphemeraFolderItem {
         EphemeraFolderItemBuilder::new()
     }
 
-    pub fn solr_formats(&self) -> Vec<solr::Format> {
+    pub fn solr_formats(&self) -> Vec<solr::FormatFacet> {
         match &self.format {
             Some(formats) => formats.iter().filter_map(|f| f.pref_label).collect(),
             _ => vec![],
@@ -140,7 +140,7 @@ mod tests {
         let ephemera_folder_item: EphemeraFolderItem = serde_json::from_reader(reader).unwrap();
         assert_eq!(
             ephemera_folder_item.format.unwrap()[0].pref_label,
-            Some(solr::Format::Book)
+            Some(solr::FormatFacet::Book)
         );
     }
 

--- a/lib/bibdata_rs/src/ephemera/ephemera_folder_item/format.rs
+++ b/lib/bibdata_rs/src/ephemera/ephemera_folder_item/format.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 
 #[derive(Copy, Clone, Deserialize, Debug)]
 pub struct Format {
-    pub pref_label: Option<solr::Format>,
+    pub pref_label: Option<solr::FormatFacet>,
 }
 
 #[cfg(test)]
@@ -30,6 +30,6 @@ mod tests {
             }
           ]"#;
         let formats: Vec<Format> = serde_json::from_str(json_ld).unwrap();
-        assert_eq!(formats[0].pref_label, Some(solr::Format::Book));
+        assert_eq!(formats[0].pref_label, Some(solr::FormatFacet::Book));
     }
 }

--- a/lib/bibdata_rs/src/solr.rs
+++ b/lib/bibdata_rs/src/solr.rs
@@ -5,9 +5,9 @@ mod access_facet;
 mod builder;
 mod dataspace_solr_mapping;
 mod ephemera_solr_mapping;
-mod format;
+mod format_facet;
 
 pub use access_facet::AccessFacet;
 pub use builder::SolrDocumentBuilder;
-pub use format::Format;
+pub use format_facet::FormatFacet;
 pub use solr_document::SolrDocument;

--- a/lib/bibdata_rs/src/solr.rs
+++ b/lib/bibdata_rs/src/solr.rs
@@ -1,10 +1,13 @@
+pub mod index;
+pub mod solr_document;
+
+mod access_facet;
 mod builder;
 mod dataspace_solr_mapping;
 mod ephemera_solr_mapping;
 mod format;
-pub mod index;
-pub mod solr_document;
 
+pub use access_facet::AccessFacet;
 pub use builder::SolrDocumentBuilder;
 pub use format::Format;
 pub use solr_document::SolrDocument;

--- a/lib/bibdata_rs/src/solr/access_facet.rs
+++ b/lib/bibdata_rs/src/solr/access_facet.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub enum AccessFacet {
+    #[serde(rename = "In the Library")]
+    InTheLibrary,
+    Online
+}

--- a/lib/bibdata_rs/src/solr/builder.rs
+++ b/lib/bibdata_rs/src/solr/builder.rs
@@ -1,6 +1,6 @@
 // This module provides a convenient way to create a SolrDocument using the builder pattern
 
-use super::{AccessFacet, Format, SolrDocument};
+use super::{AccessFacet, FormatFacet, SolrDocument};
 
 #[derive(Debug, Default)]
 pub struct SolrDocumentBuilder {
@@ -10,7 +10,7 @@ pub struct SolrDocumentBuilder {
     author_roles_1display: Option<String>,
     author_citation_display: Option<Vec<String>>,
     advisor_display: Option<Vec<String>>,
-    format: Option<Vec<Format>>,
+    format: Option<Vec<FormatFacet>>,
     id: String,
     title_t: Option<Vec<String>>,
     title_citation_display: Option<String>,
@@ -143,7 +143,7 @@ impl SolrDocumentBuilder {
         self
     }
 
-    pub fn with_format(&mut self, format: Vec<Format>) -> &mut Self {
+    pub fn with_format(&mut self, format: Vec<FormatFacet>) -> &mut Self {
         self.format = Some(format);
         self
     }

--- a/lib/bibdata_rs/src/solr/builder.rs
+++ b/lib/bibdata_rs/src/solr/builder.rs
@@ -1,6 +1,6 @@
 // This module provides a convenient way to create a SolrDocument using the builder pattern
 
-use super::{Format, SolrDocument};
+use super::{AccessFacet, Format, SolrDocument};
 
 #[derive(Debug, Default)]
 pub struct SolrDocumentBuilder {
@@ -30,7 +30,7 @@ pub struct SolrDocumentBuilder {
     notes: Option<Vec<String>>,
     notes_display: Option<Vec<String>>,
     advanced_location_s: Option<Vec<String>>,
-    access_facet: Option<String>,
+    access_facet: Option<AccessFacet>,
     holdings_1display: Option<String>,
     electronic_portfolio_s: Option<String>,
     class_year_s: Option<Vec<String>>,
@@ -193,7 +193,7 @@ impl SolrDocumentBuilder {
         self.advanced_location_s = advanced_location_s;
         self
     }
-    pub fn with_access_facet(&mut self, access_facet: Option<String>) -> &mut Self {
+    pub fn with_access_facet(&mut self, access_facet: Option<AccessFacet>) -> &mut Self {
         self.access_facet = access_facet;
         self
     }
@@ -284,7 +284,7 @@ impl SolrDocumentBuilder {
     }
     pub fn build(&self) -> SolrDocument {
         SolrDocument {
-            access_facet: self.access_facet.clone(),
+            access_facet: self.access_facet,
             advanced_location_s: self.advanced_location_s.clone(),
             advisor_display: self.advisor_display.clone(),
             author_s: self.author_s.clone(),

--- a/lib/bibdata_rs/src/solr/dataspace_solr_mapping.rs
+++ b/lib/bibdata_rs/src/solr/dataspace_solr_mapping.rs
@@ -77,7 +77,7 @@ fn title_sort(titles: Option<&Vec<String>>) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::solr::Format;
+    use crate::solr::{AccessFacet, Format};
 
     use super::*;
 
@@ -190,7 +190,7 @@ mod tests {
             .with_rights_access_rights("Walk-in Access...")
             .build();
         let solr = SolrDocument::from(&document);
-        assert_eq!(solr.access_facet.unwrap(), "Online");
+        assert_eq!(solr.access_facet.unwrap(), AccessFacet::Online);
         assert!(solr.advanced_location_s.is_none());
     }
 
@@ -215,7 +215,7 @@ mod tests {
     fn it_has_electronic_portfolio_s_by_default() {
         let document = DataspaceDocument::builder().build();
         let solr = SolrDocument::from(&document);
-        assert_eq!(solr.access_facet.unwrap(), "Online");
+        assert_eq!(solr.access_facet.unwrap(), AccessFacet::Online);
         assert!(solr.electronic_portfolio_s.unwrap().contains("thesis"));
     }
 

--- a/lib/bibdata_rs/src/solr/dataspace_solr_mapping.rs
+++ b/lib/bibdata_rs/src/solr/dataspace_solr_mapping.rs
@@ -24,7 +24,7 @@ impl From<&DataspaceDocument> for SolrDocument {
             .with_certificate_display(doc.authorized_ceritificates())
             .with_contributor_display(doc.contributor.clone())
             .with_department_display(doc.authorized_departments())
-            .with_format(vec![super::Format::SeniorThesis])
+            .with_format(vec![super::FormatFacet::SeniorThesis])
             .with_holdings_1display(doc.physical_holding_string())
             .with_location(doc.location())
             .with_location_code_s(doc.location_code())
@@ -77,7 +77,7 @@ fn title_sort(titles: Option<&Vec<String>>) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::solr::{AccessFacet, Format};
+    use crate::solr::{AccessFacet, FormatFacet};
 
     use super::*;
 
@@ -150,7 +150,7 @@ mod tests {
     fn it_is_senior_thesis() {
         let document = DataspaceDocument::builder().build();
         let solr = SolrDocument::from(&document);
-        assert_eq!(solr.format, Some(vec![Format::SeniorThesis]));
+        assert_eq!(solr.format, Some(vec![FormatFacet::SeniorThesis]));
     }
 
     #[test]

--- a/lib/bibdata_rs/src/solr/ephemera_solr_mapping.rs
+++ b/lib/bibdata_rs/src/solr/ephemera_solr_mapping.rs
@@ -179,12 +179,12 @@ mod tests {
             .id("abc123".to_owned())
             .title(vec!["Our favorite book".to_owned()])
             .format(vec![Format {
-                pref_label: Some(solr::Format::from_str("Serials").unwrap()),
+                pref_label: Some(solr::FormatFacet::from_str("Serials").unwrap()),
             }])
             .build()
             .unwrap();
         let solr_document = SolrDocument::from(&ephemera_item);
-        assert_eq!(solr_document.format, Some(vec![solr::Format::Journal]))
+        assert_eq!(solr_document.format, Some(vec![solr::FormatFacet::Journal]))
     }
 
     #[test]

--- a/lib/bibdata_rs/src/solr/format_facet.rs
+++ b/lib/bibdata_rs/src/solr/format_facet.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 #[allow(dead_code)]
 #[derive(Copy, Clone, Debug, Serialize, PartialEq)]
-pub enum Format {
+pub enum FormatFacet {
     #[serde(rename = "Archival item")]
     ArchivalItem,
     Audio,
@@ -30,7 +30,7 @@ pub enum Format {
 #[derive(Debug)]
 pub struct NoFormatMatches;
 
-impl FromStr for Format {
+impl FromStr for FormatFacet {
     type Err = NoFormatMatches;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -45,7 +45,7 @@ impl FromStr for Format {
     }
 }
 
-impl<'de> Deserialize<'de> for Format {
+impl<'de> Deserialize<'de> for FormatFacet {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -67,35 +67,35 @@ mod tests {
     #[test]
     fn it_serializes() {
         assert_eq!(
-            serde_json::to_string(&Format::ArchivalItem).unwrap(),
+            serde_json::to_string(&FormatFacet::ArchivalItem).unwrap(),
             r#""Archival item""#
         );
         assert_eq!(
-            serde_json::to_string(&Format::DataFile).unwrap(),
+            serde_json::to_string(&FormatFacet::DataFile).unwrap(),
             r#""Data file""#
         );
         assert_eq!(
-            serde_json::to_string(&Format::MusicalScore).unwrap(),
+            serde_json::to_string(&FormatFacet::MusicalScore).unwrap(),
             r#""Musical score""#
         );
         assert_eq!(
-            serde_json::to_string(&Format::SeniorThesis).unwrap(),
+            serde_json::to_string(&FormatFacet::SeniorThesis).unwrap(),
             r#""Senior thesis""#
         );
         assert_eq!(
-            serde_json::to_string(&Format::VideoProjectedMedium).unwrap(),
+            serde_json::to_string(&FormatFacet::VideoProjectedMedium).unwrap(),
             r#""Video/Projected medium""#
         );
         assert_eq!(
-            serde_json::to_string(&Format::VisualMaterial).unwrap(),
+            serde_json::to_string(&FormatFacet::VisualMaterial).unwrap(),
             r#""Visual material""#
         );
     }
 
     #[test]
     fn it_can_be_created_from_str() {
-        assert_eq!(Format::from_str("Books").unwrap(), Format::Book);
-        assert_eq!(Format::from_str("Reports").unwrap(), Format::Report);
-        assert_eq!(Format::from_str("Serials").unwrap(), Format::Journal);
+        assert_eq!(FormatFacet::from_str("Books").unwrap(), FormatFacet::Book);
+        assert_eq!(FormatFacet::from_str("Reports").unwrap(), FormatFacet::Report);
+        assert_eq!(FormatFacet::from_str("Serials").unwrap(), FormatFacet::Journal);
     }
 }

--- a/lib/bibdata_rs/src/solr/solr_document.rs
+++ b/lib/bibdata_rs/src/solr/solr_document.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::{access_facet::AccessFacet, Format, SolrDocumentBuilder};
+use super::{access_facet::AccessFacet, FormatFacet, SolrDocumentBuilder};
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct SolrDocument {
@@ -51,7 +51,7 @@ pub struct SolrDocument {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub electronic_portfolio_s: Option<String>,
 
-    pub format: Option<Vec<Format>>,
+    pub format: Option<Vec<FormatFacet>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub holdings_1display: Option<String>,

--- a/lib/bibdata_rs/src/solr/solr_document.rs
+++ b/lib/bibdata_rs/src/solr/solr_document.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::{Format, SolrDocumentBuilder};
+use super::{access_facet::AccessFacet, Format, SolrDocumentBuilder};
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct SolrDocument {
@@ -8,7 +8,7 @@ pub struct SolrDocument {
     pub advanced_location_s: Option<Vec<String>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub access_facet: Option<String>,
+    pub access_facet: Option<AccessFacet>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub advisor_display: Option<Vec<String>>,

--- a/lib/bibdata_rs/src/theses/dataspace/document/normalize.rs
+++ b/lib/bibdata_rs/src/theses/dataspace/document/normalize.rs
@@ -1,22 +1,22 @@
 // This module is responsible for normalizing data within a DataspaceDocument
 
-use crate::theses::{
+use crate::{solr::AccessFacet, theses::{
     dataspace::document::DataspaceDocument,
     department,
     embargo::{self, Embargo},
     holdings::{self, ThesisAvailability},
     language, program,
-};
+}};
 use itertools::Itertools;
 use regex::{Captures, Regex};
 use std::sync::LazyLock;
 
 impl DataspaceDocument {
-    pub fn access_facet(&self) -> Option<String> {
+    pub fn access_facet(&self) -> Option<AccessFacet> {
         match (self.embargo(), self.on_site_only()) {
             (embargo::Embargo::Current(_), _) => None,
-            (_, ThesisAvailability::AvailableOffSite) => Some("Online".to_owned()),
-            (_, ThesisAvailability::OnSiteOnly) => Some("In the Library".to_owned()),
+            (_, ThesisAvailability::AvailableOffSite) => Some(AccessFacet::Online),
+            (_, ThesisAvailability::OnSiteOnly) => Some(AccessFacet::InTheLibrary),
         }
     }
 


### PR DESCRIPTION
- Add a new `AccessFacet` enum to represent the access facet and its two possible values: "Online" or "In the library".  This reduces some allocations and speeds up the `solr_document_from_dataspace_document/from` benchmark by 2%.
- Change the name of the existing `Format` enum to `FormatFacet`, so that it's not so easy to confuse it with the `Format` struct in Ephemera