### PR TITLE
Rewrite other_versions in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,7 @@ dependencies = [
  "criterion",
  "env_logger",
  "itertools 0.14.0",
+ "library_stdnums",
  "log",
  "magnus",
  "marctk",
@@ -1247,6 +1248,12 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "library_stdnums"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff45009282f541df36b35638ca06f8ecc0c7154fe380ad79e279660e7c1d758c"
 
 [[package]]
 name = "linux-raw-sys"

--- a/lib/bibdata_rs/Cargo.toml
+++ b/lib/bibdata_rs/Cargo.toml
@@ -25,6 +25,7 @@ rayon = "1.10.0"
 anyhow = "1.0.98"
 rb-sys = "0.9.115"
 marctk = "0.5.0"
+library_stdnums = "0.1.0"
 
 [dev-dependencies]
 criterion = "0.6.0"

--- a/lib/bibdata_rs/src/lib.rs
+++ b/lib/bibdata_rs/src/lib.rs
@@ -51,6 +51,10 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
         "normalize_oclc_number",
         function!(marc::normalize_oclc_number, 1),
     )?;
+    submodule_marc.define_singleton_method(
+        "identifiers_of_all_versions",
+        function!(marc::identifiers_of_all_versions, 1),
+    )?;
     submodule_marc
         .define_singleton_method("is_oclc_number?", function!(marc::is_oclc_number, 1))?;
     Ok(())

--- a/lib/bibdata_rs/src/marc.rs
+++ b/lib/bibdata_rs/src/marc.rs
@@ -63,6 +63,11 @@ pub fn is_oclc_number(string: String) -> bool {
     identifier::is_oclc_number(&string)
 }
 
+pub fn identifiers_of_all_versions(record_string: String) -> Result<Vec<String>, magnus::Error> {
+    let record = get_record(&record_string)?;
+    Ok(identifier::identifiers_of_all_versions(&record))
+}
+
 pub fn strip_non_numeric(string: String) -> String {
     string_normalize::strip_non_numeric(&string)
 }

--- a/lib/bibdata_rs/src/marc/control_field/system_control_number.rs
+++ b/lib/bibdata_rs/src/marc/control_field/system_control_number.rs
@@ -1,9 +1,11 @@
 // This module is concerned with the 035 (system control number)
 
+use crate::marc::identifier::oclc::is_oclc_number;
 use marctk::Record;
 
 pub enum SystemControlNumber {
     Pulfa(String),
+    OCLCNumber(String),
     OtherControlNumber,
     InvalidControlNumber,
 }
@@ -15,6 +17,8 @@ impl From<&str> for SystemControlNumber {
                 Some(number) => SystemControlNumber::Pulfa(number.to_owned()),
                 None => SystemControlNumber::InvalidControlNumber,
             }
+        } else if is_oclc_number(value) {
+            Self::OCLCNumber(value.to_owned())
         } else {
             SystemControlNumber::OtherControlNumber
         }

--- a/lib/bibdata_rs/src/marc/identifier.rs
+++ b/lib/bibdata_rs/src/marc/identifier.rs
@@ -1,4 +1,75 @@
+use super::string_normalize::strip_non_numeric;
+use isbn::normalized_isbns_for_all_versions;
+use issn::normalized_issns_for_all_versions;
+use marctk::Record;
+use oclc::normalized_oclc_numbers;
+
+mod isbn;
+mod issn;
 pub mod oclc;
 
 pub use oclc::is_oclc_number;
 pub use oclc::normalize_oclc_number;
