### PR TITLE
Merge and deploy on 1/26/2026 - Remove delivery locations for the following marquand location codes

### DIFF
--- a/config/locations/holding_locations.json
+++ b/config/locations/holding_locations.json
@@ -3798,9 +3798,7 @@
             "order": 0
         },
         "holding_library": null,
-        "delivery_locations": [
-            "PJ"
-        ]
+        "delivery_locations": []
     },
     {
         "label": "Microforms: Marquand Use Only",
@@ -3820,9 +3818,7 @@
             "order": 0
         },
         "holding_library": null,
-        "delivery_locations": [
-            "PJ"
-        ]
+        "delivery_locations": []
     },
     {
         "label": "Remote Storage (ReCAP): Marquand Library Use Only",
@@ -3950,9 +3946,7 @@
             "order": 0
         },
         "holding_library": null,
-        "delivery_locations": [
-            "PJ"
-        ]
+        "delivery_locations": []
     },
     {
         "label": "Reserve",
@@ -3972,9 +3966,7 @@
             "order": 0
         },
         "holding_library": null,
-        "delivery_locations": [
-            "PJ"
-        ]
+        "delivery_locations": []
     },
     {
         "label": "Storage",
@@ -3994,9 +3986,7 @@
             "order": 0
         },
         "holding_library": null,
-        "delivery_locations": [
-            "PJ"
-        ]
+        "delivery_locations": []
     },
     {
         "label": "Marquand Use Only",
@@ -4016,9 +4006,7 @@
             "order": 0
         },
         "holding_library": null,
-        "delivery_locations": [
-            "PJ"
-        ]
+        "delivery_locations": []
     },
     {
         "label": "Rare Books: Miscellanea",


### PR DESCRIPTION
related to https://github.com/pulibrary/orangelight/issues/5416

marquand location codes: fesrf, mic, ref, res, rp, stacks, tech, wr


This policy should go in place when Marquand Library re-opens on 1/26/2026

Merge and deploy on 1/26/2026
Update the locations following the [docs](https://github.com/pulibrary/bibdata/blob/main/docs/location_changes.md#4-update-bibdata-production)
