### PR TITLE
Ephemera folder format attribute

### DIFF
--- a/lib/bibdata_rs/src/ephemera/ephemera_folder/format.rs
+++ b/lib/bibdata_rs/src/ephemera/ephemera_folder/format.rs
@@ -1,42 +1,11 @@
 use crate::solr;
 use serde::Deserialize;
 
-use serde::de::Deserializer;
 use serde::Serialize;
 
-#[derive(Copy, Clone, Debug, Serialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Format {
     pub pref_label: Option<solr::FormatFacet>,
-}
-
-impl<'de> Deserialize<'de> for Format {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        struct FormatNestedId {
-            #[serde(rename = "exact_match")]
-            exact_match: Option<serde_json::Value>,
-        }
-
-        let format_nested = FormatNestedId::deserialize(deserializer)?;
-        let facet = format_nested
-            .exact_match
-            .as_ref()
-            .and_then(|em| em.get("@id"))
-            .map(|id_val| {
-                Some(if id_val.is_string() || id_val.is_object() {
-                    solr::FormatFacet::Book
-                } else {
-                    return None;
-                })
-            });
-
-        Ok(Format {
-            pref_label: facet.flatten(),
-        })
-    }
 }
 
 #[cfg(test)]
@@ -67,23 +36,20 @@ mod tests {
     }
 
     #[test]
-    fn it_can_parse_format_from_the_json_ld_when_exact_match_has_one_id() {
+    fn it_can_parse_format_from_the_json_ld_when_there_is_no_exact_match() {
         let json_ld = r#"[
             {
               "@id": "https://figgy-staging.princeton.edu/catalog/5dbeae15-f46a-4411-a385-ce6df02231dc",
               "@type": "skos:Concept",
-              "pref_label": "Pamphlets",
+              "pref_label": "Reports",
               "in_scheme": {
                 "@id": "https://figgy.princeton.edu/ns/ephemeraGenres",
                 "@type": "skos:ConceptScheme",
                 "pref_label": "Ephemera Genres"
-              },
-              "exact_match": {
-                  "@id": "http://id.loc.gov/vocabulary/graphicMaterials/tgm001221"
               }
             }
           ]"#;
         let formats: Vec<Format> = serde_json::from_str(json_ld).unwrap();
-        assert_eq!(formats[0].pref_label, Some(solr::FormatFacet::Book));
+        assert_eq!(formats[0].pref_label, Some(solr::FormatFacet::Report));
     }
 }

--- a/lib/bibdata_rs/src/solr/format_facet.rs
+++ b/lib/bibdata_rs/src/solr/format_facet.rs
@@ -95,7 +95,7 @@ impl FromStr for FormatFacet {
             "picket signs" => Ok(Self::Book),
             "posters" => Ok(Self::VisualMaterial),
             "postcards" => Ok(Self::Book),
-            "reports" => Ok(Self::Report),
+            "report" | "reports" => Ok(Self::Report),
             "serials" => Ok(Self::Journal),
             "series" => Ok(Self::Book),
             "stickers" => Ok(Self::Book),


### PR DESCRIPTION
Remove the exact_match check of a nested id or not. Accept and map the ephemera format label to the current catalog facet

related to #2639