### PR TITLE
Experiment: do some traject processing in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "magnus",
+ "marctk",
  "mockito",
  "parse_datetime",
  "rayon",
@@ -702,6 +703,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1287,6 +1297,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "marctk"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33637e86474c9e8204ba0263f9cceee37f8142a73f4f3cb1ee20167ce836c3b9"
+dependencies = [
+ "getopts",
+ "xml-rs",
 ]
 
 [[package]]
@@ -2536,6 +2556,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "untrusted"

--- a/lib/bibdata_rs/Cargo.toml
+++ b/lib/bibdata_rs/Cargo.toml
@@ -24,6 +24,7 @@ log = "0.4.27"
 rayon = "1.10.0"
 anyhow = "1.0.98"
 rb-sys = "0.9.115"
+marctk = "0.4.2"
 
 [dev-dependencies]
 criterion = "0.6.0"

--- a/lib/bibdata_rs/src/lib.rs
+++ b/lib/bibdata_rs/src/lib.rs
@@ -7,12 +7,21 @@ mod ephemera;
 pub mod solr;
 pub mod theses;
 
+fn is_literary(xml: String) -> bool {
+    let record = marctk::Record::from_xml(&xml).next().unwrap().unwrap();
+    record.get_control_fields("008").iter().any(|field| match field.content().chars().nth(33) {
+        Some(litf) if ['1', 'd', 'e', 'f', 'j', 'p'].contains(&litf)  => true,
+        _ => false
+    })
+}
+
 #[cfg(test)]
 mod testing_support;
 
 #[magnus::init]
 fn init(ruby: &Ruby) -> Result<(), Error> {
     let module = ruby.define_module("BibdataRs")?;
+    module.define_singleton_method("literary_work?", function!(is_literary, 1))?;
     let submodule_theses = module.define_module("Theses")?;
     let submodule_ephemera = module.define_module("Ephemera")?;
     submodule_ephemera.define_singleton_method(

--- a/marc_to_solr/lib/genre.rb
+++ b/marc_to_solr/lib/genre.rb
@@ -1,3 +1,5 @@
+require_relative '../../lib/bibdata_rs'
+
 # This class is responsible for listing the
 # genres present in a given MARC record
 class Genre
@@ -175,7 +177,7 @@ class Genre
     end
 
     def literary_work?
-      book? && record.fields('008').any? { |litf| %w[1 d e f j p].include? litf.value[33] }
+      @literary ||= book? && BibdataRs.literary_work?(record.to_xml.to_s)
     end
 
     def book?


### PR DESCRIPTION
This is not ready for production.  It was an experiment to see how much overhead it would be to pass a whole MarcXML record to rust during a traject indexing routine.

It is slower, but not a lot slower -- and memoizing the Ruby method more than made up for the overhead.

The results:
```
Original ruby implementation: 45288 records in 185.262 seconds; 244.5 records/second overall.
Passing the entire MarcXML document to rust, and reparsing it there: 45288 records in 194.183 seconds; 233.2 records/second overall. (would make reindex ~20 minutes slower)
Passing the entire MarcXML document to rust, and reparsing it there, but memoizing the results in Ruby: 45288 records in 180.621 seconds; 250.7 records/second overall. (would make reindex ~10 minutes faster)
```