### PR TITLE
Migrate oclc_normalize method to Rust

### DIFF
--- a/lib/bibdata_rs/src/lib.rs
+++ b/lib/bibdata_rs/src/lib.rs
@@ -47,5 +47,9 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
         "recap_partner_notes",
         function!(marc::recap_partner_notes, 1),
     )?;
+    submodule_marc.define_singleton_method(
+        "normalize_oclc_number",
+        function!(marc::normalize_oclc_number, 1),
+    )?;
     Ok(())
 }

--- a/lib/bibdata_rs/src/marc.rs
+++ b/lib/bibdata_rs/src/marc.rs
@@ -6,6 +6,7 @@ mod string_normalize;
 pub mod control_field;
 pub mod fixed_field;
 pub mod genre;
+pub mod identifier;
 pub mod language;
 pub mod note;
 pub mod record_facet_mapping;
@@ -52,6 +53,10 @@ pub fn format_facets(record_string: String) -> Result<Vec<String>, magnus::Error
         .iter()
         .map(|facet| format!("{facet}"))
         .collect())
+}
+
+pub fn normalize_oclc_number(string: String) -> String {
+    identifier::normalize_oclc_number(&string)
 }
 
 pub fn strip_non_numeric(string: String) -> String {

--- a/lib/bibdata_rs/src/marc/identifier.rs
+++ b/lib/bibdata_rs/src/marc/identifier.rs
@@ -1,0 +1,31 @@
+use super::string_normalize::strip_non_numeric;
+
+pub fn normalize_oclc_number(original: &str) -> String {
+    let cleaned = strip_non_numeric(original);
+    match cleaned.len() {
+        1..=8 => format!("ocm{:0>8}", cleaned),
+        9 => format!("ocn{cleaned}"),
+        _ => format!("on{cleaned}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_can_normalize_oclc_number() {
+        assert_eq!(normalize_oclc_number("9913506421"), "on9913506421");
+        assert_eq!(normalize_oclc_number("9913504"), "ocm09913504");
+        assert_eq!(normalize_oclc_number("991350412"), "ocn991350412");
+        assert_eq!(normalize_oclc_number("(OCoLC)882089266"), "ocn882089266");
+        assert_eq!(normalize_oclc_number("(OCoLC)on9990014350"), "on9990014350");
+        assert_eq!(normalize_oclc_number("(OCoLC)ocn899745778"), "ocn899745778");
+        assert_eq!(normalize_oclc_number("(OCoLC)ocm00012345"), "ocm00012345");
+
+        assert_eq!(
+            normalize_oclc_number("(OCoLC)ocm00012345"),
+            normalize_oclc_number("(OCoLC)12345")
+        );
+    }
+}

--- a/marc_to_solr/lib/princeton_marc.rb
+++ b/marc_to_solr/lib/princeton_marc.rb
@@ -148,9 +148,9 @@ def other_versions record
       if (field.tag == '022') || ((field.tag == '776') && (s_field.code == 'x'))
         linked_nums << LibraryStandardNumbers::ISSN.normalize(s_field.value)
       end
-      linked_nums << oclc_normalize(s_field.value, prefix: true) if (field.tag == '035') && oclc_number?(s_field.value)
+      linked_nums << BibdataRs::Marc.normalize_oclc_number(s_field.value) if (field.tag == '035') && oclc_number?(s_field.value)
       if ((field.tag == '776') && (s_field.code == 'w')) || ((field.tag == '787') && (s_field.code == 'w'))
-        linked_nums << oclc_normalize(s_field.value, prefix: true) if oclc_number?(s_field.value)
+        linked_nums << BibdataRs::Marc.normalize_oclc_number(s_field.value) if oclc_number?(s_field.value)
         linked_nums << ('BIB' + BibdataRs::Marc.strip_non_numeric(s_field.value)) unless s_field.value.include?('(')
         if s_field.value.include?('(') && !s_field.value.start_with?('(')
           logger.error "#{record['001']} - linked field formatting: #{s_field.value}"
@@ -334,22 +334,6 @@ def oclc_number? oclc
   # Ensure it follows the OCLC standard
   # (see https://help.oclc.org/Metadata_Services/WorldShare_Collection_Manager/Data_sync_collections/Prepare_your_data/30035_field_and_OCLC_control_numbers)
   clean_oclc.match(/\(OCoLC\)(ocn|ocm|on)*\d+/) != nil
-end
-
-def oclc_normalize oclc, opts = { prefix: false }
-  oclc_num = BibdataRs::Marc.strip_non_numeric(oclc)
-  if opts[:prefix] == true
-    case oclc_num.length
-    when 1..8
-      'ocm' + ('%08d' % oclc_num)
-    when 9
-      'ocn' + oclc_num
-    else
-      'on' + oclc_num
-    end
-  else
-    oclc_num
-  end
 end
 
 # Construct (or retrieve) the cache manager service

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -1375,7 +1375,7 @@ end
 to_field 'oclc_s', extract_marc('035a') do |_record, accumulator|
   oclcs = []
   accumulator.each_with_index do |value, _i|
-    oclcs << oclc_normalize(value) if oclc_number?(value)
+    oclcs << BibdataRs::Marc.strip_non_numeric(value) if oclc_number?(value)
   end
   accumulator.replace(oclcs)
 end

--- a/spec/marc_to_solr/lib/princeton_marc_spec.rb
+++ b/spec/marc_to_solr/lib/princeton_marc_spec.rb
@@ -290,27 +290,6 @@ describe 'From princeton_marc.rb' do
     end
   end
 
-  describe 'oclc_s normalize' do
-    it 'without prefix' do
-      expect(oclc_normalize('(OCoLC)882089266')).to eq('882089266')
-      expect(oclc_normalize('(OCoLC)on9990014350')).to eq('9990014350')
-      expect(oclc_normalize('(OCoLC)ocn899745778')).to eq('899745778')
-      expect(oclc_normalize('(OCoLC)ocm00012345')).to eq('12345')
-    end
-
-    it 'with prefix' do
-      expect(oclc_normalize('(OCoLC)882089266', prefix: true)).to eq('ocn882089266')
-      expect(oclc_normalize('(OCoLC)on9990014350', prefix: true)).to eq('on9990014350')
-      expect(oclc_normalize('(OCoLC)ocn899745778', prefix: true)).to eq('ocn899745778')
-      expect(oclc_normalize('(OCoLC)ocm00012345', prefix: true)).to eq('ocm00012345')
-    end
-
-    it 'source with and without prefix normalize the same way' do
-      expect(oclc_normalize('(OCoLC)ocm00012345')).to eq(oclc_normalize('(OCoLC)12345'))
-      expect(oclc_normalize('(OCoLC)ocm00012345', prefix: true)).to eq(oclc_normalize('(OCoLC)12345', prefix: true))
-    end
-  end
-
   describe 'oclc_number?' do
     it 'detects invalid OCLC numbers' do
       expect(oclc_number?('(OCoLC)TGPSM11-B2267 ')).to be false
@@ -359,9 +338,9 @@ describe 'From princeton_marc.rb' do
     end
 
     it 'includes isbn, issn, oclc nums for expected fields/subfields' do
-      expect(@linked_nums).to include(oclc_normalize(@oclc_num, prefix: true))
-      expect(@linked_nums).to include(oclc_normalize(@oclc_num2, prefix: true))
-      expect(@linked_nums).to include(oclc_normalize(@oclc_num4, prefix: true))
+      expect(@linked_nums).to include(BibdataRs::Marc.normalize_oclc_number(@oclc_num))
+      expect(@linked_nums).to include(BibdataRs::Marc.normalize_oclc_number(@oclc_num2))
+      expect(@linked_nums).to include(BibdataRs::Marc.normalize_oclc_number(@oclc_num4))
       expect(@linked_nums).to include('BIB' + BibdataRs::Marc.strip_non_numeric(@bib))
       expect(@linked_nums).to include(LibraryStandardNumbers::ISSN.normalize(@issn_num))
       expect(@linked_nums).to include(LibraryStandardNumbers::ISSN.normalize(@issn_num2))
@@ -377,11 +356,11 @@ describe 'From princeton_marc.rb' do
     end
 
     it 'excludes numbers not in expect subfields' do
-      expect(@linked_nums).not_to include(oclc_normalize(@oclc_num3, prefix: true))
+      expect(@linked_nums).not_to include(BibdataRs::Marc.normalize_oclc_number(@oclc_num3))
     end
 
     it 'excludes non oclc/non bib in expected oclc/bib subfield' do
-      expect(@linked_nums).not_to include(oclc_normalize(@non_oclc_non_bib, prefix: true))
+      expect(@linked_nums).not_to include(BibdataRs::Marc.normalize_oclc_number(@non_oclc_non_bib))
     end
   end
 


### PR DESCRIPTION
For what it's worth, the rust implementation is quite a bit faster: it takes .044 seconds on a file of ~50,000 records, while the ruby implementation took .387 seconds for the same file.