### PR TITLE
Refactor: move Rust ruby method bindings to their own function and module

### DIFF
--- a/lib/bibdata_rs/src/lib.rs
+++ b/lib/bibdata_rs/src/lib.rs
@@ -17,7 +17,6 @@ mod testing_support;
 fn init(ruby: &Ruby) -> Result<(), Error> {
     let module = ruby.define_module("BibdataRs")?;
     let submodule_languages = module.define_module("Languages")?;
-    let submodule_marc = module.define_module("Marc")?;
     let submodule_theses = module.define_module("Theses")?;
     let submodule_ephemera = module.define_module("Ephemera")?;
     submodule_ephemera.define_singleton_method(
@@ -50,56 +49,6 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
         "two_letter_code",
         function!(languages::two_letter_code_owned, 1),
     )?;
-    submodule_marc.define_singleton_method("access_notes", function!(marc::access_notes, 1))?;
-    submodule_marc.define_singleton_method("genres", function!(marc::genres, 1))?;
-    submodule_marc.define_singleton_method(
-        "original_languages_of_translation",
-        function!(marc::original_languages_of_translation, 1),
-    )?;
-    submodule_marc
-        .define_singleton_method("strip_non_numeric", function!(marc::strip_non_numeric, 1))?;
-
-    submodule_marc.define_singleton_method("format_facets", function!(marc::format_facets, 1))?;
-    submodule_marc.define_singleton_method(
-        "alma_code_start_22?",
-        function!(marc::alma_code_start_22, 1),
-    )?;
-    submodule_marc.define_singleton_method("is_scsb?", function!(marc::is_scsb, 1))?;
-    submodule_marc.define_singleton_method(
-        "recap_partner_notes",
-        function!(marc::recap_partner_notes, 1),
-    )?;
-    submodule_marc.define_singleton_method("private_items?", function!(marc::private_items, 2))?;
-    submodule_marc.define_singleton_method(
-        "normalize_oclc_number",
-        function!(marc::normalize_oclc_number, 1),
-    )?;
-    submodule_marc.define_singleton_method(
-        "identifiers_of_all_versions",
-        function!(marc::identifiers_of_all_versions, 1),
-    )?;
-    submodule_marc
-        .define_singleton_method("is_oclc_number?", function!(marc::is_oclc_number, 1))?;
-    submodule_marc.define_singleton_method(
-        "current_location_code",
-        function!(marc::current_location_code, 1),
-    )?;
-    submodule_marc.define_singleton_method(
-        "permanent_location_code",
-        function!(marc::permanent_location_code, 1),
-    )?;
-    submodule_marc.define_singleton_method(
-        "publication_statements",
-        function!(marc::publication_statements, 1),
-    )?;
-    submodule_marc
-        .define_singleton_method("build_call_number", function!(marc::build_call_number, 1))?;
-    submodule_marc.define_singleton_method("holding_id", function!(marc::holding_id, 2))?;
-    submodule_marc.define_singleton_method("subjects_cjk", function!(marc::subjects_cjk, 1))?;
-    submodule_marc.define_singleton_method("notes_cjk", function!(marc::notes_cjk, 1))?;
-    submodule_marc.define_module_function(
-        "trim_punctuation",
-        function!(marc::trim_punctuation_owned, 1),
-    )?;
+    marc::register_ruby_methods(&module)?;
     Ok(())
 }

--- a/lib/bibdata_rs/src/marc.rs
+++ b/lib/bibdata_rs/src/marc.rs
@@ -2,8 +2,6 @@ use itertools::Itertools;
 use magnus::exception;
 use marctk::Record;
 
-mod string_normalize;
-
 pub mod cjk;
 pub mod control_field;
 pub mod fixed_field;
@@ -16,6 +14,10 @@ pub mod record_facet_mapping;
 pub mod scsb;
 pub mod variable_length_field;
 
+mod ruby_bindings;
+mod string_normalize;
+
+pub use ruby_bindings::register_ruby_methods;
 pub use string_normalize::trim_punctuation;
 
 pub fn holding_id(

--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -1,0 +1,48 @@
+use super::*;
+use magnus::{function, Module, Object, RModule};
+
+// This module is responsible for the communication between Ruby and Rust code on the topic of MARC
+// (specifically the BibdataRs::Marc Ruby module and the crate::marc Rust module)
+
+pub fn register_ruby_methods(parent_module: &RModule) -> Result<(), magnus::Error> {
+    let submodule_marc = parent_module.define_module("Marc")?;
+    submodule_marc.define_singleton_method("access_notes", function!(access_notes, 1))?;
+    submodule_marc
+        .define_singleton_method("alma_code_start_22?", function!(alma_code_start_22, 1))?;
+    submodule_marc.define_singleton_method("build_call_number", function!(build_call_number, 1))?;
+    submodule_marc
+        .define_singleton_method("current_location_code", function!(current_location_code, 1))?;
+    submodule_marc.define_singleton_method("format_facets", function!(format_facets, 1))?;
+    submodule_marc.define_singleton_method("genres", function!(genres, 1))?;
+    submodule_marc.define_singleton_method("holding_id", function!(holding_id, 2))?;
+    submodule_marc.define_singleton_method(
+        "identifiers_of_all_versions",
+        function!(identifiers_of_all_versions, 1),
+    )?;
+    submodule_marc.define_singleton_method("is_oclc_number?", function!(is_oclc_number, 1))?;
+    submodule_marc.define_singleton_method("is_scsb?", function!(is_scsb, 1))?;
+    submodule_marc
+        .define_singleton_method("normalize_oclc_number", function!(normalize_oclc_number, 1))?;
+    submodule_marc.define_singleton_method("notes_cjk", function!(notes_cjk, 1))?;
+    submodule_marc.define_singleton_method(
+        "original_languages_of_translation",
+        function!(original_languages_of_translation, 1),
+    )?;
+    submodule_marc.define_singleton_method(
+        "permanent_location_code",
+        function!(permanent_location_code, 1),
+    )?;
+    submodule_marc.define_singleton_method("private_items?", function!(private_items, 2))?;
+    submodule_marc.define_singleton_method(
+        "publication_statements",
+        function!(publication_statements, 1),
+    )?;
+
+    submodule_marc
+        .define_singleton_method("recap_partner_notes", function!(recap_partner_notes, 1))?;
+    submodule_marc.define_singleton_method("strip_non_numeric", function!(strip_non_numeric, 1))?;
+    submodule_marc.define_singleton_method("subjects_cjk", function!(subjects_cjk, 1))?;
+    submodule_marc
+        .define_module_function("trim_punctuation", function!(trim_punctuation_owned, 1))?;
+    Ok(())
+}


### PR DESCRIPTION
This declutters our magnus init function a bit, and provides a module where we can manage Rust code related to the BibdataRs::Marc Ruby module.