### PR TITLE
Change Subject.rs ExactMatch to be Optional

### DIFF
--- a/lib/bibdata_rs/src/solr/ephemera_solr_mapping.rs
+++ b/lib/bibdata_rs/src/solr/ephemera_solr_mapping.rs
@@ -288,18 +288,20 @@ mod tests {
             .id("abc123".to_owned())
             .title(vec!["Our favorite book".to_owned()])
             .subject(vec![Subject {
-                exact_match: ExactMatch {
+                exact_match: Some(ExactMatch {
                     id: ephemera::ephemera_folder::subject::Id {
                         id: "http://id.loc.gov/authorities/subjects/sh85088762".to_owned(),
                     },
-                },
+                }),
                 label: "Music".to_string(),
             }])
             .build()
             .unwrap();
         assert!(ephemera_item.subject.unwrap()[0]
             .exact_match
-            .accepted_loc_vocabulary());
+            .as_ref()
+            .map(|em| em.accepted_loc_vocabulary())
+            .unwrap_or(false));
     }
     #[test]
     fn it_includes_subject_terms_in_lc_subject_display_and_lc_subject_facet_field() {
@@ -307,11 +309,11 @@ mod tests {
             .id("abc123".to_owned())
             .title(vec!["Our favorite book".to_owned()])
             .subject(vec![Subject {
-                exact_match: ExactMatch {
+                exact_match: Some(ExactMatch {
                     id: ephemera::ephemera_folder::subject::Id {
                         id: "http://id.loc.gov/authorities/subjects/sh85088762".to_owned(),
                     },
-                },
+                }),
                 label: "Music".to_string(),
             }])
             .build()
@@ -336,11 +338,11 @@ mod tests {
             .id("abc123".to_owned())
             .title(vec!["Our favorite book".to_owned()])
             .subject(vec![Subject {
-                exact_match: ExactMatch {
+                exact_match: Some(ExactMatch {
                     id: ephemera::ephemera_folder::subject::Id {
                         id: "https://homosaurus.org/v4/homoit0000485".to_owned(),
                     },
-                },
+                }),
                 label: "Gay Community".to_string(),
             }])
             .build()

--- a/lib/tasks/ephemera.rake
+++ b/lib/tasks/ephemera.rake
@@ -11,9 +11,17 @@ namespace :ephemera do
     end
 
     documents = BibdataRs::Ephemera.json_ephemera_document(figgy_url)
+    if documents.empty?
+      puts 'No documents to index.'
+      exit 1
+    end
+
     BibdataRs::Ephemera.index_string(solr_url, documents)
 
     puts "Successfully indexed #{documents.length} documents to #{solr_url}"
+
+  rescue StandardError => e
+    puts "Error during indexing: #{e.message}"
   end
 
   desc 'Delete all ephemera records from solr'


### PR DESCRIPTION
Don't index the subject when ExactMatch is None
Log in trace the subject missing the exact match (this one needs some more work)
use env_logger::try_init() instead of init() that way it will not panic if called multiple times and will ensure logger is initialized. Rescue and stop rake task if the are are no documents or if there is an error.

related to [#2924]

If you want to test it on bibdata-staging:
```
deploy@bibdata-staging1:/opt/bibdata/current$ RUST_LOG=trace FIGGY_URL=https://figgy.princeton.edu bundle exec rake ephemera:full_reindex
```

For example check on [catalog staging](https://catalog-staging.princeton.edu/catalog/fb49c0c8-8eeb-4e32-afbe-04d8d14edacf). 
It does not have these two subjects that you can see in [figgy jsonld](https://figgy.princeton.edu/catalog/fb49c0c8-8eeb-4e32-afbe-04d8d14edacf.jsonld)
```
{
@id: "https://figgy.princeton.edu/catalog/02865ece-06d0-409c-ac00-1a13eb5da6f0",
@type: "skos:Concept",
pref_label: "Women--Government policy",
in_scheme: {
@id: "https://figgy.princeton.edu/ns/ephemeraSubjects/genderAndSexuality",
@type: "skos:ConceptScheme",
pref_label: "Gender and sexuality"
}
},
{
@id: "https://figgy.princeton.edu/catalog/bb518b04-daee-4aa3-beba-1e40bb7c369d",
@type: "skos:Concept",
pref_label: "Women--Legal status, laws, etc.",
in_scheme: {
@id: "https://figgy.princeton.edu/ns/ephemeraSubjects/genderAndSexuality",
@type: "skos:ConceptScheme",
pref_label: "Gender and sexuality"
}
},
```