### PR TITLE
Log dataspace.princeton.edu requests as well as theses-dissertations requests

### DIFF
--- a/lib/bibdata_rs/src/theses/dataspace/collection.rs
+++ b/lib/bibdata_rs/src/theses/dataspace/collection.rs
@@ -79,7 +79,7 @@ pub fn collections_as_solr(
     community_handle: String,
     rest_limit: u32,
 ) -> Result<(), magnus::Error> {
-    env_logger::init();
+    let _ = env_logger::try_init();
     let documents: Vec<DataspaceDocument> =
         get_document_list(&server, &community_handle, rest_limit, |server, handle| {
             community::get_collection_list(server, handle, community::get_community_id)

--- a/lib/bibdata_rs/src/theses/legacy_dataspace/collection.rs
+++ b/lib/bibdata_rs/src/theses/legacy_dataspace/collection.rs
@@ -38,7 +38,7 @@ pub fn legacy_collections_as_solr(
     community_handle: String,
     rest_limit: u32,
 ) -> Result<(), magnus::Error> {
-    // env_logger::init();
+    let _ = env_logger::try_init();
     let documents: Vec<DataspaceDocument> =
         get_document_list(&server, &community_handle, rest_limit, |server, handle| {
             community::get_collection_list(server, handle, community::get_community_id)


### PR DESCRIPTION
Prior to this commit, the env_logger was only initialized for theses-dissertations code, after the legacy dataspace code has already run.  This makes it difficult to troubleshoot legacy dataspace runs, since there are no logs.