### PR TITLE
Remove unnecessary call from bibliographic holding availability endpoint

### DIFF
--- a/app/adapters/alma_adapter/availability_status.rb
+++ b/app/adapters/alma_adapter/availability_status.rb
@@ -149,23 +149,6 @@ class AlmaAdapter
       holdings.find { |h| h['holding_id'] == holding_id }
     end
 
-    # Returns all the items for a given holding_id in the current bib.
-    # This is a more specific version of `item_data`.
-    #
-    # If the holding has more than ITEMS_PER_PAGE items the Alma gem will automatically
-    # make multiple calls to the Alma API.
-    def holding_item_data(holding_id:)
-      data = nil
-      options = { enable_loggable: true, timeout: 10 }
-      message = "Items for bib: #{bib.id}, holding_id: #{holding_id}"
-      AlmaAdapter::Execute.call(options:, message:) do
-        opts = { limit: Alma::BibItemSet::ITEMS_PER_PAGE, holding_id:, order_by: 'enum_a' }
-        items = Alma::BibItem.find(bib.id, opts).all.map { |item| AlmaAdapter::AlmaItem.new(item) }
-        data = { items:, total_count: items.count }
-      end
-      data
-    end
-
     private
 
       # Returns the extra location information that we store in the local database

--- a/spec/adapters/alma_adapter_spec.rb
+++ b/spec/adapters/alma_adapter_spec.rb
@@ -258,14 +258,11 @@ RSpec.describe AlmaAdapter do
     let(:library_lewis_stacks) { file_fixture('alma/library_lewis_stacks.json') }
 
     before do
-      stub_alma_ids(ids: '9919392043506421', status: 200)
       stub_alma_holding_items(mms_id: '9919392043506421', holding_id: '22105104420006421', filename: '9919392043506421_holding_items.json')
-      stub_alma_ids(ids: '99122455086806421', status: 200)
       stub_alma_holding_items(mms_id: '99122455086806421', holding_id: '22477860740006421', filename: '99122455086806421_holding_items.json')
       stub_alma_library(library_code: 'firestone', location_code: 'dixn')
       stub_alma_library(library_code: 'firestone', location_code: 'stacks')
 
-      stub_alma_ids(ids: '9999362473506421', status: 200)
       # https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/9999362473506421/holdings/22752541670006421/items?limit=100&order_by=enum_a
       stub_alma_holding_items(mms_id: '9999362473506421', holding_id: '22752541670006421', filename: '9999362473506421_holding_items.json')
       stub_alma_holding_items(mms_id: '9999362473506421', holding_id: '22752541690006421', filename: '9999362473506421_holding_items_two.json')
@@ -315,6 +312,11 @@ RSpec.describe AlmaAdapter do
       expect(item[:location]).to eq 'firestone$dixn'
       expect(item[:pickup_location_id]).to eq 'firestone'
       expect(item[:pickup_location_code]).to eq 'firestone'
+    end
+
+    it 'does not make unnecessary http requests' do
+      adapter.get_availability_holding(id: '99122455086806421', holding_id: '22477860740006421')
+      expect(WebMock).to have_requested(:get, /alma/).times(1)
     end
   end
 

--- a/spec/controllers/bibliographic_controller_spec.rb
+++ b/spec/controllers/bibliographic_controller_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe BibliographicController, type: :controller do
 
   describe '#availability_holding' do
     before do
-      stub_alma_ids(ids: 'not-exist', status: 200, fixture: 'not_found')
+      stub_alma_holding_items(mms_id: 'not-exist', holding_id: 'not-exist', filename: 'holding_items_nonexistant_mmsid.json', status: 400)
       stub_alma_ids(ids: '9922486553506421', status: 200)
       stub_alma_holding_items(mms_id: '9922486553506421', holding_id: '22117511410006421', filename: '9922486553506421_holding_items.json')
       stub_alma_holding_items(mms_id: '9922486553506421', holding_id: 'not-exist', filename: 'not_found_items.json')

--- a/spec/fixtures/files/alma/holding_items_nonexistant_mmsid.json
+++ b/spec/fixtures/files/alma/holding_items_nonexistant_mmsid.json
@@ -1,0 +1,12 @@
+{
+    "errorsExist": true,
+    "errorList": {
+      "error": [
+        {
+          "errorCode": "401688",
+          "errorMessage": "Search failed for Items with mmsId 123, holdings id 456.",
+          "trackingId": "bad-bad-bad-123"
+        }
+      ]
+    }
+  }

--- a/spec/support/stub_alma.rb
+++ b/spec/support/stub_alma.rb
@@ -32,11 +32,11 @@ module AlmaStubbing
                  body: alma_path.join("holding_#{holding_id}.json"))
   end
 
-  def stub_alma_holding_items(mms_id:, holding_id:, filename:, query: 'limit=100')
+  def stub_alma_holding_items(mms_id:, holding_id:, filename:, query: 'limit=100', status: 200)
     alma_path = Pathname.new(file_fixture_path).join('alma')
     query_string = [query, 'order_by=enum_a'].select(&:present?).join('&')
     stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/#{mms_id}/holdings/#{holding_id}/items?#{query_string}")
-      .to_return(status: 200,
+      .to_return(status:,
                  headers: { 'Content-Type' => 'application/json' },
                  body: alma_path.join(filename))
   end


### PR DESCRIPTION
This affects the endpoint /bibliographic/:bib_id/holdings/:holding_id/availability, which is used by the Requests form.

Prior to this commit, this endpoint made 2 or more requests to Alma:
* 1 to retrieve the MarcXML record along with requests and general availability data
* 1 or more to retrieve the item availability data

The first call was only used to retrieve the bib id -- something that we already have because the user provided it in the request. Therefore, we can eliminate this call and save an extra 500-1000ms each time we load the request form (and be gentler on our API limits).

Found while investigating performance issues related to https://github.com/pulibrary/orangelight/issues/3228