### PR TITLE
Helps with updating rubocop rails

### DIFF
--- a/config/locales/flash_messages.en.yml
+++ b/config/locales/flash_messages.en.yml
@@ -1,0 +1,7 @@
+en:
+  flash_messages:
+    error: "Error"
+    alert: "Danger!"
+    notice: "A notice"
+    success: "Success!"
+    flash: "Flash"

--- a/spec/views/shared/flash_messages_view_spec.rb
+++ b/spec/views/shared/flash_messages_view_spec.rb
@@ -4,43 +4,43 @@ require 'rails_helper'
 
 describe 'shared/flash_messages', type: :view do
   it 'renders flash error partial if there is an error' do
-    flash.now[:error] = ['Error 1', 'Error 2']
+    flash.now[:error] = [I18n.t('flash_messages.error'), I18n.t('flash_messages.error')]
     render partial: 'shared/flash_messages'
     expect(response).to render_template(partial: 'shared/_error_flash_message')
   end
 
   it "doesn't render flash error partial for a flash notice" do
-    flash.now[:notice] = 'A notice'
+    flash.now[:notice] = I18n.t('flash_messages.notice')
     render partial: 'shared/flash_messages'
     expect(response).not_to render_template(partial: 'shared/_error_flash_message')
   end
 
   it 'each flash error is rendered within an <li>' do
-    flash.now[:error] = ['Error 1', 'Error 2']
+    flash.now[:error] = [I18n.t('flash_messages.error'), I18n.t('flash_messages.error')]
     render partial: 'shared/flash_messages'
     flash.now[:error].each { |e| expect(response.body.include?("<li>#{e}</li>")).to be true }
   end
 
   it 'renders flash notice message' do
-    flash.now[:notice] = 'A notice'
+    flash.now[:notice] = I18n.t('flash_messages.notice')
     render partial: 'shared/flash_messages'
     expect(response.body.include?(flash.now[:notice])).to be true
   end
 
   it 'renders flash success message' do
-    flash.now[:success] = 'Success!'
+    flash.now[:success] = I18n.t('flash_messages.success')
     render partial: 'shared/flash_messages'
     expect(response.body.include?(flash.now[:success])).to be true
   end
 
   it 'renders flash alert message' do
-    flash.now[:alert] = 'Danger!'
+    flash.now[:alert] = I18n.t('flash_messages.alert')
     render partial: 'shared/flash_messages'
     expect(response.body.include?(flash.now[:alert])).to be true
   end
 
   it 'renders flash message' do
-    flash.now[:flash] = 'Flash'
+    flash.now[:flash] = I18n.t('flash_messages.flash')
     render partial: 'shared/flash_messages'
     expect(response.body.include?(flash.now[:flash])).to be true
   end


### PR DESCRIPTION
resolves Rails/I18nLocaleTexts
Move locale texts to the locale files in the config/locales directory

helps with https://github.com/pulibrary/bibdata/commit/86a64fb7cd01de0cef71c2b7f79298a6542d7aa3