### PR TITLE
Upgrade to magnus 0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,21 +1294,21 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "magnus"
-version = "0.6.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1597ef40aa8c36be098249e82c9a20cf7199278ac1c1a1a995eeead6a184479"
+checksum = "3b36a5b126bbe97eb0d02d07acfeb327036c6319fd816139a49824a83b7f9012"
 dependencies = [
  "magnus-macros",
  "rb-sys",
- "rb-sys-env 0.1.2",
+ "rb-sys-env",
  "seq-macro",
 ]
 
 [[package]]
 name = "magnus-macros"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5968c820e2960565f647819f5928a42d6e874551cab9d88d75e3e0660d7f71e3"
+checksum = "47607461fd8e1513cb4f2076c197d8092d921a1ea75bd08af97398f593751892"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1838,12 +1838,6 @@ dependencies = [
 
 [[package]]
 name = "rb-sys-env"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35802679f07360454b418a5d1735c89716bde01d35b1560fc953c1415a0b3bb"
-
-[[package]]
-name = "rb-sys-env"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f8d2924cf136a1315e2b4c7460a39f62ef11ee5d522df9b2750fab55b868b6"
@@ -1855,7 +1849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ccb543252549fc28f5d290322e041cd682bd199a8e1caaa813fb6e63dd221e"
 dependencies = [
  "rb-sys",
- "rb-sys-env 0.2.2",
+ "rb-sys-env",
  "rb-sys-test-helpers-macros",
 ]
 

--- a/lib/bibdata_rs/Cargo.toml
+++ b/lib/bibdata_rs/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-magnus = { version = "0.6.2" }
+magnus = { version = "0.8.0" }
 regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde-xml-rs = "0.8.0"

--- a/lib/bibdata_rs/src/ephemera/ephemera_folder.rs
+++ b/lib/bibdata_rs/src/ephemera/ephemera_folder.rs
@@ -369,15 +369,15 @@ pub struct ItemResponse {
     pub data: Vec<EphemeraFolder>,
 }
 
-pub fn json_ephemera_document(url: String) -> Result<String, magnus::Error> {
+pub fn json_ephemera_document(ruby: &magnus::Ruby, url: String) -> Result<String, magnus::Error> {
     #[cfg(not(test))]
     let _ = env_logger::try_init();
     let rt = tokio::runtime::Runtime::new()
-        .map_err(|e| magnus::Error::new(magnus::exception::runtime_error(), e.to_string()))?;
+        .map_err(|e| magnus::Error::new(ruby.exception_runtime_error(), e.to_string()))?;
     rt.block_on(async {
         let folder_results = ephemera_folders_iterator(&url, 1_000)
             .await
-            .map_err(|e| magnus::Error::new(magnus::exception::runtime_error(), e.to_string()))?;
+            .map_err(|e| magnus::Error::new(ruby.exception_runtime_error(), e.to_string()))?;
 
         for folder_json in &folder_results {
             if let Ok(folder) = serde_json::from_str::<EphemeraFolder>(folder_json) {
@@ -395,6 +395,8 @@ pub fn json_ephemera_document(url: String) -> Result<String, magnus::Error> {
 
 #[cfg(test)]
 mod tests {
+    use magnus::Ruby;
+
     use crate::{
         ephemera::{ephemera_folder::country::ExactMatch, CatalogClient},
         solr,
@@ -474,7 +476,8 @@ mod tests {
                 .expect(12)
                 .create();
 
-            let result = json_ephemera_document(server.url().to_string()).unwrap();
+            let ruby = unsafe { Ruby::get_unchecked() };
+            let result = json_ephemera_document(&ruby, server.url().to_string()).unwrap();
 
             let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
             assert!(parsed.is_array());
@@ -516,7 +519,8 @@ mod tests {
                 .expect(12)
                 .create();
 
-            let result = json_ephemera_document(server.url().to_string()).unwrap();
+            let ruby = unsafe { Ruby::get_unchecked() };
+            let result = json_ephemera_document(&ruby, server.url().to_string()).unwrap();
             let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
             assert!(parsed.is_array());
             folder_mock.assert();

--- a/lib/bibdata_rs/src/marc.rs
+++ b/lib/bibdata_rs/src/marc.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use magnus::exception;
+use magnus::Ruby;
 use marctk::Record;
 
 pub mod call_number;
@@ -23,11 +23,12 @@ pub use ruby_bindings::register_ruby_methods;
 pub use string_normalize::trim_punctuation;
 
 pub fn holding_id(
+    ruby: &Ruby,
     field_string: String,
     full_record: String,
 ) -> Result<Option<String>, magnus::Error> {
-    let field = field_852(&field_string)?;
-    let record = get_record(&full_record)?;
+    let field = field_852(ruby, &field_string)?;
+    let record = get_record(ruby, &full_record)?;
     let subfield_code_8 = field.first_subfield("8");
     let subfield_code_0 = field.first_subfield("0");
     match (subfield_code_8, subfield_code_0) {
@@ -42,40 +43,41 @@ pub fn holding_id(
 pub fn alma_code_start_22(code: String) -> bool {
     code.starts_with("22") && code.ends_with("06421")
 }
-pub fn genres(record_string: String) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(&record_string)?;
+pub fn genres(ruby: &Ruby, record_string: String) -> Result<Vec<String>, magnus::Error> {
+    let record = get_record(ruby, &record_string)?;
     Ok(genre::genres(&record))
 }
 
 pub fn original_languages_of_translation(
+    ruby: &Ruby,
     record_string: String,
 ) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(&record_string)?;
+    let record = get_record(ruby, &record_string)?;
     Ok(language::original_languages_of_translation(&record)
         .iter()
         .map(|language| language.english_name.to_owned())
         .collect())
 }
 
-pub fn access_notes(record_string: String) -> Result<Option<Vec<String>>, magnus::Error> {
-    let record = get_record(&record_string)?;
+pub fn access_notes(ruby: &Ruby, record_string: String) -> Result<Option<Vec<String>>, magnus::Error> {
+    let record = get_record(ruby, &record_string)?;
     Ok(note::access_notes(&record))
 }
 
-pub fn recap_partner_notes(record_string: String) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(&record_string)?;
+pub fn recap_partner_notes(ruby: &Ruby, record_string: String) -> Result<Vec<String>, magnus::Error> {
+    let record = get_record(ruby, &record_string)?;
     Ok(scsb::recap_partner::recap_partner_notes(&record))
 }
 
-pub fn is_scsb(record_string: String) -> Result<bool, magnus::Error> {
-    let record = get_record(&record_string)?;
+pub fn is_scsb(ruby: &Ruby, record_string: String) -> Result<bool, magnus::Error> {
+    let record = get_record(ruby, &record_string)?;
     Ok(scsb::is_scsb(&record))
 }
 
 // Build the permanent location code from 852$b and 852$c
 // Do not append the 852c if it is a SCSB - we save the SCSB locations as scsbnypl and scsbcul
-pub fn permanent_location_code(field_string: String) -> Result<Option<String>, magnus::Error> {
-    let field = field_852(&field_string)?;
+pub fn permanent_location_code(ruby: &Ruby, field_string: String) -> Result<Option<String>, magnus::Error> {
+    let field = field_852(ruby, &field_string)?;
     Ok(match field.first_subfield("8") {
         Some(alma_code) if alma_code_start_22(alma_code.content().to_string()) => {
             let b = field
@@ -94,20 +96,20 @@ pub fn permanent_location_code(field_string: String) -> Result<Option<String>, m
     })
 }
 
-fn field_852(field_string: &String) -> Result<marctk::Field, magnus::Error> {
-    let record = get_record(field_string)?;
+fn field_852(ruby: &Ruby, field_string: &String) -> Result<marctk::Field, magnus::Error> {
+    let record = get_record(ruby, field_string)?;
     let field_852 = record.get_fields("852").into_iter().next();
     let field_852 = field_852.ok_or_else(|| {
         magnus::Error::new(
-            exception::runtime_error(),
+            ruby.exception_runtime_error(),
             format!("No 852 field found in record {}", field_string),
         )
     })?;
     Ok(field_852.clone())
 }
 
-pub fn current_location_code(field_string: String) -> Result<Option<String>, magnus::Error> {
-    let record = get_record(&field_string)?;
+pub fn current_location_code(ruby: &Ruby, field_string: String) -> Result<Option<String>, magnus::Error> {
+    let record = get_record(ruby, &field_string)?;
     let field_876 = record.get_fields("876").into_iter().next();
     Ok(field_876.and_then(
         |field| match (field.first_subfield("y"), field.first_subfield("z")) {
@@ -116,9 +118,9 @@ pub fn current_location_code(field_string: String) -> Result<Option<String>, mag
         },
     ))
 }
-pub fn build_call_number(field_string: String) -> Result<Option<String>, magnus::Error> {
+pub fn build_call_number(ruby: &Ruby, field_string: String) -> Result<Option<String>, magnus::Error> {
     // call_number = [field_852['h'], field_852['i'], field_852['k'], field_852['j']].reject(&:blank?)
-    let record = get_record(&field_string)?;
+    let record = get_record(ruby, &field_string)?;
     let field_852 = record.get_fields("852").into_iter().next();
     let call_number = field_852.map(|field| {
         field
@@ -133,15 +135,15 @@ pub fn build_call_number(field_string: String) -> Result<Option<String>, magnus:
     Ok(call_number.filter(|s| !s.is_empty()))
 }
 
-pub fn format_facets(record_string: String) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(&record_string)?;
+pub fn format_facets(ruby: &Ruby, record_string: String) -> Result<Vec<String>, magnus::Error> {
+    let record = get_record(ruby, &record_string)?;
     Ok(record_facet_mapping::format_facets(&record)
         .iter()
         .map(|facet| format!("{facet}"))
         .collect())
 }
-pub fn private_items(record_string: String, holding_id: String) -> Result<bool, magnus::Error> {
-    let record = get_record(&record_string)?;
+pub fn private_items(ruby: &Ruby, record_string: String, holding_id: String) -> Result<bool, magnus::Error> {
+    let record = get_record(ruby, &record_string)?;
     let fields_876 = record.get_fields("876");
     let mut items = fields_876.iter().filter(|field| {
         field.first_subfield("0").map(|subfield| subfield.content()) == Some(&holding_id)
@@ -152,13 +154,13 @@ pub fn private_items(record_string: String, holding_id: String) -> Result<bool, 
     }))
 }
 
-pub fn notes_cjk(record_string: String) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(&record_string)?;
+pub fn notes_cjk(ruby: &Ruby, record_string: String) -> Result<Vec<String>, magnus::Error> {
+    let record = get_record(ruby, &record_string)?;
     Ok(cjk::notes_cjk(&record).collect())
 }
 
-pub fn subjects_cjk(record_string: String) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(&record_string)?;
+pub fn subjects_cjk(ruby: &Ruby, record_string: String) -> Result<Vec<String>, magnus::Error> {
+    let record = get_record(ruby, &record_string)?;
     Ok(cjk::subjects_cjk(&record).collect())
 }
 
@@ -170,13 +172,13 @@ pub fn is_oclc_number(string: String) -> bool {
     identifier::is_oclc_number(&string)
 }
 
-pub fn identifiers_of_all_versions(record_string: String) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(&record_string)?;
+pub fn identifiers_of_all_versions(ruby: &Ruby, record_string: String) -> Result<Vec<String>, magnus::Error> {
+    let record = get_record(ruby, &record_string)?;
     Ok(identifier::identifiers_of_all_versions(&record))
 }
 
-pub fn publication_statements(record_string: String) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(&record_string)?;
+pub fn publication_statements(ruby: &Ruby, record_string: String) -> Result<Vec<String>, magnus::Error> {
+    let record = get_record(ruby, &record_string)?;
     Ok(publication::publication_statements(&record).collect())
 }
 
@@ -188,10 +190,10 @@ pub fn trim_punctuation_owned(string: String) -> String {
     trim_punctuation(&string)
 }
 
-fn get_record(breaker: &str) -> Result<Record, magnus::Error> {
+fn get_record(ruby: &Ruby, breaker: &str) -> Result<Record, magnus::Error> {
     Record::from_breaker(breaker).map_err(|err| {
         magnus::Error::new(
-            exception::runtime_error(),
+            ruby.exception_runtime_error(),
             format!("Found error {} while parsing breaker {}", err, breaker),
         )
     })

--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -59,21 +59,23 @@ pub fn register_ruby_methods(parent_module: &RModule) -> Result<(), magnus::Erro
 }
 
 fn call_number_labels_for_display_from_marc_breaker(
+    ruby: &Ruby,
     record_string: String,
 ) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(&record_string)?;
+    let record = get_record(ruby, &record_string)?;
     Ok(call_number::call_number_labels_for_display(&record))
 }
 
 fn call_number_labels_for_browse_from_marc_breaker(
+    ruby: &Ruby,
     record_string: String,
 ) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(&record_string)?;
+    let record = get_record(ruby, &record_string)?;
     Ok(call_number::call_number_labels_for_browse(&record))
 }
 
-fn icpsr_subjects_from_marc_breaker(record_string: String) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(&record_string)?;
+fn icpsr_subjects_from_marc_breaker(ruby: &Ruby, record_string: String) -> Result<Vec<String>, magnus::Error> {
+    let record = get_record(ruby, &record_string)?;
     Ok(subject::icpsr_subjects(&record))
 }
 

--- a/lib/bibdata_rs/src/solr/index.rs
+++ b/lib/bibdata_rs/src/solr/index.rs
@@ -1,5 +1,6 @@
 pub use super::SolrDocument;
 use anyhow::Result;
+use magnus::Ruby;
 use reqwest::header::CONTENT_TYPE;
 
 pub fn index(solr_url: &str, documents: &[SolrDocument]) -> Result<()> {
@@ -13,16 +14,16 @@ pub fn index(solr_url: &str, documents: &[SolrDocument]) -> Result<()> {
     Ok(())
 }
 
-pub fn index_string(solr_url: String, documents: String) -> Result<(), magnus::Error> {
+pub fn index_string(ruby: &Ruby, solr_url: String, documents: String) -> Result<(), magnus::Error> {
     if documents.trim().is_empty() {
         return Err(magnus::Error::new(
-            magnus::exception::runtime_error(),
+            ruby.exception_runtime_error(),
             "No documents to index",
         ));
     }
     let document_vec: Vec<SolrDocument> = serde_json::from_str(&documents).map_err(|e| {
         magnus::Error::new(
-            magnus::exception::runtime_error(),
+            ruby.exception_runtime_error(),
             format!(
                 "Coulld not parse documents from JSON string: {:?}, {}",
                 e, documents

--- a/lib/bibdata_rs/src/theses/dataspace/collection.rs
+++ b/lib/bibdata_rs/src/theses/dataspace/collection.rs
@@ -14,7 +14,7 @@ use crate::theses::{
 };
 use anyhow::{anyhow, Result};
 use log::debug;
-use magnus::exception;
+use magnus::Ruby;
 use rayon::prelude::*;
 use serde::Deserialize;
 
@@ -65,16 +65,17 @@ pub fn collection_url(server: &str, scope: &str, page_size: &str, page: &str) ->
     )
 }
 
-fn magnus_err_from_serde_err(value: &serde_json::Error) -> magnus::Error {
-    magnus::Error::new(exception::runtime_error(), value.to_string())
+fn magnus_err_from_serde_err(ruby: &Ruby, value: &serde_json::Error) -> magnus::Error {
+    magnus::Error::new(ruby.exception_runtime_error(), value.to_string())
 }
 
-fn magnus_err_from_anyhow_err(value: &anyhow::Error) -> magnus::Error {
-    magnus::Error::new(exception::runtime_error(), value.to_string())
+fn magnus_err_from_anyhow_err(ruby: &Ruby, value: &anyhow::Error) -> magnus::Error {
+    magnus::Error::new(ruby.exception_runtime_error(), value.to_string())
 }
 
 // The main function for thesis caching, to be called from Ruby
 pub fn collections_as_solr(
+    ruby: &Ruby,
     server: String,
     community_handle: String,
     rest_limit: u32,
@@ -84,9 +85,9 @@ pub fn collections_as_solr(
         get_document_list(&server, &community_handle, rest_limit, |server, handle| {
             community::get_collection_list(server, handle, community::get_community_id)
         })
-        .map_err(|e| magnus_err_from_anyhow_err(&e))?;
+        .map_err(|e| magnus_err_from_anyhow_err(ruby, &e))?;
     let file = File::create(temp_theses_cache_path())
-        .map_err(|value| magnus_err_from_anyhow_err(&anyhow!(value)))?;
+        .map_err(|value| magnus_err_from_anyhow_err(ruby, &anyhow!(value)))?;
     let mut writer = BufWriter::new(file);
     serde_json::to_writer_pretty(
         &mut writer,
@@ -95,10 +96,10 @@ pub fn collections_as_solr(
             .map(SolrDocument::from)
             .collect::<Vec<SolrDocument>>(),
     )
-    .map_err(|e| magnus_err_from_serde_err(&e))?;
+    .map_err(|e| magnus_err_from_serde_err(ruby, &e))?;
     writer
         .flush()
-        .map_err(|value| magnus_err_from_anyhow_err(&anyhow!(value)))?;
+        .map_err(|value| magnus_err_from_anyhow_err(ruby, &anyhow!(value)))?;
     Ok(())
 }
 
@@ -311,8 +312,9 @@ mod tests {
             .mock("GET", "/core/communities/")
             .with_status(500)
             .create();
+        let ruby = unsafe { Ruby::get_unchecked() };
 
-        assert!(collections_as_solr(server.url(), "88435/dsp019c67wm88m".to_owned(), 100).is_err());
+        assert!(collections_as_solr(&ruby, server.url(), "88435/dsp019c67wm88m".to_owned(), 100).is_err());
         mock_bad_response.assert();
     }
 }

--- a/lib/bibdata_rs/src/theses/legacy_dataspace/collection.rs
+++ b/lib/bibdata_rs/src/theses/legacy_dataspace/collection.rs
@@ -14,7 +14,7 @@ use crate::theses::{
 };
 use anyhow::{anyhow, Result};
 use log::debug;
-use magnus::exception;
+use magnus::Ruby;
 use rayon::prelude::*;
 
 pub fn collection_url(server: &str, id: &str, rest_limit: &str, offset: &str) -> String {
@@ -24,16 +24,17 @@ pub fn collection_url(server: &str, id: &str, rest_limit: &str, offset: &str) ->
     )
 }
 
-fn magnus_err_from_serde_err(value: &serde_json::Error) -> magnus::Error {
-    magnus::Error::new(exception::runtime_error(), value.to_string())
+fn magnus_err_from_serde_err(ruby: &Ruby, value: &serde_json::Error) -> magnus::Error {
+    magnus::Error::new(ruby.exception_runtime_error(), value.to_string())
 }
 
-fn magnus_err_from_anyhow_err(value: &anyhow::Error) -> magnus::Error {
-    magnus::Error::new(exception::runtime_error(), value.to_string())
+fn magnus_err_from_anyhow_err(ruby: &Ruby, value: &anyhow::Error) -> magnus::Error {
+    magnus::Error::new(ruby.exception_runtime_error(), value.to_string())
 }
 
 // The main function for thesis caching, to be called from Ruby
 pub fn legacy_collections_as_solr(
+    ruby: &Ruby,
     server: String,
     community_handle: String,
     rest_limit: u32,
@@ -43,9 +44,9 @@ pub fn legacy_collections_as_solr(
         get_document_list(&server, &community_handle, rest_limit, |server, handle| {
             community::get_collection_list(server, handle, community::get_community_id)
         })
-        .map_err(|e| magnus_err_from_anyhow_err(&e))?;
+        .map_err(|e| magnus_err_from_anyhow_err(ruby, &e))?;
     let file = File::create(temp_legacy_theses_cache_path())
-        .map_err(|value| magnus_err_from_anyhow_err(&anyhow!(value)))?;
+        .map_err(|value| magnus_err_from_anyhow_err(ruby, &anyhow!(value)))?;
     let mut writer = BufWriter::new(file);
     serde_json::to_writer_pretty(
         &mut writer,
@@ -54,10 +55,10 @@ pub fn legacy_collections_as_solr(
             .map(SolrDocument::from)
             .collect::<Vec<SolrDocument>>(),
     )
-    .map_err(|e| magnus_err_from_serde_err(&e))?;
+    .map_err(|e| magnus_err_from_serde_err(ruby, &e))?;
     writer
         .flush()
-        .map_err(|value| magnus_err_from_anyhow_err(&anyhow!(value)))?;
+        .map_err(|value| magnus_err_from_anyhow_err(ruby, &anyhow!(value)))?;
     Ok(())
 }
 
@@ -234,9 +235,10 @@ mod tests {
             .mock("GET", "/communities/")
             .with_status(500)
             .create();
+        let ruby = unsafe { Ruby::get_unchecked() };
 
         assert!(
-            legacy_collections_as_solr(server.url(), "88435/dsp019c67wm88m".to_owned(), 100)
+            legacy_collections_as_solr(&ruby, server.url(), "88435/dsp019c67wm88m".to_owned(), 100)
                 .is_err()
         );
         mock_bad_response.assert();


### PR DESCRIPTION
Code changes are to address a new deprecation warning. Previously, we could call `magnus::exception::runtime_error()`, and it would obtain its own Ruby handle and provide the appropriate exception class.  With the new API, we have to provide a Ruby handle instead.

See [Release notes](https://github.com/matsadler/magnus/releases/tag/0.8.0)