### PR TITLE
Include worker role in whenever_roles config/deploy.rb

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -41,7 +41,7 @@ set :linked_files, ['marc_to_solr/translation_maps/figgy_mms_ids.yaml']
 
 set :keep_releases, 3
 
-set :whenever_roles, ->{ [:cron, :cron_staging, :cron_production] }
+set :whenever_roles, ->{ [:cron, :cron_staging, :cron_production, :worker] }
 
 namespace :sidekiq do
   task :restart do


### PR DESCRIPTION
closes #https://github.com/pulibrary/orangelight/issues/5060

confirmed that it adds the figgy_mms_ids:build_translation_map task in the crontab