### PR TITLE
Require honeybadger at the top of the file solr_deleter.rb

### DIFF
--- a/marc_to_solr/lib/solr_deleter.rb
+++ b/marc_to_solr/lib/solr_deleter.rb
@@ -2,6 +2,7 @@
 
 require 'net/http'
 require 'json'
+require 'honeybadger'
 
 # This class allow us to delete Solr records with our current
 # version of Traject. Once we upgrade to Traject version 3.1


### PR DESCRIPTION
Fixes the following error:

/bibdata/marc_to_solr/lib/solr_deleter.rb:73:in
'SolrDeleter#delete_batch': uninitialized constant SolrDeleter::Honeybadger (NameError)