### PR TITLE
Add parallel non-Latin publication statements back

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "marctk"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1eca22081ab92a86e5c3db7d258a4c16f051f2bc7b34b5522803ce6964c61af"
+checksum = "824169a757e4fe8cc0b274b328992d65e3a9421431c9aa115507d85fd2fd53c1"
 dependencies = [
  "getopts",
  "xml-rs",

--- a/lib/bibdata_rs/Cargo.toml
+++ b/lib/bibdata_rs/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4.27"
 rayon = "1.10.0"
 anyhow = "1.0.98"
 rb-sys = "0.9.115"
-marctk = "0.5.0"
+marctk = {version = "0.6.0", features = ["marc21_bibliographic"] }
 library_stdnums = "0.1.0"
 
 [dev-dependencies]

--- a/lib/bibdata_rs/src/marc/control_field/cataloging_source.rs
+++ b/lib/bibdata_rs/src/marc/control_field/cataloging_source.rs
@@ -51,7 +51,7 @@ mod tests {
 
     #[test]
     fn it_categorizes_record_with_no_040_as_archival_description() {
-        let record = Record::from_breaker("").unwrap();
+        let record = Record::default();
         assert!(uses_archival_description(&record));
     }
 

--- a/lib/bibdata_rs/src/marc/publication.rs
+++ b/lib/bibdata_rs/src/marc/publication.rs
@@ -2,13 +2,16 @@
 
 use super::{
     fixed_field::dates::{DateType, EndDate},
-    variable_length_field::join_subfields,
+    variable_length_field::{join_all_subfields, join_subfields},
 };
 use itertools::Itertools;
 use marctk::Record;
 
 pub fn publication_statements(record: &Record) -> impl Iterator<Item = String> + use<'_> {
-    statements_from_260(record).chain(statements_from_264(record))
+    statements_from_260(record)
+        .chain(statements_from_parallel_260(record))
+        .chain(statements_from_264(record))
+        .chain(statements_from_parallel_264(record))
 }
 
 fn statements_from_264(record: &Record) -> impl Iterator<Item = String> + use<'_> {
@@ -16,7 +19,7 @@ fn statements_from_264(record: &Record) -> impl Iterator<Item = String> + use<'_
         .extract_partial_fields("264abcefg3")
         .into_iter()
         .sorted_by(|a, b| a.ind2().cmp(b.ind2()))
-        .map(|field| join_subfields(&field))
+        .map(|field| join_all_subfields(&field))
 }
 
 fn statements_from_260(record: &Record) -> impl Iterator<Item = String> + use<'_> {
@@ -24,16 +27,48 @@ fn statements_from_260(record: &Record) -> impl Iterator<Item = String> + use<'_
         .extract_partial_fields("260abcefg")
         .into_iter()
         .map(move |field| {
-            let content = join_subfields(&field);
-            match (DateType::from(record), EndDate::try_from(record)) {
-                (DateType::ContinuousResourceCeasedPublication, Ok(end_date))
-                    if content.ends_with("-") =>
-                {
-                    format!("{content}{end_date}")
-                }
-                _ => content,
-            }
+            let content = join_all_subfields(&field);
+            append_end_date_if_needed(&content, record)
         })
+}
+
+fn statements_from_parallel_264(record: &Record) -> impl Iterator<Item = String> + use<'_> {
+    record
+        .get_parallel_fields("264")
+        .into_iter()
+        .map(move |field| {
+            let content =
+                join_subfields(field.subfields().iter().filter(|subfield| {
+                    ["a", "b", "c", "e", "f", "g", "3"].contains(&subfield.code())
+                }));
+            append_end_date_if_needed(&content, record)
+        })
+}
+
+fn statements_from_parallel_260(record: &Record) -> impl Iterator<Item = String> + use<'_> {
+    record
+        .get_parallel_fields("260")
+        .into_iter()
+        .map(move |field| {
+            let content = join_subfields(
+                field
+                    .subfields()
+                    .iter()
+                    .filter(|subfield| ["a", "b", "c", "e", "f", "g"].contains(&subfield.code())),
+            );
+            append_end_date_if_needed(&content, record)
+        })
+}
+
+fn append_end_date_if_needed(publication_statement: &str, record: &Record) -> String {
+    match (DateType::from(record), EndDate::try_from(record)) {
+        (DateType::ContinuousResourceCeasedPublication, Ok(end_date))
+            if publication_statement.ends_with("-") =>
+        {
+            format!("{publication_statement}{end_date}")
+        }
+        _ => publication_statement.to_owned(),
+    }
 }
 
 #[cfg(test)]
