### PR TITLE
Normalize the ephemera thumbnail url so that we index it with the dimensions currently use in the catalog

### DIFF
--- a/lib/bibdata_rs/src/ephemera/ephemera_folder.rs
+++ b/lib/bibdata_rs/src/ephemera/ephemera_folder.rs
@@ -52,7 +52,12 @@ pub struct Thumbnail {
     #[serde(rename = "@id")]
     pub thumbnail_url: String,
 }
-
+impl Thumbnail {
+    pub fn normalized_url(&self) -> String {
+        self.thumbnail_url
+            .replace("/full/!200,150/0/default.jpg", "/square/225,/0/default.jpg")
+    }
+}
 #[derive(Debug, Serialize, PartialEq, Clone)]
 pub struct AuthorRoles {
     pub secondary_authors: Vec<String>,
@@ -67,7 +72,7 @@ impl EphemeraFolder {
         EphemeraFolderBuilder::new()
     }
     pub fn thumbnail_url(&self) -> Option<String> {
-        self.thumbnail.as_ref().map(|t| t.thumbnail_url.clone())
+        self.thumbnail.as_ref().map(|t| t.normalized_url().clone())
     }
     pub fn solr_formats(&self) -> Vec<solr::FormatFacet> {
         match &self.format {

--- a/lib/bibdata_rs/src/solr/ephemera_solr_mapping.rs
+++ b/lib/bibdata_rs/src/solr/ephemera_solr_mapping.rs
@@ -529,7 +529,7 @@ mod tests {
         let solr_document = SolrDocument::from(&ephemera_folder);
         assert_eq!(
             solr_document.thumbnail_display,
-            Some("https://iiif-cloud.princeton.edu/iiif/2/c9%2Fa6%2F2b%2Fc9a62b81f8014b13933f4cf462c092dc%2Fintermediate_file/full/!200,150/0/default.jpg".to_string())
+            Some("https://iiif-cloud.princeton.edu/iiif/2/c9%2Fa6%2F2b%2Fc9a62b81f8014b13933f4cf462c092dc%2Fintermediate_file/square/225,/0/default.jpg".to_string())
         );
     }
 }


### PR DESCRIPTION
Normalize the ephemera thumbnail url so that we index it with the square dimension we use currently in the catalog

related to [#2639]
closes [#2920]