### PR TITLE
[#2869] Add target directory to capistrano linked_dirs

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,6 +25,7 @@ set :passenger_restart_with_touch, true
 
 # Default value for linked_dirs is []
 set :linked_dirs, %w{
+  target
   tmp/pids
   tmp/cache
   tmp/figgy_ark_cache


### PR DESCRIPTION
This allows us to persist the Rust build cache between deployments, saving time and disk space.

Before: deploying to bibdata-staging2 took 3 minutes and 43 seconds
After: it takes 1 minute and 4 seconds.

Closes #2869