### PR TITLE
Add custom implementation of Deserialize in origin_place and coverage

### DIFF
--- a/lib/bibdata_rs/src/ephemera/ephemera_folder.rs
+++ b/lib/bibdata_rs/src/ephemera/ephemera_folder.rs
@@ -115,8 +115,10 @@ where
         Some(raw) => {
             let mut result = Vec::new();
             for value in raw {
-                if let Ok(item) = serde_json::from_value::<T>(value) {
-                    result.push(item);
+                if value.is_object() || value.is_array() {
+                    if let Ok(item) = serde_json::from_value::<T>(value) {
+                        result.push(item);
+                    }
                 }
             }
             if result.is_empty() {
@@ -159,7 +161,7 @@ impl EphemeraFolder {
         match &self.coverage {
             Some(coverage_vector) => coverage_vector
                 .iter()
-                .filter(|coverage| coverage.exact_match.accepted_vocabulary())
+                .filter(|coverage| coverage.exact_match.as_ref().map_or(false, |em| em.accepted_vocabulary()))
                 .map(|coverage| coverage.label.clone())
                 .collect(),
             None => vec![],
@@ -170,7 +172,7 @@ impl EphemeraFolder {
         match &self.origin {
             Some(origin_vector) => origin_vector
                 .iter()
-                .filter(|origin| origin.exact_match.accepted_vocabulary())
+                .filter(|origin| origin.exact_match.as_ref().map_or(false, |em| em.accepted_vocabulary()))
                 .map(|origin| origin.label.clone())
                 .collect(),
             None => vec![],
@@ -529,15 +531,15 @@ mod tests {
             .title(vec!["The worst book ever!".to_string()])
             .coverage(vec![
                 Coverage {
-                    exact_match: ExactMatch {
+                    exact_match: Some(ExactMatch {
                         id: "http://id.loc.gov/vocabulary/countries/an".to_string(),
-                    },
+                    }),
                     label: "Andorra".to_string(),
                 },
                 Coverage {
-                    exact_match: ExactMatch {
+                    exact_match: Some(ExactMatch {
                         id: "http://bad-bad-bad".to_string(),
-                    },
+                    }),
                     label: "Anguilla".to_string(),
                 },
             ])

--- a/lib/bibdata_rs/src/ephemera/ephemera_folder/coverage.rs
+++ b/lib/bibdata_rs/src/ephemera/ephemera_folder/coverage.rs
@@ -1,11 +1,28 @@
 use crate::ephemera_folder::country::ExactMatch;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
+use serde_json::Value;
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Debug)]
 pub struct Coverage {
-    pub exact_match: ExactMatch,
-    #[serde(rename = "pref_label")]
-    pub label: String,
+  pub exact_match: Option<ExactMatch>,
+  pub label: String,
+}
+
+impl<'de> Deserialize<'de> for Coverage {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    let value = Value::deserialize(deserializer)?;
+    let label = value.get("pref_label")
+      .and_then(|v| v.as_str())
+      .unwrap_or("").to_string();
+    let exact_match = match value.get("exact_match") {
+      Some(em_value) => ExactMatch::deserialize(em_value).ok(),
+      None => None,
+    };
+    Ok(Coverage { exact_match, label })
+  }
 }
 
 #[cfg(test)]
@@ -46,12 +63,49 @@ mod tests {
           ]"#;
         let coverage_vector: Vec<Coverage> = serde_json::from_str(json_ld).unwrap();
         assert_eq!(
-            coverage_vector[0].exact_match.id,
+            coverage_vector[0].exact_match.as_ref().unwrap().id,
             "http://id.loc.gov/vocabulary/countries/an"
         );
         assert_eq!(coverage_vector[0].label, "Andorra");
         assert_eq!(coverage_vector[1].label, "Anguilla");
-        assert!(coverage_vector[0].exact_match.accepted_vocabulary());
-        assert!(!coverage_vector[1].exact_match.accepted_vocabulary());
+        assert!(coverage_vector[0].exact_match.as_ref().unwrap().accepted_vocabulary());
+        assert!(!coverage_vector[1].exact_match.as_ref().unwrap().accepted_vocabulary());
+    }
+    
+    #[test]
+    fn it_can_parse_coverage_and_skips_entry_when_exact_match_is_missing_from_the_json_ld() {
+        let json_ld = r#"[
+            {
+                "@id": "https://figgy-staging.princeton.edu/catalog/8d175872-80fc-4389-bd0b-5034d1178669",
+                "@type": "skos:Concept",
+                "pref_label": "Andorra",
+                "in_scheme": {
+                  "@id": "https://figgy.princeton.edu/ns/lAEGeographicAreas",
+                  "@type": "skos:ConceptScheme",
+                  "pref_label": "LAE Geographic Areas"
+                },
+                "exact_match": {
+                        "@id": "http://id.loc.gov/vocabulary/countries/an"
+                }
+            },
+            {
+                "@id": "https://figgy-staging.princeton.edu/catalog/6170d545-fe9b-4df9-ae72-776083f00102",
+                "@type": "skos:Concept",
+                "pref_label": "Anguilla",
+                "in_scheme": {
+                  "@id": "https://figgy.princeton.edu/ns/lAEGeographicAreas",
+                  "@type": "skos:ConceptScheme",
+                  "pref_label": "LAE Geographic Areas"
+                }
+            }
+          ]"#;
+        let raw: Vec<Value> = serde_json::from_str(json_ld).unwrap();
+        let coverage_vector: Vec<Coverage> = raw.into_iter()
+            .filter_map(|v| Coverage::deserialize(v).ok())
+            .filter(|c| c.exact_match.is_some())
+            .collect();
+        assert_eq!(coverage_vector.len(), 1);
+        assert_eq!(coverage_vector[0].label, "Andorra");
+        assert_eq!(coverage_vector[0].exact_match.as_ref().unwrap().id, "http://id.loc.gov/vocabulary/countries/an");
     }
 }

--- a/lib/bibdata_rs/src/solr/ephemera_solr_mapping.rs
+++ b/lib/bibdata_rs/src/solr/ephemera_solr_mapping.rs
@@ -366,9 +366,9 @@ mod tests {
             .id("abc123".to_owned())
             .title(vec!["Our favorite book".to_owned()])
             .coverage(vec![Coverage {
-                exact_match: country::ExactMatch {
+                exact_match: Some(country::ExactMatch {
                     id: "http://id.loc.gov/vocabulary/countries/an".to_owned(),
-                },
+                }),
                 label: "Andorra".to_string(),
             }])
             .build()
@@ -397,9 +397,9 @@ mod tests {
             .title(vec!["Bohemian Rhapsody".to_string()])
             .page_count("333".to_string())
             .origin_place(vec![OriginPlace {
-                exact_match: country::ExactMatch {
+                exact_match: Some(country::ExactMatch {
                     id: "http://id.loc.gov/vocabulary/countries/ck".to_owned(),
-                },
+                }),
                 label: "Colombia".to_string(),
             }])
             .build()
@@ -434,9 +434,9 @@ mod tests {
             .date_created(vec!["1973".to_string()])
             .publisher(vec!["Rolling Press".to_string()])
             .origin_place(vec![OriginPlace {
-                exact_match: country::ExactMatch {
+                exact_match: Some(country::ExactMatch {
                     id: "http://id.loc.gov/vocabulary/countries/ck".to_owned(),
-                },
+                }),
                 label: "Colombia".to_string(),
             }])
             .build()


### PR DESCRIPTION
closes #3020

If pref_label is missing then defalt to an empty string If the exact_match exists and it has the wrong structure it returns None instead of erroring

related to [#3020]

I've indexed the ephemera in catalog-staging 
Example [figgy record](https://figgy.princeton.edu/catalog/a2a91e54-a262-4a52-b88d-3ceea851db49.jsonld)  that was breaking the code because of the unexpected structure.
Indexed record in the [catalog](https://catalog-staging.princeton.edu/catalog?search_field=all_fields&q=a2a91e54-a262-4a52-b88d-3ceea851db49)

Compare the coverage in jsonld with the content in the [geographic facet](https://catalog-staging.princeton.edu/catalog?search_field=all_fields&q=a2a91e54-a262-4a52-b88d-3ceea851db49)