### PR TITLE
Fix cleanup toolchains step

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -146,7 +146,7 @@ namespace :deploy do
   task :cleanup_toolchains do
     on roles(:all) do
       within release_path do
-        execute :rustup, :toolchain, :remove, '$(rustup toolchain list | grep -v active | grep -v default)'
+        execute :rake, 'rust:cleanup_toolchains'
       end
     end
   end

--- a/lib/tasks/compile.rake
+++ b/lib/tasks/compile.rake
@@ -3,3 +3,14 @@ require 'rb_sys/extensiontask'
 RbSys::ExtensionTask.new('bibdata_rs', Gem::Specification.new) do |ext|
   ext.lib_dir = 'lib/bibdata_rs'
 end
+
+namespace :rust do
+  desc 'Cleanup old rust toolchain versions'
+  task cleanup_toolchains: :environment do
+    system <<~END_TOOLCHAIN_COMMAND
+      for toolchain in $(rustup toolchain list | grep -v active | grep -v default); do
+        rustup toolchain remove "$toolchain"
+      done
+    END_TOOLCHAIN_COMMAND
+  end
+end


### PR DESCRIPTION
Previously, the command to cleanup old rust toolchains failed in cases where there were no old toolchains to remove with:

```
rustup toolchain remove $(rustup toolchain list | grep -v active | grep -v default)
error: the following required arguments were not provided:
  <TOOLCHAIN>...

usage: rustup[EXE] toolchain uninstall <TOOLCHAIN>...
```

We address this problem by putting the remove command into a for loop. For convenience of adding this bash to capistrano, we add the command to a rake task.