### PR TITLE
[#2639] Add electronic_access method in EphemeraFolder

### DIFF
--- a/lib/bibdata_rs/src/ephemera/ephemera_folder.rs
+++ b/lib/bibdata_rs/src/ephemera/ephemera_folder.rs
@@ -28,6 +28,7 @@ pub struct EphemeraFolder {
     pub coverage: Option<Vec<Coverage>>,
     pub date_created: Option<Vec<String>>,
     pub description: Option<Vec<String>>,
+    pub electronic_access: Option<Vec<solr::ElectronicAccess>>,
     pub format: Option<Vec<Format>>,
     #[serde(rename = "@id")]
     pub id: String,
@@ -144,6 +145,13 @@ impl EphemeraFolder {
     }
     pub fn access_facet(&self) -> Option<AccessFacet> {
         Some(AccessFacet::Online)
+    }
+    pub fn electronic_access(&self) -> Option<solr::ElectronicAccess> {
+        Some(solr::ElectronicAccess {
+            url: self.id.clone(),
+            link_text: "Online Content".to_owned(),
+            link_description: Some("Born Digital Monographs, Serials, & Series Reports".to_owned()),
+        })
     }
 }
 

--- a/lib/bibdata_rs/src/ephemera/ephemera_folder_builder.rs
+++ b/lib/bibdata_rs/src/ephemera/ephemera_folder_builder.rs
@@ -4,6 +4,7 @@ use super::ephemera_folder::origin_place::OriginPlace;
 use super::ephemera_folder::EphemeraFolder;
 use crate::ephemera::ephemera_folder::language::Language;
 use crate::ephemera_folder::subject::Subject;
+use crate::solr::ElectronicAccess;
 
 #[derive(Default)]
 pub struct EphemeraFolderBuilder {
@@ -13,6 +14,7 @@ pub struct EphemeraFolderBuilder {
     coverage: Option<Vec<Coverage>>,
     date_created: Option<Vec<String>>,
     description: Option<Vec<String>>,
+    electronic_access: Option<Vec<ElectronicAccess>>,
     format: Option<Vec<Format>>,
     id: Option<String>,
     language: Option<Vec<Language>>,
@@ -57,6 +59,10 @@ impl EphemeraFolderBuilder {
     }
     pub fn description(mut self, description: Vec<String>) -> Self {
         self.description = Some(description);
+        self
+    }
+    pub fn electronic_access(mut self, electronic_access: Vec<ElectronicAccess>) -> Self {
+        self.electronic_access = Some(electronic_access);
         self
     }
     pub fn format(mut self, format: Vec<Format>) -> Self {
@@ -117,6 +123,7 @@ impl EphemeraFolderBuilder {
             coverage: self.coverage,
             date_created: self.date_created,
             description: self.description,
+            electronic_access: self.electronic_access,
             format: self.format,
             id,
             language: self.language,

--- a/lib/bibdata_rs/src/solr/ephemera_solr_mapping.rs
+++ b/lib/bibdata_rs/src/solr/ephemera_solr_mapping.rs
@@ -11,6 +11,7 @@ impl From<&EphemeraFolder> for SolrDocument {
             .with_author_sort(value.creator.clone().unwrap_or_default().first().cloned())
             .with_author_citation_display(value.creator.clone())
             .with_description_display(Some(value.page_count_origin_place_labels_combined()))
+            .with_electronic_access_1display(value.electronic_access())
             .with_format(value.solr_formats())
             .with_geographic_facet(Some(value.coverage_labels()))
             .with_homoit_subject_display(value.subject_labels())
@@ -433,6 +434,30 @@ mod tests {
         assert_eq!(
             solr_document.title_sort,
             Some("Our favorite book".to_string())
+        );
+    }
+    #[test]
+    fn it_has_electronic_access_1display() {
+        let ephemera_item = EphemeraFolder::builder()
+            .id("abc123".to_owned())
+            .title(vec!["Our favorite book".to_owned()])
+            .electronic_access(vec![solr::ElectronicAccess {
+                url: "http://example.com".to_owned(),
+                link_text: "Access Link".to_owned(),
+                link_description: Some("Description of the link".to_owned()),
+            }])
+            .build()
+            .unwrap();
+        let solr_document = SolrDocument::from(&ephemera_item);
+        assert_eq!(
+            solr_document.electronic_access_1display,
+            Some(solr::ElectronicAccess {
+                url: ephemera_item.id.clone(),
+                link_text: "Online Content".to_owned(),
+                link_description: Some(
+                    "Born Digital Monographs, Serials, & Series Reports".to_owned()
+                ),
+            })
         );
     }
 }


### PR DESCRIPTION
part of #2639 

Add electronic_access method in EphemeraFolder
to build the electronic_access_1display field that is expected in solr Map the following as the content of the ephemera electronic_access_1display. url is the ephemera folder id.

```
url: "https://figgy-staging.princeton.edu/catalog/af4a941d-96a4-463e-9043-cfa512e5eddd",
link_text: "Online Content",
link_description: "Born Digital Monographs, Serials, & Series Reports"
```