@@ -49,6 +84,46 @@ mod tests {
         assert_eq!(
             statements.next(),
             Some("Milano : Armenia Editore, 1976-1979.".to_owned())
+        );
+        assert_eq!(statements.next(), None);
+    }
+
+    #[test]
+    fn it_gets_parallel_publication_statements_in_non_latin_script_from_260() {
+        let record =
+            Record::from_breaker("=245 00 $6880-01$a2006-2025 Sŏul, tosi kŏnch'uk hyŏksin ŭi kirok : ilsang ŭl pit naenŭn Sŏul ŭi tosi kŏnch'uk p'ŭrojekt'ŭ 66.
+=880 00 $6245-01$a2006-2025 서울, 도시건축 혁신의 기록 : 일상을 빛내는 서울의 도시건축 프로젝트 66.
+=260 \\ $6880-02$a Sŏul: $b Sŏul T'ŭkpyŏlsi, $c 2025.
+=880 \\ $6260-02$a 서울: $b 서울특별시, $c 2025.").unwrap();
+        let mut statements = publication_statements(&record);
+
+        assert_eq!(
+            statements.next(),
+            Some("Sŏul: Sŏul T'ŭkpyŏlsi, 2025.".to_owned())
+        );
+        assert_eq!(
+            statements.next(),
+            Some("서울: 서울특별시, 2025.".to_owned())
+        );
+        assert_eq!(statements.next(), None);
+    }
+
+    #[test]
+    fn it_gets_parallel_publication_statements_in_non_latin_script_from_264() {
+        let record =
+            Record::from_breaker(r"=245 00 $6880-01$a Mahākālera tarjanī : $b Baṅgabandhu Śekha Mujibake nibedita kabitā / $c sampādanā, Kāmāla Caudhurī = Mohakaler torjoni : Bangabandhu Sheikh Mujibke nibedito kobita.
+=880 00 $6245-01$aমহাকালের তর্জনী : $b বঙ্গবন্ধু শেখ মুজিবকে নিবেদিত কবিতা / $c সম্পাদনা, কামাল চৌধুরী = Mohakaler torjoni : Bangabandhu Sheikh Mujibke nibedito kobita.
+=264 \1 $6880-02$a Ḍhākā : $b Di Iunibhārsiṭi Presa Limiṭeḍa, $c Mārca 2022.
+=880 \1 $6264-02$a ঢাকা : $b ডি ইউনিভার্সিটি প্রেস লিমিটেড, $c মার্চ ২০২২.").unwrap();
+        let mut statements = publication_statements(&record);
+
+        assert_eq!(
+            statements.next(),
+            Some("Ḍhākā : Di Iunibhārsiṭi Presa Limiṭeḍa, Mārca 2022.".to_owned())
+        );
+        assert_eq!(
+            statements.next(),
+            Some("ঢাকা : ডি ইউনিভার্সিটি প্রেস লিমিটেড, মার্চ ২০২২.".to_owned())
         );
         assert_eq!(statements.next(), None);
     }

--- a/lib/bibdata_rs/src/marc/variable_length_field.rs
+++ b/lib/bibdata_rs/src/marc/variable_length_field.rs
@@ -1,12 +1,12 @@
 use itertools::Itertools;
-use marctk::Field;
+use marctk::{Field, Subfield};
 
-pub fn join_subfields(field: &Field) -> String {
-    let raw = field
-        .subfields()
-        .iter()
-        .map(|subfield| subfield.content())
-        .join(" ");
+pub fn join_all_subfields(field: &Field) -> String {
+    join_subfields(field.subfields().iter())
+}
+
+pub fn join_subfields<'a>(subfields: impl Iterator<Item = &'a Subfield>) -> String {
+    let raw = subfields.map(|subfield| subfield.content()).join(" ");
     combine_consecutive_whitespace(&raw)
 }
 


### PR DESCRIPTION
PR #2880 introduced a regression by neglecting to include non-Latin publication statements from the 880 fields.

This commit upgrades marctk to 0.6.0, which includes a convenience function for retrieving data from 880 fields, and fixes the regression by adding the non-Latin statements back.