### PR TITLE
Index the compressed xml marc record in the new marcxml field

### DIFF
--- a/app/services/marcxml_compressor.rb
+++ b/app/services/marcxml_compressor.rb
@@ -1,0 +1,23 @@
+# Service to decompress MARCXML stored in Solr
+# The MARCXML field is stored as gzip-compressed, base64-encoded strings
+class MarcxmlCompressor
+  # Decompress a MARCXML string from Solr
+  # @param compressed_string [String] Base64-encoded gzipped MARCXML
+  # @return [String] Decompressed MARCXML string
+  def self.decompress(compressed_string)
+    return nil if compressed_string.blank?
+
+    decoded = Base64.strict_decode64(compressed_string)
+    Zlib::GzipReader.new(StringIO.new(decoded)).read
+  end
+
+  # @param xml_string [String] MARCXML string
+  # @return [String] Base64-encoded gzipped MARCXML
+  def self.compress(xml_string)
+    return nil if xml_string.blank?
+
+    compressed = StringIO.new
+    Zlib::GzipWriter.wrap(compressed) { |gz| gz.write(xml_string) }
+    Base64.strict_encode64(compressed.string)
+  end
+end

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -546,6 +546,9 @@
    <field name="standard_no_index" type="string" indexed="true" stored="false" multiValued="true" />
    <field name="uniform_title_s" type="text" indexed="true" stored="true" multiValued="true" />
    <field name="_version_" type="plong" indexed="true" stored="true" multiValued="false"/>
+   
+    <!-- MARCXML field - stores gzipped+base64 MARCXML as string -->
+   <field name="marcxml" type="string" indexed="false" stored="true" multiValued="false"/>
 
     <!-- Dynamic field definitions.  If a field name is not found, dynamicFields
         will be used if the name matches any of the patterns.

--- a/spec/services/marcxml_compressor_spec.rb
+++ b/spec/services/marcxml_compressor_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe MarcxmlCompressor do
+  let(:sample_xml) do
+    <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <record xmlns="http://www.loc.gov/MARC21/slim">
+        <leader>00000nam a2200000 a 4500</leader>
+        <controlfield tag="001">123456789</controlfield>
+        <datafield tag="245" ind1="0" ind2="0">
+          <subfield code="a">A Title</subfield>
+        </datafield>
+      </record>
+    XML
+  end
+
+  describe '.compress' do
+    it 'compresses an XML string' do
+      compressed = described_class.compress(sample_xml)
+      expect(compressed).to be_a(String)
+    end
+
+    it 'returns nil for nil input' do
+      expect(described_class.compress(nil)).to be_nil
+    end
+
+    it 'returns nil for empty string' do
+      expect(described_class.compress('')).to be_nil
+    end
+  end
+
+  describe '.decompress' do
+    it 'decompresses a compressed XML string' do
+      compressed = described_class.compress(sample_xml)
+      decompressed = described_class.decompress(compressed)
+      expect(decompressed).to eq(sample_xml)
+    end
+
+    it 'returns nil for nil input' do
+      expect(described_class.decompress(nil)).to be_nil
+    end
+
+    it 'returns nil for empty string' do
+      expect(described_class.decompress('')).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Index the compressed xml marc record in the new marcxml field

Add service to decompress the marcxml
field when requested form the catalog

