### PR TITLE
Address flakey test

### DIFF
--- a/lib/bibdata_rs/src/ephemera/ephemera_folder_item.rs
+++ b/lib/bibdata_rs/src/ephemera/ephemera_folder_item.rs
@@ -129,7 +129,6 @@ mod tests {
     async fn test_get_item_data() {
         preserving_envvar_async("FIGGY_BORN_DIGITAL_EPHEMERA_URL", || async {
             let mut server = mockito::Server::new_async().await;
-            std::env::set_var("FIGGY_BORN_DIGITAL_EPHEMERA_URL", server.url());
 
             let mock = server
                 .mock(


### PR DESCRIPTION
Setting the environment variable is not necessary for the test, and it can cause other tests to fail (about 3 out of every 100 test runs).

After removing this line, I ran the ephemera test suite 2000 times, and got no failures:

```
$ for run in {1..2000} ; do
  cargo test ephemera 2>/dev/null 1>&2 || echo "BAD"
done | wc -l
       0
```