### PR TITLE
Remove link:Born Digital Monographic Reports and Papers from the electronic_access_1display

### DIFF
--- a/lib/bibdata_rs/src/ephemera/born_digital_collection.rs
+++ b/lib/bibdata_rs/src/ephemera/born_digital_collection.rs
@@ -53,7 +53,7 @@ pub async fn chunk_read_id(
     for id in ids {
         let client = CatalogClient::new(url.to_owned());
         let mut response = client.get_item_data(&id).await?;
-        if let Ok(thumbnail) = response.fetch_thumbnail(&url, &id).await {
+        if let Ok(thumbnail) = response.fetch_thumbnail(url, &id).await {
             response.thumbnail = thumbnail;
         }
         responses.push(SolrDocument::from(&response));
@@ -148,7 +148,10 @@ mod tests {
         // Mock get_item_data response
         let item_data_path = "../../spec/fixtures/files/ephemera/ephemera1.json";
         let _mock_item = server
-            .mock("GET", "/catalog/af4a941d-96a4-463e-9043-cfa511e5eddd.jsonld")
+            .mock(
+                "GET",
+                "/catalog/af4a941d-96a4-463e-9043-cfa511e5eddd.jsonld",
+            )
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body_from_file(item_data_path)
@@ -159,7 +162,10 @@ mod tests {
             "thumbnail": { "@id": "https://example.com/thumbnail.jpg" }
         }"#;
         let _mock_manifest = server
-            .mock("GET", "/concern/ephemera_folders/af4a941d-96a4-463e-9043-cfa511e5eddd/manifest")
+            .mock(
+                "GET",
+                "/concern/ephemera_folders/af4a941d-96a4-463e-9043-cfa511e5eddd/manifest",
+            )
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(manifest_json)

--- a/lib/bibdata_rs/src/ephemera/ephemera_folder.rs
+++ b/lib/bibdata_rs/src/ephemera/ephemera_folder.rs
@@ -1,4 +1,4 @@
-use crate::solr::{self, AccessFacet, DigitalContent};
+use crate::solr::{self, AccessFacet};
 
 use super::{
     born_digital_collection::ephemera_folders_iterator,
@@ -222,20 +222,16 @@ impl EphemeraFolder {
     }
     pub fn electronic_access(&self) -> Option<solr::ElectronicAccess> {
         Some(solr::ElectronicAccess {
-            url: self.id.clone(),
-            link_text: "Online Content".to_owned(),
-            link_description: Some("Born Digital Monographic Reports and Papers".to_owned()),
+            url: format!(
+                "https://catalog-staging.princeton.edu/catalog/{}#view",
+                self.normalized_id()
+            ),
+            link_text: "Digital content".to_owned(),
+            link_description: None,
             iiif_manifest_paths: Some(format!(
                 "https://figgy.princeton.edu/concern/ephemera_folders/{}/manifest",
                 self.normalized_id()
             )),
-            digital_content: Some(DigitalContent {
-                link_text: vec!["Digital content".to_owned()],
-                url: format!(
-                    "https://catalog-staging.princeton.edu/catalog/{}#view",
-                    self.normalized_id()
-                ),
-            }),
         })
     }
     pub fn normalized_id(&self) -> String {
@@ -321,27 +317,6 @@ mod tests {
         assert_eq!(
             ephemera_folder_item.format.unwrap()[0].pref_label,
             Some(solr::FormatFacet::Book)
-        );
-    }
-
-    #[tokio::test]
-    async fn it_can_read_the_digital_content_from_json_ld() {
-        let file = File::open("../../spec/fixtures/files/ephemera/ephemera1.json").unwrap();
-        let reader = BufReader::new(file);
-
-        let ephemera_folder_item: EphemeraFolder = serde_json::from_reader(reader).unwrap();
-        let digital_content = ephemera_folder_item
-            .electronic_access()
-            .unwrap()
-            .digital_content
-            .unwrap();
-        assert_eq!(
-            digital_content.link_text,
-            vec!["Digital content".to_string()]
-        );
-        assert_eq!(
-            digital_content.url,
-            "https://catalog-staging.princeton.edu/catalog/af4a941d-96a4-463e-9043-cfa512e5eddd#view".to_string()
         );
     }
 

--- a/lib/bibdata_rs/src/solr/electronic_access.rs
+++ b/lib/bibdata_rs/src/solr/electronic_access.rs
@@ -6,7 +6,6 @@ pub struct ElectronicAccess {
     pub link_text: String,
     pub link_description: Option<String>,
     pub iiif_manifest_paths: Option<String>,
-    pub digital_content: Option<DigitalContent>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -33,21 +32,6 @@ impl Serialize for ElectronicAccess {
             serde_json::Value::Array(notes.into_iter().map(serde_json::Value::String).collect()),
         );
 
-        // Digital Content
-        if let Some(dc) = &self.digital_content {
-            hash.shift_insert(
-                1,
-                dc.url.clone(),
-                serde_json::Value::Array(
-                    dc.link_text
-                        .iter()
-                        .cloned()
-                        .map(serde_json::Value::String)
-                        .collect(),
-                ),
-            );
-        }
-
         // IIIF Manifest Paths
         if let Some(iiif_url) = &self.iiif_manifest_paths {
             let mut iiif_map = serde_json::Map::new();
@@ -56,7 +40,7 @@ impl Serialize for ElectronicAccess {
                 serde_json::Value::String(iiif_url.clone()),
             );
             hash.shift_insert(
-                2,
+                1,
                 "iiif_manifest_paths".to_string(),
                 serde_json::Value::Object(iiif_map),
             );
@@ -98,26 +82,6 @@ impl<'de> Deserialize<'de> for ElectronicAccess {
             .and_then(|v| v.as_str())
             .map(|s| s.to_owned());
 
-        // Digital Content
-        let digital_content = map
-            .iter()
-            .find(|(k, _)| *k != "iiif_manifest_paths" && *k != url)
-            .and_then(|(dc_url, dc_notes)| {
-                let dc_notes_arr = dc_notes.as_array()?;
-                let dc_link_texts: Vec<String> = dc_notes_arr
-                    .iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_owned()))
-                    .collect();
-                if dc_link_texts.is_empty() {
-                    None
-                } else {
-                    Some(DigitalContent {
-                        url: dc_url.clone(),
-                        link_text: dc_link_texts,
-                    })
-                }
-            });
-
         // IIIF Manifest URL
         let iiif_manifest_url = map
             .get("iiif_manifest_paths")
@@ -131,7 +95,6 @@ impl<'de> Deserialize<'de> for ElectronicAccess {
             link_text,
             link_description,
             iiif_manifest_paths: iiif_manifest_url,
-            digital_content,
         })
     }
 }
@@ -141,30 +104,12 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn it_can_serialize_digital_content_to_json() {
-        let access = ElectronicAccess {
-            url: "https://figgy-staging.princeton.edu/catalog/af4a941d-96a4-463e-9043-cfa512e5eddd".to_string(),
-            link_text: "Online Content".to_string(),
-            link_description: Some("Born Digital Monographic Reports and Papers".to_string()),
-            iiif_manifest_paths: Some("https://figgy.princeton.edu/concern/ephemera_folders/af4a941d-96a4-463e-9043-cfa512e5eddd/manifest".to_string()),
-            digital_content: Some(DigitalContent {
-                link_text: vec!["Digital Content".to_string()],
-                url: "https://catalog-staging.princeton.edu/catalog/af4a941d-96a4-463e-9043-cfa512e5eddd#view".to_string(),
-            })
-        };
-        assert_eq!(
-            serde_json::to_string(&access).unwrap(),
-            r#""{\"https://figgy-staging.princeton.edu/catalog/af4a941d-96a4-463e-9043-cfa512e5eddd\":[\"Online Content\",\"Born Digital Monographic Reports and Papers\"],\"https://catalog-staging.princeton.edu/catalog/af4a941d-96a4-463e-9043-cfa512e5eddd#view\":[\"Digital Content\"],\"iiif_manifest_paths\":{\"ephemera_ark\":\"https://figgy.princeton.edu/concern/ephemera_folders/af4a941d-96a4-463e-9043-cfa512e5eddd/manifest\"}}""#
-        );
-    }
-    #[test]
     fn it_can_serialize_to_json() {
         let access = ElectronicAccess {
             url: "http://arks.princeton.edu/ark:/88435/dch989rf19q".to_owned(),
             link_text: "Electronic Resource".to_owned(),
             link_description: None,
             iiif_manifest_paths: None,
-            digital_content: None,
         };
         assert_eq!(
             serde_json::to_string(&access).unwrap(),

--- a/lib/bibdata_rs/src/solr/ephemera_solr_mapping.rs
+++ b/lib/bibdata_rs/src/solr/ephemera_solr_mapping.rs
@@ -127,14 +127,10 @@ mod tests {
             solr_document.electronic_access_1display,
             Some(
                 ElectronicAccess {
-                    url: "https://figgy-staging.princeton.edu/catalog/af4a941d-96a4-463e-9043-cfa512e5eddd".to_string(),
-                    link_text: "Online Content".to_string(),
-                    link_description: Some("Born Digital Monographic Reports and Papers".to_string()),
-                    iiif_manifest_paths: Some("https://figgy.princeton.edu/concern/ephemera_folders/af4a941d-96a4-463e-9043-cfa512e5eddd/manifest".to_string()),
-                    digital_content: Some(DigitalContent {
-                        link_text: vec!["Digital content".to_string()],
-                        url: "https://catalog-staging.princeton.edu/catalog/af4a941d-96a4-463e-9043-cfa512e5eddd#view".to_string(),
-                    })
+                    url: "https://catalog-staging.princeton.edu/catalog/af4a941d-96a4-463e-9043-cfa512e5eddd#view".to_string().to_string(),
+                    link_text: "Digital content".to_string(),
+                    link_description: None,
+                    iiif_manifest_paths: Some("https://figgy.princeton.edu/concern/ephemera_folders/af4a941d-96a4-463e-9043-cfa512e5eddd/manifest".to_string())
                 }
             )
         )
@@ -481,13 +477,12 @@ mod tests {
             .title(vec!["Our favorite book".to_owned()])
             .electronic_access(vec![solr::ElectronicAccess {
                 url: "http://example.com".to_owned(),
-                link_text: "Access Link".to_owned(),
-                link_description: Some("Description of the link".to_owned()),
+                link_text: "".to_owned(),
+                link_description: None,
                 iiif_manifest_paths: Some(
                     "https://figgy.princeton.edu/concern/ephemera_folders/abc123/manifest"
                         .to_owned(),
                 ),
-                digital_content: None,
             }])
             .build()
             .unwrap();
@@ -495,17 +490,13 @@ mod tests {
         assert_eq!(
             solr_document.electronic_access_1display,
             Some(solr::ElectronicAccess {
-                url: ephemera_item.id.clone(),
-                link_text: "Online Content".to_owned(),
-                link_description: Some("Born Digital Monographic Reports and Papers".to_owned()),
+                url: "https://catalog-staging.princeton.edu/catalog/abc123#view".to_string(),
+                link_text: "Digital content".to_owned(),
+                link_description: None,
                 iiif_manifest_paths: Some(
                     "https://figgy.princeton.edu/concern/ephemera_folders/abc123/manifest"
                         .to_owned()
-                ),
-                digital_content: Some(DigitalContent {
-                    link_text: vec!["Digital content".to_owned()],
-                    url: "https://catalog-staging.princeton.edu/catalog/abc123#view".to_string(),
-                })
+                )
             })
         );
     }

--- a/lib/bibdata_rs/src/solr/solr_document.rs
+++ b/lib/bibdata_rs/src/solr/solr_document.rs
@@ -167,7 +167,6 @@ mod tests {
                 link_text: "DataSpace".to_owned(),
                 link_description: Some("Full text".to_owned()),
                 iiif_manifest_paths: None,
-                digital_content: None,
             }))
             .build();
         let serialized = serde_json::to_string(&document).unwrap();

--- a/lib/bibdata_rs/src/theses/dataspace/document/normalize.rs
+++ b/lib/bibdata_rs/src/theses/dataspace/document/normalize.rs
@@ -251,8 +251,7 @@ mod tests {
                 url: "http://arks.princeton.edu/ark:/88435/dsp01b2773v788".to_owned(),
                 link_text: "DataSpace".to_owned(),
                 link_description: Some("Full text".to_owned()),
-                iiif_manifest_paths: None,
-                digital_content: None
+                iiif_manifest_paths: None
             }
         );
     }
@@ -280,8 +279,7 @@ mod tests {
                 url: "http://arks.princeton.edu/ark:/88435/dsp01b2773v788".to_owned(),
                 link_text: "DataSpace".to_owned(),
                 link_description: Some("Full text".to_owned()),
-                iiif_manifest_paths: None,
-                digital_content: None
+                iiif_manifest_paths: None
             }
         );
     }

--- a/lib/bibdata_rs/src/theses/holdings.rs
+++ b/lib/bibdata_rs/src/theses/holdings.rs
@@ -67,7 +67,6 @@ pub fn dataspace_url_with_metadata(
             ThesisAvailability::AvailableOffSite => Some("Full text".to_owned()),
         },
         iiif_manifest_paths: None,
-        digital_content: None,
     })
 }
 


### PR DESCRIPTION
Remove link:Born Digital Monographic Reports and Papers from the electronic_access_1display
So that it does not appear in the online section

related to #2639

This change will index electronic_access_1display in ephemera born digital as:

```
"electronic_access_1display":"{\"https://catalog-staging.princeton.edu/catalog/f4e58e9f-623d-41aa-9a8c-0919f3f7d4ed#view\":[\"Digital content\"],\"iiif_manifest_paths\":{\"ephemera_ark\":\"https://figgy.princeton.edu/concern/ephemera_folders/f4e58e9f-623d-41aa-9a8c-0919f3f7d4ed/manifest\"}}"
```