### PR TITLE
Make sure benchmark measures the correct thing

### DIFF
--- a/lib/bibdata_rs/benches/marc_bench.rs
+++ b/lib/bibdata_rs/benches/marc_bench.rs
@@ -3,13 +3,13 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use marctk::Record;
 
 fn genre_facet_benchmark(c: &mut Criterion) {
+    let record = Record::from_xml_file("../../spec/fixtures/99100026953506421.mrx")
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap();
     c.bench_function("genres", |b| {
         b.iter(|| {
-            let record = Record::from_xml_file("../../spec/fixtures/99100026953506421.mrx")
-                .unwrap()
-                .next()
-                .unwrap()
-                .unwrap();
             assert_eq!(genres(&record), vec!["Periodicals", "Facsimiles"]);
         })
     });


### PR DESCRIPTION
This benchmark was meant to benchmark the `genres` function, but it spends much of its time parsing XML so that it can actually run the function in question.

This commit moves the XML parsing out of the benchmark, so that it can focus on measuring what we actually want to measure.