### PR TITLE
[ElectronicAccess] Rename iiif_manifest_url to iiif_manifest_paths

### DIFF
--- a/lib/bibdata_rs/src/ephemera/ephemera_folder.rs
+++ b/lib/bibdata_rs/src/ephemera/ephemera_folder.rs
@@ -186,7 +186,7 @@ impl EphemeraFolder {
             url: self.id.clone(),
             link_text: "Online Content".to_owned(),
             link_description: Some("Born Digital Monographic Reports and Papers".to_owned()),
-            iiif_manifest_url: Some(format!(
+            iiif_manifest_paths: Some(format!(
                 "https://figgy.princeton.edu/concern/ephemera_folders/{}/manifest",
                 self.normalized_id()
             )),

--- a/lib/bibdata_rs/src/solr/electronic_access.rs
+++ b/lib/bibdata_rs/src/solr/electronic_access.rs
@@ -6,7 +6,7 @@ pub struct ElectronicAccess {
     pub url: String,
     pub link_text: String,
     pub link_description: Option<String>,
-    pub iiif_manifest_url: Option<String>,
+    pub iiif_manifest_paths: Option<String>,
     pub digital_content: Option<DigitalContent>,
 }
 
@@ -50,7 +50,7 @@ impl Serialize for ElectronicAccess {
         }
 
         // IIIF Manifest Paths
-        if let Some(iiif_url) = &self.iiif_manifest_url {
+        if let Some(iiif_url) = &self.iiif_manifest_paths {
             let mut iiif_map = serde_json::Map::new();
             iiif_map.insert(
                 "ephemera_ark".to_string(),
@@ -131,7 +131,7 @@ impl<'de> Deserialize<'de> for ElectronicAccess {
             url: url.clone(),
             link_text,
             link_description,
-            iiif_manifest_url,
+            iiif_manifest_paths: iiif_manifest_url,
             digital_content,
         })
     }
@@ -147,7 +147,7 @@ mod tests {
             url: "https://figgy-staging.princeton.edu/catalog/af4a941d-96a4-463e-9043-cfa512e5eddd".to_string(),
             link_text: "Online Content".to_string(),
             link_description: Some("Born Digital Monographic Reports and Papers".to_string()),
-            iiif_manifest_url: Some("https://figgy.princeton.edu/concern/ephemera_folders/af4a941d-96a4-463e-9043-cfa512e5eddd/manifest".to_string()),
+            iiif_manifest_paths: Some("https://figgy.princeton.edu/concern/ephemera_folders/af4a941d-96a4-463e-9043-cfa512e5eddd/manifest".to_string()),
             digital_content: Some(DigitalContent {
                 link_text: vec!["Digital Content".to_string()],
                 url: "https://catalog-staging.princeton.edu/catalog/af4a941d-96a4-463e-9043-cfa512e5eddd#view".to_string(),
@@ -164,7 +164,7 @@ mod tests {
             url: "http://arks.princeton.edu/ark:/88435/dch989rf19q".to_owned(),
             link_text: "Electronic Resource".to_owned(),
             link_description: None,
-            iiif_manifest_url: None,
+            iiif_manifest_paths: None,
             digital_content: None,
         };
         assert_eq!(

--- a/lib/bibdata_rs/src/solr/ephemera_solr_mapping.rs
+++ b/lib/bibdata_rs/src/solr/ephemera_solr_mapping.rs
@@ -127,7 +127,7 @@ mod tests {
                     url: "https://figgy-staging.princeton.edu/catalog/af4a941d-96a4-463e-9043-cfa512e5eddd".to_string(),
                     link_text: "Online Content".to_string(),
                     link_description: Some("Born Digital Monographic Reports and Papers".to_string()),
-                    iiif_manifest_url: Some("https://figgy.princeton.edu/concern/ephemera_folders/af4a941d-96a4-463e-9043-cfa512e5eddd/manifest".to_string()),
+                    iiif_manifest_paths: Some("https://figgy.princeton.edu/concern/ephemera_folders/af4a941d-96a4-463e-9043-cfa512e5eddd/manifest".to_string()),
                     digital_content: Some(DigitalContent {
                         link_text: vec!["Digital content".to_string()],
                         url: "https://catalog-staging.princeton.edu/catalog/af4a941d-96a4-463e-9043-cfa512e5eddd#view".to_string(),
@@ -466,7 +466,7 @@ mod tests {
                 url: "http://example.com".to_owned(),
                 link_text: "Access Link".to_owned(),
                 link_description: Some("Description of the link".to_owned()),
-                iiif_manifest_url: Some(
+                iiif_manifest_paths: Some(
                     "https://figgy.princeton.edu/concern/ephemera_folders/abc123/manifest"
                         .to_owned(),
                 ),
@@ -481,7 +481,7 @@ mod tests {
                 url: ephemera_item.id.clone(),
                 link_text: "Online Content".to_owned(),
                 link_description: Some("Born Digital Monographic Reports and Papers".to_owned()),
-                iiif_manifest_url: Some(
+                iiif_manifest_paths: Some(
                     "https://figgy.princeton.edu/concern/ephemera_folders/abc123/manifest"
                         .to_owned()
                 ),

--- a/lib/bibdata_rs/src/solr/solr_document.rs
+++ b/lib/bibdata_rs/src/solr/solr_document.rs
@@ -163,7 +163,7 @@ mod tests {
                 url: "http://arks.princeton.edu/ark:/88435/dsp01b2773v788".to_owned(),
                 link_text: "DataSpace".to_owned(),
                 link_description: Some("Full text".to_owned()),
-                iiif_manifest_url: None,
+                iiif_manifest_paths: None,
                 digital_content: None,
             }))
             .build();

--- a/lib/bibdata_rs/src/theses/dataspace/document/normalize.rs
+++ b/lib/bibdata_rs/src/theses/dataspace/document/normalize.rs
@@ -251,7 +251,7 @@ mod tests {
                 url: "http://arks.princeton.edu/ark:/88435/dsp01b2773v788".to_owned(),
                 link_text: "DataSpace".to_owned(),
                 link_description: Some("Full text".to_owned()),
-                iiif_manifest_url: None,
+                iiif_manifest_paths: None,
                 digital_content: None,
             }
         );
@@ -280,7 +280,7 @@ mod tests {
                 url: "http://arks.princeton.edu/ark:/88435/dsp01b2773v788".to_owned(),
                 link_text: "DataSpace".to_owned(),
                 link_description: Some("Full text".to_owned()),
-                iiif_manifest_url: None,
+                iiif_manifest_paths: None,
                 digital_content: None,
             }
         );

--- a/lib/bibdata_rs/src/theses/holdings.rs
+++ b/lib/bibdata_rs/src/theses/holdings.rs
@@ -66,7 +66,7 @@ pub fn dataspace_url_with_metadata(
             ThesisAvailability::OnSiteOnly => Some("Citation only".to_owned()),
             ThesisAvailability::AvailableOffSite => Some("Full text".to_owned()),
         },
-        iiif_manifest_url: None,
+        iiif_manifest_paths: None,
         digital_content: None,
     })
 }


### PR DESCRIPTION
[ElectronicAccess] Rename iiif_manifest_url to iiif_manifest_paths
to keep a consistency with the key attribute in the electronic_access_1display