### PR TITLE
AugmentTheSubject: use a Set to make subfield_a_match? faster

### DIFF
--- a/marc_to_solr/lib/augment_the_subject.rb
+++ b/marc_to_solr/lib/augment_the_subject.rb
@@ -33,7 +33,7 @@ class AugmentTheSubject
       parsed_json = JSON.parse(File.read(LCSH_STANDALONE_A_FILE), { symbolize_names: true })
       parsed_json[:standalone_subfield_a].map do |term|
         normalize(term)
-      end
+      end.to_set
     end
   end
 


### PR DESCRIPTION
In a Vernier profile, 17% of all indexing time was spent in AugmentTheSubject#subfield_a_match?, almost all of which was Array#include?

This commit switches from Array#include? to Set#include?, which is much faster. Vernier says that this method now only take 0.6% of all indexing time, and Traject'ss statistics have increased from 240 records/second to 283 records/second locally.