### PR TITLE
Only run rust tests once in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,12 +137,11 @@ jobs:
     steps:
       - checkout
       - rust/install
-      - rust/test
       - run:
           name: Install cargo-llvm-cov
           command: cargo +stable install cargo-llvm-cov --locked
       - run:
-          name: Run coverage
+          name: Run tests with coverage
           command: cargo llvm-cov --lcov --output-path lcov.info --ignore-filename-regex iso_639_2b
       - coveralls/upload:
           coverage_file: lcov.info


### PR DESCRIPTION
Before this commit, we ran the rust tests twice in CI: once with coverage, once without it.

This commit keeps only the test run with coverage, so that we can save a little time in CI.

You can see that [this still catches failing tests on this branch](https://github.com/pulibrary/bibdata/compare/main...failing-rust-test)