### PR TITLE
Give more details on parsing failures when using reqwest's json() method

### DIFF
--- a/lib/bibdata_rs/src/ephemera/mod.rs
+++ b/lib/bibdata_rs/src/ephemera/mod.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use born_digital_collection::FoldersResponse;
 use ephemera_folder::EphemeraFolder;
 use log::debug;
@@ -22,20 +23,26 @@ impl CatalogClient {
     pub fn new(url: String) -> Self {
         CatalogClient { url }
     }
-    pub async fn get_folder_data(&self) -> Result<FoldersResponse, reqwest::Error> {
+    pub async fn get_folder_data(&self) -> anyhow::Result<FoldersResponse> {
         let path = std::env::var("FIGGY_BORN_DIGITAL_EPHEMERA_URL").unwrap_or("/catalog.json?f%5Bephemera_project_ssim%5D%5B%5D=Born+Digital+Monographs%2C+Serials%2C+%26+Series+Reports&f%5Bhuman_readable_type_ssim%5D%5B%5D=Ephemera+Folder&f%5Bstate_ssim%5D%5B%5D=complete&per_page=100&q=".to_string());
         let url = format!("{}{}", &self.url, path);
         debug!("Fetching JSON-LD of folders at {}", url);
         let response = reqwest::get(url).await?;
-        let data: FoldersResponse = response.json().await?;
+        let data: FoldersResponse = response
+            .json()
+            .await
+            .map_err(|err| anyhow!("Could not parse born digital search results: {err:?}"))?;
         Ok(data)
     }
 
-    pub async fn get_item_data(&self, id: &str) -> Result<EphemeraFolder, reqwest::Error> {
+    pub async fn get_item_data(&self, id: &str) -> anyhow::Result<EphemeraFolder> {
         let url = format!("{}/catalog/{}.jsonld", &self.url, id);
         debug!("Fetching JSON-LD of a single folder at {}", url);
-        let response = reqwest::get(url).await?;
-        let data: EphemeraFolder = response.json().await?;
+        let response = reqwest::get(&url).await?;
+        let data: EphemeraFolder = response
+            .json()
+            .await
+            .map_err(|err| anyhow!("Could not parse ephemera folder JSON at {url}: {err:?}"))?;
         Ok(data)
     }
 }

--- a/lib/bibdata_rs/src/theses/dataspace/collection.rs
+++ b/lib/bibdata_rs/src/theses/dataspace/collection.rs
@@ -150,7 +150,9 @@ fn get_documents_in_collection(
 }
 
 fn get_url_as_json(url: &str) -> Result<Vec<DataspaceDocument>> {
-    reqwest::blocking::get(url)?.json().map_err(|e| anyhow!(e))
+    reqwest::blocking::get(url)?
+        .json()
+        .map_err(|e| anyhow!("Could not parse json at {url}: {e:?}"))
 }
 
 #[cfg(test)]

--- a/lib/bibdata_rs/src/theses/dataspace/community.rs
+++ b/lib/bibdata_rs/src/theses/dataspace/community.rs
@@ -20,8 +20,9 @@ struct Collection {
 /// The DSpace id of the community we're fetching content for.
 /// E.g., for handle '88435/dsp019c67wm88m', the DSpace id is 267
 pub fn get_community_id(server: &str, community_handle: &str) -> Result<Option<u32>> {
-    let communities: Vec<Community> =
-        reqwest::blocking::get(format!("{}/communities/", server))?.json()?;
+    let communities: Vec<Community> = reqwest::blocking::get(format!("{}/communities/", server))?
+        .json()
+        .map_err(|e| anyhow!("Could not parse json: {e:?}"))?;
     let theses_community = communities
         .iter()
         .find(|community| community.handle == community_handle)
@@ -44,7 +45,9 @@ pub fn get_collection_list(
         id_selector(server, community_handle)?.unwrap_or_default()
     );
     info!("Querying {} for the collections", url);
-    let collections: Vec<Collection> = reqwest::blocking::get(url)?.json()?;
+    let collections: Vec<Collection> = reqwest::blocking::get(url)?
+        .json()
+        .map_err(|e| anyhow!("Could not parse json: {e:?}"))?;
     Ok(collections
         .iter()
         .filter_map(|collection| collection.id)


### PR DESCRIPTION
By default, when you call `.json()` on a reqwest response that contains invalid JSON, you get a `reqwest::Error` that displays a very vague error message 'error decoding response body'

We don't have anything sensitive in any of our existing calls, and getting more information about the parsing failures would be extremely helpful.  Therefore, this commit maps these errors to `anyhow` errors that contain all of the useful debugging information.