### PR TITLE
Remove digital_content from electronic access

### DIFF
--- a/lib/bibdata_rs/src/theses/legacy_dataspace/document/normalize.rs
+++ b/lib/bibdata_rs/src/theses/legacy_dataspace/document/normalize.rs
@@ -251,8 +251,7 @@ mod tests {
                 url: "http://arks.princeton.edu/ark:/88435/dsp01b2773v788".to_owned(),
                 link_text: "Thesis Central".to_owned(),
                 link_description: Some("Full text".to_owned()),
-                iiif_manifest_paths: None,
-                digital_content: None
+                iiif_manifest_paths: None
             }
         );
     }
@@ -280,8 +279,7 @@ mod tests {
                 url: "http://arks.princeton.edu/ark:/88435/dsp01b2773v788".to_owned(),
                 link_text: "Thesis Central".to_owned(),
                 link_description: Some("Full text".to_owned()),
-                iiif_manifest_paths: None,
-                digital_content: None
+                iiif_manifest_paths: None
             }
         );
     }


### PR DESCRIPTION
CI was failing after merging my PR because the legacy datasapace electronic access struct still had a digital_content property