### PR TITLE
Include item "requested" attribute in the holdings API call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ target
 Makefile
 mkmf.log
 .vscode/*
+vendor/bundle

--- a/app/adapters/alma_adapter/alma_item.rb
+++ b/app/adapters/alma_adapter/alma_item.rb
@@ -252,7 +252,8 @@ class AlmaAdapter
         label: holding_location_label(composite_location), # Firestore Library
         description: item_data['description'], # "v. 537, no. 7618 (2016 Sept. 1)" - new in Alma
         enum_display: enumeration, # in Alma there are many enumerations
-        chron_display: chronology # in Alma there are many chronologies
+        chron_display: chronology, # in Alma there are many chronologies
+        requested: item_data['requested']
       }.merge(temp_library_availability_summary)
     end
 

--- a/spec/adapters/alma_adapter_spec.rb
+++ b/spec/adapters/alma_adapter_spec.rb
@@ -270,6 +270,7 @@ RSpec.describe AlmaAdapter do
       expect(item[:in_temp_library]).to be false
       expect(item[:temp_library_code]).to be_nil
       expect(item[:label]).to eq 'Lewis Library - Stacks'
+      expect(item[:requested]).to be false
 
       # We are hard-coding this value to "N" to preserve the property in the response
       # but we are not really using this value anymore.
@@ -287,7 +288,7 @@ RSpec.describe AlmaAdapter do
                     status: 'Available', status_label: 'Item in place', status_source: 'base_status', process_type: nil,
                     on_reserve: 'Y', item_type: 'Gen', pickup_location_id: 'lewis', pickup_location_code: 'lewis',
                     location: 'lewis$resterm', label: 'Lewis Library - Term Loan Reserves', description: '', enum_display: '',
-                    chron_display: '', in_temp_library: true, temp_library_code: 'lewis',
+                    chron_display: '', requested: false, in_temp_library: true, temp_library_code: 'lewis',
                     temp_library_label: 'Lewis Library - Term Loan Reserves', temp_location_code: 'lewis$resterm',
                     temp_location_label: 'Lewis Library - Term Loan Reserves' }
       expect(item).to eq item_test


### PR DESCRIPTION
Include item "requested" attribute in the holdings API call

bibliographic/bib_id/holdings/holding_id/availability.json API call

This API call is used in the catalog request form.

related to https://github.com/pulibrary/orangelight/issues/5632