### PR TITLE
Add frozen_string_literals comments to marc_to_solr files that are compatible with them

### DIFF
--- a/marc_to_solr/lib/access_facet_builder.rb
+++ b/marc_to_solr/lib/access_facet_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Class for building access_facet values
 class AccessFacetBuilder
   # Build access facet

--- a/marc_to_solr/lib/alma_reader.rb
+++ b/marc_to_solr/lib/alma_reader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Alma MARC-XML files have no namespace defined, so we have to bypass that
 # requirement in Nokogiri.
 class AlmaReader < Traject::MarcReader

--- a/marc_to_solr/lib/cache_adapter.rb
+++ b/marc_to_solr/lib/cache_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Class which provides an API similar to that of ActiveSupport::Cache::Store Objects
 # Currently this just supports the Lightly Gem (@see https://github.com/DannyBen/lightly)
 class CacheAdapter

--- a/marc_to_solr/lib/cache_manager.rb
+++ b/marc_to_solr/lib/cache_manager.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/module'
 
 # Class for handling instances of caching objects

--- a/marc_to_solr/lib/cache_map.rb
+++ b/marc_to_solr/lib/cache_map.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'faraday'
 require 'active_support/core_ext/string'
 

--- a/marc_to_solr/lib/composite_cache_map.rb
+++ b/marc_to_solr/lib/composite_cache_map.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Composite of CacheMaps
 # Provides the ability to build a cache from multiple Solr endpoints
 class CompositeCacheMap

--- a/marc_to_solr/lib/electronic_access_link.rb
+++ b/marc_to_solr/lib/electronic_access_link.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'normal_uri_factory'
 require_relative 'uri_ark'
 

--- a/marc_to_solr/lib/electronic_access_link_factory.rb
+++ b/marc_to_solr/lib/electronic_access_link_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ElectronicAccessLinkFactory
   # Extract values from a given MARC subfield
   # @param s_field the MARC subfield

--- a/marc_to_solr/lib/electronic_portfolio_builder.rb
+++ b/marc_to_solr/lib/electronic_portfolio_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Class for building electronic portfolio JSON from marc fields
 class ElectronicPortfolioBuilder
   # Build electronic portfolio JSON from marc fields

--- a/marc_to_solr/lib/embargo_date_extractor.rb
+++ b/marc_to_solr/lib/embargo_date_extractor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class EmbargoDateExtractor
   def initialize(record)
     @record = record

--- a/marc_to_solr/lib/geo.rb
+++ b/marc_to_solr/lib/geo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # geo.rb
 # extract geo-related data from MARC
 

--- a/marc_to_solr/lib/iiif_manifest_url_builder.rb
+++ b/marc_to_solr/lib/iiif_manifest_url_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Class for building instances of URI::HTTPS for IIIF Manifest URL's
 class IIIFManifestUrlBuilder
   # Constructor

--- a/marc_to_solr/lib/language_extractor.rb
+++ b/marc_to_solr/lib/language_extractor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A class to pull out language information from
 # a MARC record
 class LanguageExtractor

--- a/marc_to_solr/lib/linked_fields_extractor.rb
+++ b/marc_to_solr/lib/linked_fields_extractor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This class is responsible for extracting and validating
 # Alma MMS IDs from the 773 and 774 MARC fields
 class LinkedFieldsExtractor

--- a/marc_to_solr/lib/marc_breaker.rb
+++ b/marc_to_solr/lib/marc_breaker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This class is responsible for converting MARC records into the
 # MarcBreaker format (see https://www.loc.gov/marc/makrbrkr.html)
 #
@@ -38,8 +40,8 @@ class MarcBreaker
 
   private
 
-    MARC_BREAKER_SF_DELIMITER = '$'.freeze
-    MARC_BREAKER_SF_DELIMITER_ESCAPE = '{dollar}'.freeze
+    MARC_BREAKER_SF_DELIMITER = '$'
+    MARC_BREAKER_SF_DELIMITER_ESCAPE = '{dollar}'
 
     def escape_to_breaker(value)
       value.gsub(MARC_BREAKER_SF_DELIMITER, MARC_BREAKER_SF_DELIMITER_ESCAPE).tr("\n", ' ')

--- a/marc_to_solr/lib/normal_uri_factory.rb
+++ b/marc_to_solr/lib/normal_uri_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Class for building normalized URIs
 class NormalUriFactory
   # Constructor

--- a/marc_to_solr/lib/orangelight_url_builder.rb
+++ b/marc_to_solr/lib/orangelight_url_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Class for building instances of URI::HTTPS for Orangelight URL's
 class OrangelightUrlBuilder
   # Constructor

--- a/marc_to_solr/lib/process_holdings_helpers.rb
+++ b/marc_to_solr/lib/process_holdings_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ProcessHoldingsHelpers
   attr_reader :record, :marc_breaker
 

--- a/marc_to_solr/lib/pul_solr_json_writer.rb
+++ b/marc_to_solr/lib/pul_solr_json_writer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yell'
 
 require 'traject/util'

--- a/marc_to_solr/lib/solr_deleter.rb
+++ b/marc_to_solr/lib/solr_deleter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'net/http'
 require 'json'
 

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -1,4 +1,5 @@
-# Traject config goes here
+# frozen_string_literal: true
+
 require 'active_support'
 require 'active_support/core_ext/object/blank'
 require 'traject/macros/marc21_semantics'

--- a/marc_to_solr/lib/uri_ark.rb
+++ b/marc_to_solr/lib/uri_ark.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Class modeling the ARK standard for URL's
 # @see https://tools.ietf.org/html/draft-kunze-ark-18
 class URI::ARK < URI::Generic

--- a/marc_to_solr/translation_maps/format.rb
+++ b/marc_to_solr/translation_maps/format.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {
   'AJ' => 'Journal',
   'AN' => 'Newspaper',

--- a/marc_to_solr/translation_maps/relators.rb
+++ b/marc_to_solr/translation_maps/relators.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {
   'abr' => 'Abridger',
   'act' => 'Actor',

--- a/marc_to_solr/translation_maps/sudocs.rb
+++ b/marc_to_solr/translation_maps/sudocs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {
   'A' => 'A - Agriculture',
   'AE' => 'AE - National Archives and Records Administration',

--- a/marc_to_solr/translation_maps/sudocs_split.rb
+++ b/marc_to_solr/translation_maps/sudocs_split.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {
   'A' => 'SuDocs: A-G',
   'AE' => 'SuDocs: A-G',


### PR DESCRIPTION
We don't have the relevant rubocop check enabled, so many files are missing this magic comment.

This does make the MarcBreaker class slightly faster, although fully indexing a large MARC file takes about the same amount of time.  I checked MarcBreaker's performance with the following microbenchmark in `rails c`:

```
record = MARC::XMLReader.new(Rails.root.join('spec/fixtures/marc_to_solr/9914141453506421.mrx').to_s).first
Benchmark.ips { it.report { MarcBreaker.break(record) } }
```

Before:
```
Warming up --------------------------------------
                       472.000 i/100ms
Calculating -------------------------------------
                          4.705k (± 1.2%) i/s  (212.53 μs/i) -     23.600k in   5.016528s
```

After:
```
Warming up --------------------------------------
                       512.000 i/100ms
Calculating -------------------------------------
                          5.178k (± 1.4%) i/s  (193.11 μs/i) -     26.112k in   5.043372s
```