### PR TITLE
marctk 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "marctk"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824169a757e4fe8cc0b274b328992d65e3a9421431c9aa115507d85fd2fd53c1"
+checksum = "b5334d95ab3304897b9cedfaa8b266f20961bf3dbaa6e3e4ab66171c2a138ddf"
 dependencies = [
  "getopts",
  "xml-rs",


### PR DESCRIPTION
This includes a performance improvement that helps the genres benchmark:

Before
```
genres                  time:   [25.852 µs 25.908 µs 25.971 µs]
```

After
```
genres                  time:   [22.482 µs 22.572 µs 22.655 µs]
                        change: [−13.007% −12.685% −12.387%] (p = 0.00 < 0.05)
                        Performance has improved.
```