### PR TITLE
Rewrite a simple ruby method (strip_non_numeric) in rust

### DIFF
--- a/lib/bibdata_rs/src/lib.rs
+++ b/lib/bibdata_rs/src/lib.rs
@@ -28,5 +28,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
         function!(collection::collections_as_solr, 3),
     )?;
     submodule_marc.define_singleton_method("genres", function!(marc::genres, 1))?;
+    submodule_marc
+        .define_singleton_method("strip_non_numeric", function!(marc::strip_non_numeric, 1))?;
     Ok(())
 }

--- a/lib/bibdata_rs/src/marc.rs
+++ b/lib/bibdata_rs/src/marc.rs
@@ -1,16 +1,20 @@
 use magnus::exception;
 use marctk::Record;
 
-mod punctuation;
+mod string_normalize;
 
 pub mod fixed_field;
 pub mod genre;
 
-pub use punctuation::trim_punctuation;
+pub use string_normalize::trim_punctuation;
 
 pub fn genres(record_string: String) -> Result<Vec<String>, magnus::Error> {
     let record = get_record(&record_string)?;
     Ok(genre::genres(&record))
+}
+
+pub fn strip_non_numeric(string: String) -> String {
+    string_normalize::strip_non_numeric(&string)
 }
 
 fn get_record(breaker: &str) -> Result<Record, magnus::Error> {

--- a/lib/bibdata_rs/src/marc/string_normalize.rs
+++ b/lib/bibdata_rs/src/marc/string_normalize.rs
@@ -28,6 +28,15 @@ pub fn trim_punctuation(string: &str) -> String {
         .to_owned()
 }
 
+pub fn strip_non_numeric(string: &str) -> String {
+    string
+        .chars()
+        // remove preceding zeroes
+        .skip_while(|c| !c.is_numeric() || c == &'0')
+        .filter(|c| c.is_numeric())
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/marc_to_solr/lib/princeton_marc.rb
+++ b/marc_to_solr/lib/princeton_marc.rb
@@ -151,7 +151,7 @@ def other_versions record
       linked_nums << oclc_normalize(s_field.value, prefix: true) if (field.tag == '035') && oclc_number?(s_field.value)
       if ((field.tag == '776') && (s_field.code == 'w')) || ((field.tag == '787') && (s_field.code == 'w'))
         linked_nums << oclc_normalize(s_field.value, prefix: true) if oclc_number?(s_field.value)
-        linked_nums << ('BIB' + strip_non_numeric(s_field.value)) unless s_field.value.include?('(')
+        linked_nums << ('BIB' + BibdataRs::Marc.strip_non_numeric(s_field.value)) unless s_field.value.include?('(')
         if s_field.value.include?('(') && !s_field.value.start_with?('(')
           logger.error "#{record['001']} - linked field formatting: #{s_field.value}"
         end
@@ -328,10 +328,6 @@ def process_subject_topic_facet record
   lcsh_subjects + other_thesaurus_subjects
 end
 
-def strip_non_numeric num_str
-  num_str.gsub(/\D/, '').to_i.to_s
-end
-
 def oclc_number? oclc
   # Strip spaces and dashes
   clean_oclc = oclc.gsub(/[\-\s]/, '')
@@ -341,7 +337,7 @@ def oclc_number? oclc
 end
 
 def oclc_normalize oclc, opts = { prefix: false }
-  oclc_num = strip_non_numeric(oclc)
+  oclc_num = BibdataRs::Marc.strip_non_numeric(oclc)
   if opts[:prefix] == true
     case oclc_num.length
     when 1..8

--- a/spec/marc_to_solr/lib/princeton_marc_spec.rb
+++ b/spec/marc_to_solr/lib/princeton_marc_spec.rb
@@ -362,7 +362,7 @@ describe 'From princeton_marc.rb' do
       expect(@linked_nums).to include(oclc_normalize(@oclc_num, prefix: true))
       expect(@linked_nums).to include(oclc_normalize(@oclc_num2, prefix: true))
       expect(@linked_nums).to include(oclc_normalize(@oclc_num4, prefix: true))
-      expect(@linked_nums).to include('BIB' + strip_non_numeric(@bib))
+      expect(@linked_nums).to include('BIB' + BibdataRs::Marc.strip_non_numeric(@bib))
       expect(@linked_nums).to include(LibraryStandardNumbers::ISSN.normalize(@issn_num))
       expect(@linked_nums).to include(LibraryStandardNumbers::ISSN.normalize(@issn_num2))
       expect(@linked_nums).to include(LibraryStandardNumbers::ISBN.normalize(@isbn_num))


### PR DESCRIPTION
Just a small incremental move toward rust.  The rust version  is faster!

```
$ cat benchmark-non-numeric.rb
require 'benchmark/ips'

Benchmark.ips do |x|
  x.config(warmup: 2, time: 5)
  x.report('rust') { BibdataRs::Marc.strip_non_numeric('(OCoLC)on9990014350') }
  x.report('ruby') { strip_non_numeric('(OCoLC)on9990014350') }
end

$ ruby benchmark-non-numeric.rb
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                rust   546.714k i/100ms
                ruby    60.168k i/100ms
Calculating -------------------------------------
                rust      5.426M (± 1.0%) i/s  (184.28 ns/i) -     27.336M in   5.038023s
                ruby    597.877k (± 1.3%) i/s    (1.67 μs/i) -      3.008M in   5.032628s
```