+
+// Get identifier numbers for all known versions of this title from the record.
+// This is used to link records together in the catalog's Other Versions feature.
+pub fn identifiers_of_all_versions(record: &Record) -> Vec<String> {
+    normalized_isbns_for_all_versions(record)
+        .chain(normalized_issns_for_all_versions(record))
+        .chain(normalized_oclc_numbers(record))
+        .chain(normalized_oclc_numbers(record))
+        .chain(linked_record_control_numbers(record))
+        .collect()
+}
+
+// Record control numbers can either be OCLC numbers (which are normalized to a format like ocn991350412)
+// or some other type of control number (which are normalized and include the prefix BIB)
+fn linked_record_control_numbers(record: &Record) -> impl Iterator<Item = String> {
+    record
+        .extract_values("776w:787w")
+        .into_iter()
+        .filter_map(|value| {
+            if is_oclc_number(&value) {
+                Some(normalize_oclc_number(&value))
+            } else if value.contains('(') {
+                Some(format!("BIB{}", strip_non_numeric(&value)))
+            } else {
+                None
+            }
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_can_get_identifiers_of_all_versions() {
+        let record = Record::from_breaker(
+            r#"=776 \\ $w9947652213506421
+=776 \\ $w(DLC)12345678
+=776 \\ $w(OCoLC)on9990014350
+=787 \\ $w(OCoLC)on9990014351$z(OCoLC)on9990014352
+=035 \\ $a(OCoLC)on9990014353
+=022 \\ $l0378-5955$y0378-5955
+=776 \\ $x1234-5679
+=776 \\ $z0-9752298-0-X
+=020 \\ $aISBN: 978-0-306-40615-7$z0-306-40615-2"#,
+        )
+        .unwrap();
+        assert_eq!(
+            identifiers_of_all_versions(&record).sort(),
+            vec![
+                "BIB9947652213506421",
+                "on9990014350",
+                "on9990014351",
+                "on9990014353",
+                "03785955",
+                "12345679",
+                "9780975229804",
+                "9780306406157"
+            ]
+            .sort()
+        )
+    }
+}

--- a/lib/bibdata_rs/src/marc/identifier/isbn.rs
+++ b/lib/bibdata_rs/src/marc/identifier/isbn.rs
@@ -1,0 +1,9 @@
+use library_stdnums::{isbn::ISBN, traits::Normalize};
+use marctk::Record;
+
+pub fn normalized_isbns_for_all_versions(record: &Record) -> impl Iterator<Item = String> {
+    record
+        .extract_values("020az:776z")
+        .into_iter()
+        .filter_map(|value| ISBN::new(value).normalize())
+}

--- a/lib/bibdata_rs/src/marc/identifier/issn.rs
+++ b/lib/bibdata_rs/src/marc/identifier/issn.rs
@@ -1,0 +1,9 @@
+use library_stdnums::{issn::ISSN, traits::Normalize};
+use marctk::Record;
+
+pub fn normalized_issns_for_all_versions(record: &Record) -> impl Iterator<Item = String> {
+    record
+        .extract_values("022alyz:776x")
+        .into_iter()
+        .filter_map(|value| ISSN::new(value).normalize())
+}

--- a/lib/bibdata_rs/src/marc/identifier/oclc.rs
+++ b/lib/bibdata_rs/src/marc/identifier/oclc.rs
@@ -1,6 +1,19 @@
-use crate::marc::string_normalize::strip_non_numeric;
+use crate::marc::{
+    control_field::system_control_number::{system_control_numbers, SystemControlNumber},
+    string_normalize::strip_non_numeric,
+};
+use marctk::Record;
 use regex::Regex;
 use std::sync::LazyLock;
+
+pub fn normalized_oclc_numbers(record: &Record) -> impl Iterator<Item = String> {
+    system_control_numbers(record)
+        .into_iter()
+        .filter_map(|number| match number {
+            SystemControlNumber::OCLCNumber(oclc) => Some(normalize_oclc_number(&oclc)),
+            _ => None,
+        })
+}
 
 pub fn normalize_oclc_number(original: &str) -> String {
     let cleaned = strip_non_numeric(original);

--- a/marc_to_solr/lib/princeton_marc.rb
+++ b/marc_to_solr/lib/princeton_marc.rb
@@ -133,34 +133,6 @@ def standard_no_hash record
   standard_no
 end
 
-# Handles ISBNs, ISSNs, and OCLCs
-# ISBN: 020a, 020z, 776z
-# ISSN: 022a, 022l, 022y, 022z, 776x
-# OCLC: 035a, 776w, 787w
-# BIB: 776w, 787w (adds BIB prefix so Blacklight can detect whether to search id field)
-def other_versions record
-  linked_nums = []
-  Traject::MarcExtractor.cached('020az:022alyz:035a:776wxz:787w').collect_matching_lines(record) do |field, _spec, _extractor|
-    field.subfields.each do |s_field|
-      if (field.tag == '020') || ((field.tag == '776') && (s_field.code == 'z'))
-        linked_nums << LibraryStandardNumbers::ISBN.normalize(s_field.value)
-      end
-      if (field.tag == '022') || ((field.tag == '776') && (s_field.code == 'x'))
-        linked_nums << LibraryStandardNumbers::ISSN.normalize(s_field.value)
-      end
-      linked_nums << BibdataRs::Marc.normalize_oclc_number(s_field.value) if (field.tag == '035') && BibdataRs::Marc.is_oclc_number?(s_field.value)
-      if ((field.tag == '776') && (s_field.code == 'w')) || ((field.tag == '787') && (s_field.code == 'w'))
-        linked_nums << BibdataRs::Marc.normalize_oclc_number(s_field.value) if BibdataRs::Marc.is_oclc_number?(s_field.value)
-        linked_nums << ('BIB' + BibdataRs::Marc.strip_non_numeric(s_field.value)) unless s_field.value.include?('(')
-        if s_field.value.include?('(') && !s_field.value.start_with?('(')
-          logger.error "#{record['001']} - linked field formatting: #{s_field.value}"
-        end
-      end
-    end
-  end
-  linked_nums.compact.uniq
-end
-
 # only includes values before $t
 def process_names record
   Traject::MarcExtractor.cached('100aqbcdk:110abcdfgkln:111abcdfgklnpq:700aqbcdk:710abcdfgkln:711abcdfgklnpq').collect_matching_lines(record) do |field, spec, extractor|

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -1393,9 +1393,8 @@ end
 #    3500 022A776X
 #    3500 020A776Z
 #    3500 776Z020A
-to_field 'other_version_s' do |record, accumulator|
-  linked_nums = other_versions(record)
-  accumulator.replace(linked_nums)
+to_field 'other_version_s' do |_record, accumulator, context|
+  accumulator.replace(BibdataRs::Marc.identifiers_of_all_versions(context.clipboard[:marc_breaker]))
 end
 
 # Original language:

--- a/spec/marc_to_solr/lib/princeton_marc_spec.rb
+++ b/spec/marc_to_solr/lib/princeton_marc_spec.rb
@@ -290,59 +290,6 @@ describe 'From princeton_marc.rb' do
     end
   end
 
-  describe 'other_versions function' do
-    before(:all) do
-      @bib = '9947652213506421'
-      @bib_776w = { '776' => { 'ind1' => '', 'ind2' => ' ', 'subfields' => [{ 'w' => @bib }] } }
-      @non_oclc_non_bib = '(DLC)12345678'
-      @non_oclc_non_bib_776w = { '776' => { 'ind1' => '', 'ind2' => ' ', 'subfields' => [{ 'w' => @non_oclc_non_bib }] } }
-      @oclc_num = '(OCoLC)on9990014350'
-      @oclc_776w = { '776' => { 'ind1' => '', 'ind2' => ' ', 'subfields' => [{ 'w' => @oclc_num }] } }
-      @oclc_num2 = '(OCoLC)on9990014351'
-      @oclc_num3 = '(OCoLC)on9990014352'
-      @oclc_787w = { '787' => { 'ind1' => '', 'ind2' => ' ', 'subfields' => [{ 'w' => @oclc_num2 }, { 'z' => @oclc_num3 }] } }
-      @oclc_num4 = '(OCoLC)on9990014353'
-      @oclc_035a = { '035' => { 'ind1' => '', 'ind2' => ' ', 'subfields' => [{ 'a' => @oclc_num4 }] } }
-      @issn_num = '0378-5955'
-      @issn_022 = { '022' => { 'ind1' => '', 'ind2' => ' ', 'subfields' => [{ 'l' => @issn_num }, { 'y' => @issn_num }] } }
-      @issn_num2 = '1234-5679'
-      @issn_776x = { '776' => { 'ind1' => '', 'ind2' => ' ', 'subfields' => [{ 'x' => @issn_num2 }] } }
-      @isbn_num = '0-9752298-0-X'
-      @isbn_776z = { '776' => { 'ind1' => '', 'ind2' => ' ', 'subfields' => [{ 'z' => @isbn_num }] } }
-      @isbn_num2 = 'ISBN: 978-0-306-40615-7'
-      @isbn_num2_10d = '0-306-40615-2'
-      @isbn_020 = { '020' => { 'ind1' => '', 'ind2' => ' ', 'subfields' => [{ 'a' => @isbn_num2 }, { 'z' => @isbn_num2_10d }] } }
-      @sample_marc = MARC::Record.new_from_hash('fields' => [@bib_776w, @non_oclc_non_bib_776w, @oclc_776w, @oclc_787w, @oclc_035a, @issn_022, @issn_776x, @isbn_776z, @isbn_020])
-      @linked_nums = other_versions(@sample_marc)
-    end
-
-    it 'includes isbn, issn, oclc nums for expected fields/subfields' do
-      expect(@linked_nums).to include(BibdataRs::Marc.normalize_oclc_number(@oclc_num))
-      expect(@linked_nums).to include(BibdataRs::Marc.normalize_oclc_number(@oclc_num2))
-      expect(@linked_nums).to include(BibdataRs::Marc.normalize_oclc_number(@oclc_num4))
-      expect(@linked_nums).to include('BIB' + BibdataRs::Marc.strip_non_numeric(@bib))
-      expect(@linked_nums).to include(LibraryStandardNumbers::ISSN.normalize(@issn_num))
-      expect(@linked_nums).to include(LibraryStandardNumbers::ISSN.normalize(@issn_num2))
-      expect(@linked_nums).to include(LibraryStandardNumbers::ISBN.normalize(@isbn_num))
-      expect(@linked_nums).to include(LibraryStandardNumbers::ISBN.normalize(@isbn_num2))
-      expect(@linked_nums).to include(LibraryStandardNumbers::ISBN.normalize(@isbn_num2_10d))
-    end
-
-    it 'removes duplicates' do
-      expect(LibraryStandardNumbers::ISBN.normalize(@isbn_num2)).to eq(LibraryStandardNumbers::ISBN.normalize(@isbn_num2_10d))
-      expect(@linked_nums.count(LibraryStandardNumbers::ISSN.normalize(@issn_num))).to eq 1
-      expect(@linked_nums.count(LibraryStandardNumbers::ISBN.normalize(@isbn_num2_10d))).to eq 1
-    end
-
-    it 'excludes numbers not in expect subfields' do
-      expect(@linked_nums).not_to include(BibdataRs::Marc.normalize_oclc_number(@oclc_num3))
-    end
-
-    it 'excludes non oclc/non bib in expected oclc/bib subfield' do
-      expect(@linked_nums).not_to include(BibdataRs::Marc.normalize_oclc_number(@non_oclc_non_bib))
-    end
-  end
-
   describe 'process_names, process_alt_script_names function' do
     before(:all) do
       @t100 = { '100' => { 'ind1' => '', 'ind2' => ' ', 'subfields' => [{ 'a' => 'John' }, { 'd' => '1492' }, { 't' => 'TITLE' }, { 'k' => 'ignore' }] } }


### PR DESCRIPTION
Also, move oclc validation and normalization to its own module.

The Rust implementation is faster.  For a file of ~50,000 records, the ruby implementation took 3.678 seconds while the rust implementation took .941 seconds.