### PR TITLE
Update parse-datetime version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,12 +124,12 @@ name = "bibdata_rs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "chrono",
  "codes-iso-639",
  "criterion",
  "env_logger",
  "indexmap",
  "itertools 0.14.0",
+ "jiff",
  "library_stdnums",
  "log",
  "magnus",
@@ -243,9 +243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -1151,26 +1149,43 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.13"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02000660d30638906021176af16b17498bd0d12813dbfe7b276d8bc7f3c0806"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.13"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c30758ddd7188629c6713fc45d1188af4f44c90582311d0c8d8c9907f60c48"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -1473,13 +1488,12 @@ dependencies = [
 
 [[package]]
 name = "parse_datetime"
-version = "0.11.0"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b77d27257a460cefd73a54448e5f3fd4db224150baf6ca3e02eedf4eb2b3e9"
+checksum = "acea383beda9652270f3c9678d83aa58cbfc16880343cae0c0c8c7d6c0974132"
 dependencies = [
- "chrono",
+ "jiff",
  "num-traits",
- "regex",
  "winnow",
 ]
 

--- a/lib/bibdata_rs/Cargo.toml
+++ b/lib/bibdata_rs/Cargo.toml
@@ -17,8 +17,7 @@ reqwest = { version = "0.12.15", features = ["json", "blocking"] }
 tokio = { version = "1", features = ["full"] }
 itertools = "0.14.0"
 codes-iso-639 = "0.1.5"
-parse_datetime = "0.11.0"
-chrono = "0.4.44"
+parse_datetime = "0.13.0"
 env_logger = "0.11.8"
 log = "0.4.27"
 rayon = "1.10.0"
@@ -28,6 +27,7 @@ marctk = {version = "0.6.0", features = ["marc21_bibliographic"] }
 library_stdnums = "0.1.0"
 indexmap = "2"
 unicode-blocks = "0.1.9"
+jiff = "0.2.23"
 
 [dev-dependencies]
 criterion = "0.8.2"

--- a/lib/bibdata_rs/src/theses/embargo.rs
+++ b/lib/bibdata_rs/src/theses/embargo.rs
@@ -1,6 +1,6 @@
 // This module is responsible for handling embargoed theses
 
-use chrono::prelude::*;
+use jiff::{Timestamp, Zoned};
 use parse_datetime::parse_datetime;
 
 #[derive(Debug, PartialEq)]
@@ -20,7 +20,7 @@ impl Embargo {
         match raw_embargo_date(lift_dates, terms_dates) {
             Some(date) => match parse_datetime(date) {
                 Ok(parsed) => {
-                    if parsed > Utc::now() {
+                    if parsed.timestamp() > Timestamp::now() {
                         Self::Current(embargo_text(lift_dates, terms_dates, doc_id))
                     } else {
                         Self::Expired
@@ -54,13 +54,13 @@ fn embargo_date(
     terms_dates: Option<&Vec<String>>,
 ) -> Option<String> {
     parsed_embargo_date(lift_dates, terms_dates)
-        .map(|date| format!("{}", date.format("%B %-d, %Y")))
+        .map(|date| date.strftime("%B %-d, %Y").to_string())
 }
 
 fn parsed_embargo_date(
     lift_dates: Option<&Vec<String>>,
     terms_dates: Option<&Vec<String>>,
-) -> Option<DateTime<FixedOffset>> {
+) -> Option<Zoned> {
     match raw_embargo_date(lift_dates, terms_dates) {
         Some(date) => parse_datetime(date).ok(),
         None => None,


### PR DESCRIPTION
A few minor changes were needed due to the breaking change in 0.12.0 to use the jiff crate rather than chrono, see [0.12.0 release notes](https://github.com/uutils/parse_datetime/releases/tag/v0.12.0).