### PR TITLE
Migrate oclc_number? method to Rust

### DIFF
--- a/lib/bibdata_rs/src/lib.rs
+++ b/lib/bibdata_rs/src/lib.rs
@@ -51,5 +51,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
         "normalize_oclc_number",
         function!(marc::normalize_oclc_number, 1),
     )?;
+    submodule_marc
+        .define_singleton_method("is_oclc_number?", function!(marc::is_oclc_number, 1))?;
     Ok(())
 }

--- a/lib/bibdata_rs/src/marc.rs
+++ b/lib/bibdata_rs/src/marc.rs
@@ -59,6 +59,10 @@ pub fn normalize_oclc_number(string: String) -> String {
     identifier::normalize_oclc_number(&string)
 }
 
+pub fn is_oclc_number(string: String) -> bool {
+    identifier::is_oclc_number(&string)
+}
+
 pub fn strip_non_numeric(string: String) -> String {
     string_normalize::strip_non_numeric(&string)
 }

--- a/marc_to_solr/lib/princeton_marc.rb
+++ b/marc_to_solr/lib/princeton_marc.rb
@@ -148,9 +148,9 @@ def other_versions record
       if (field.tag == '022') || ((field.tag == '776') && (s_field.code == 'x'))
         linked_nums << LibraryStandardNumbers::ISSN.normalize(s_field.value)
       end
-      linked_nums << BibdataRs::Marc.normalize_oclc_number(s_field.value) if (field.tag == '035') && oclc_number?(s_field.value)
+      linked_nums << BibdataRs::Marc.normalize_oclc_number(s_field.value) if (field.tag == '035') && BibdataRs::Marc.is_oclc_number?(s_field.value)
       if ((field.tag == '776') && (s_field.code == 'w')) || ((field.tag == '787') && (s_field.code == 'w'))
-        linked_nums << BibdataRs::Marc.normalize_oclc_number(s_field.value) if oclc_number?(s_field.value)
+        linked_nums << BibdataRs::Marc.normalize_oclc_number(s_field.value) if BibdataRs::Marc.is_oclc_number?(s_field.value)
         linked_nums << ('BIB' + BibdataRs::Marc.strip_non_numeric(s_field.value)) unless s_field.value.include?('(')
         if s_field.value.include?('(') && !s_field.value.start_with?('(')
           logger.error "#{record['001']} - linked field formatting: #{s_field.value}"
@@ -326,14 +326,6 @@ def process_subject_topic_facet record
     end
   end.flatten.compact
   lcsh_subjects + other_thesaurus_subjects
-end
-
-def oclc_number? oclc
-  # Strip spaces and dashes
-  clean_oclc = oclc.gsub(/[\-\s]/, '')
-  # Ensure it follows the OCLC standard
-  # (see https://help.oclc.org/Metadata_Services/WorldShare_Collection_Manager/Data_sync_collections/Prepare_your_data/30035_field_and_OCLC_control_numbers)
-  clean_oclc.match(/\(OCoLC\)(ocn|ocm|on)*\d+/) != nil
 end
 
 # Construct (or retrieve) the cache manager service

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -1375,7 +1375,7 @@ end
 to_field 'oclc_s', extract_marc('035a') do |_record, accumulator|
   oclcs = []
   accumulator.each_with_index do |value, _i|
-    oclcs << BibdataRs::Marc.strip_non_numeric(value) if oclc_number?(value)
+    oclcs << BibdataRs::Marc.strip_non_numeric(value) if BibdataRs::Marc.is_oclc_number?(value)
   end
   accumulator.replace(oclcs)
 end

--- a/spec/marc_to_solr/lib/princeton_marc_spec.rb
+++ b/spec/marc_to_solr/lib/princeton_marc_spec.rb
@@ -290,27 +290,6 @@ describe 'From princeton_marc.rb' do
     end
   end
 
-  describe 'oclc_number?' do
-    it 'detects invalid OCLC numbers' do
-      expect(oclc_number?('(OCoLC)TGPSM11-B2267 ')).to be false
-      expect(oclc_number?('(OCoLC)xon9990014350')).to be false
-      expect(oclc_number?('(OCoLC)onx9990014350')).to be false
-    end
-
-    it 'detects valid OCLC numbers' do
-      # Includes various prefixes and extraneous (but harmless) spaces
-      values = []
-      values << '(OCoLC)882089266'
-      values << '(OCoLC)on9990014350'
-      values << '(OCoLC)ocn899745778'
-      values << '(OCoLC)ocm00112267 '
-      values << '(OCoLC)on 9990014350'
-      values.each do |value|
-        expect(oclc_number?(value)).to be true
-      end
-    end
-  end
-
   describe 'other_versions function' do
     before(:all) do
       @bib = '9947652213506421'


### PR DESCRIPTION
The rust implementation is faster, for a file of ~50,000 records, the ruby implementation takes .619 seconds while the rust implementation takes .162 seconds.