related to [#2504]

## example marcxml field for [SCSB-5978280](https://catalog-qa.princeton.edu/catalog/SCSB-5978280/raw)
```
=== example id:"SCSB-5978280"===

"marcxml":"H4sIAAvpZ2kAA8VX227bOBD9Fb6xBSJpSIkSmdoCHCNom6Zp0SzQh6IPlETbamnJleQm3t/ZP9kvWxKug2wss67Si55k83DmzJkLqVGj8rop0O1SV+0YL7pudRoENzc3vq5zf15/DV5P3k0pCVpdLnE60koWqknBPrlcIkQpAE0SVKKIAYyCb4BRXlddU+tZqXSBOjkfYwCC0+vp9ZnHRMIpN+D7oP4tDKfU+oqpIEmUsNA/ahvHKY+AEmiJ4IDMo6rPMp+Zl8z+MlwQmP/mCNkoSnSMUYFTPyPAwyROKH24o5Cd3MLLqiBjTLB9oWOM8NYAATACtutsi8rrQo2xxOmL9VKdoFc+uvBHwW55D/gFp09eqapS3QJd1Ivq6X1scOd8nwd/yEMwus9jgdOL63PEQ48A48faRjvb8M12zPpjPK/mZaVUUxrFy6rtGhNz1bWOeG+NMGXb1c3G/+lsXivZrhtlKfwiBjutgfYzAM6o4FFkavPUQSHH6b//EPAFG86A9DPghEBiCAw2zA6U88sq1+tCtRaubodLxyDqtX9WZrqs541cLTanaOWjD6bNP3qU0OG+aNwfy2VdFXXlTFFmyylfyKrMpUb36/zt2hDNZVfWVXviTrIdUkez/y0NvbMdHsjy7Ymd/Eb+E7TSslPf06jU2kLrpmt99MytBmUoXx4tx92cpbtkRqyX8gQttu2M6pkd/XeJWio7xuv5BgVuYh+yzUd0N4R9ZCf3I2YD6ef5/IyDF4axoMNNRz1ZK3B6deUI0Ky/l28ur471Cg/HLRwYt39NSMzc5eG/4Cwe7FjY8/5POAbe03nGcUwh8AGiKADh8E9t5w9OshBJr/PMHTEBj3DPXtVcpb50F4p0LCuceo7lGU5N8zkAcwv47ACY0Ta8NYQg+6ptcJokCfDo6FLYt3vgnH13+Yiy7k/w/y6hQydE2D98nryZ1pfTp49WA3pUNuZJERdSZqGXiDjyoijMvIyT2Mtgpkg2k0lEXIVpype6GsoU7kzqVg0+SvmPHaUPgKYCmBAAYeKOoc3brNqs9GB5eRLv0zzKu8mBUT7mnDpAn8xh+VWWWmZaOWArnIZhFIbGY8hIGLtMdib37rv29UI2qnBg/jbn18Sxrk2znU8nbw+pGmw/ddP/ACbHYT7zDgAA",
```

## Benchmark in my local
```
time bundle exec traject -c marc_to_solr/lib/traject_config.rb ~/Downloads/scsb_update_20260111_182500_1.xml -u http://localhost:62139/solr/bibdata-core-development/
```
### with marcxml compressed
```
INFO finished Traject::Indexer#process: 3749 records in 11.094 seconds; 337.9 records/second overall.
bundle exec traject -c marc_to_solr/lib/traject_config.rb  -u   9.94s user 1.90s system 99% cpu 11.954 total
```
### without marcxml field
```
INFO finished Traject::Indexer#process: 3749 records in 6.756 seconds; 554.9 records/second overall.
bundle exec traject -c marc_to_solr/lib/traject_config.rb  -u   6.00s user 0.33s system 83% cpu 7.622 total
```
## In bibdata-woreker-qa1 - Indexing again using directly the traject 
### without marcxml field
```
INFO finished Traject::Indexer#process: 30000 records in 294.441 seconds; 101.9 records/second overall.

real    4m56.460s
user    4m50.052s
sys     0m3.039s
```
### with marcxml field
```
NFO finished Traject::Indexer#process: 30000 records in 399.717 seconds; 75.1 records/second overall.

real    6m41.728s
user    6m39.801s
sys     0m3.342s
```

## require 'benchmark' in my local rails console
### without marcxml

```
0.001210   0.014269  60.774698 ( 61.271474)
User CPU time: 0.0012099999999999334s
System CPU time: 0.014269000000000087s
Total time: 60.774698s
Real time: 61.27147400000831s
```

### with marcxml field
```

Successfully indexed file 
0.001376   0.015608  69.382877 ( 69.382345)
User CPU time: 0.0013760000000000439s
System CPU time: 0.015607999999999844s
Total time: 69.382877s
Real time: 69.38234499999089s
```
### The following results are on bibdata-worker-qa1 . the numbers are higher but there was some kind of redis client timeout error. I dont know if it affected the results on qa:
```
Indexing WITHOUT marcxml field...
Successfully indexed file /home/deploy/scsbfull_nypl_20260101_150000_5.xml

0.002486   0.000179 275.834239 (276.795694)
User CPU time: 0.0024860000000002103s
System CPU time: 0.00017899999999992922s
Total time: 275.8342389999999s
Real time: 276.7956944159232s

Indexing WITH marcxml field...
Successfully indexed file /home/deploy/scsbfull_nypl_20260101_150000_5.xml

0.002363   0.000548 344.468805 (343.661297)
User CPU time: 0.002363000000000781s
System CPU time: 0.0005479999999999929s
Total time: 344.468805s
Real time: 343.66129734227434s
```

I will attempt indexing the same file on catalog-staging where I didnt see this kind of redis client error. 


## Using the numbers from my local rate records/second:

The time for indexing 30,000 records in my local with no marcxml field is closer to the reality which is almost 7 hours for SCSB records.
The indexing of 11,000,000 with the new marcxml field will be around 8 hours. 


## Report stored size in solr for compressed, raw xml , and solr document 
```
# (you can run it as a spec in the config_spec.rb)
it 'reports compression ratio and sizes' do
        # Get original MARCXML
        original_record = fixture_record('SCSB-8157262') # raw marc mrc
        original_xml = original_record.to_xml.to_s
        original_size = original_xml.bytesize

        # Compressed marcxml field stored in Solr # @scsb_nypl is the indexed SCSB-8157262 
        compressed = @scsb_nypl['marcxml'].first
        stored_size = compressed.bytesize
        
        # Calculate storage reduction between compressed marcxml field and raw marc xml field
        storage_reduction = (1 - stored_size.to_f / original_size) * 100

        # Calculate total indexed record size
        total_record_size = @scsb_nypl.values.flatten.join.bytesize
        marcxml_percentage = (stored_size.to_f / total_record_size) * 100

        # Print the results
        puts "\n  MARCXML Storage calculations for SCSB-8157262:"
        puts "    Original XML size:         #{original_size} bytes (#{(original_size / 1024.0).round(2)} KB)"
        puts "    Stored in Solr (Base64):   #{stored_size} bytes (#{(stored_size / 1024.0).round(2)} KB)"
        puts "    Storage reduction with the compressed marcxml:         #{storage_reduction.round(2)}%"
        puts "    Total solr record size:         #{total_record_size} bytes (#{(total_record_size / 1024.0).round(2)} KB)"
        puts "    MARCXML % of record:       #{marcxml_percentage.round(2)}%"
      end
````
### The above calculations will print
```
MARCXML Storage calculations for SCSB-8157262:
    Original XML size:         79128 bytes (77.27 KB)
    compressed marcxml Stored in Solr (Base64):   6524 bytes (6.37 KB)
    Storage reduction:         91.76%
    Total record size:         56163 bytes (54.85 KB)
    MARCXML % of record:       11.62%
```
