### PR TITLE
Rewrite cataloged_tdt in Rust

### DIFF
--- a/lib/bibdata_rs/benches/marc_bench.rs
+++ b/lib/bibdata_rs/benches/marc_bench.rs
@@ -1,16 +1,12 @@
 use bibdata_rs::{
-    marc::{call_number::call_number_labels_for_display, genre::genres},
+    marc::{call_number::call_number_labels_for_display, date::cataloged_date, genre::genres},
     solr::AuthorRoles,
 };
 use criterion::{Criterion, criterion_group, criterion_main};
 use marctk::Record;
 
 fn author_role_benchmark(c: &mut Criterion) {
-    let record = Record::from_xml_file("../../spec/fixtures/99100026953506421.mrx")
-        .unwrap()
-        .next()
-        .unwrap()
-        .unwrap();
+    let record = fixture_record("../../spec/fixtures/99100026953506421.mrx");
     let expected = AuthorRoles {
         editors: vec!["Nakanishi, Naoki".to_string()],
         ..Default::default()
@@ -23,11 +19,7 @@ fn author_role_benchmark(c: &mut Criterion) {
 }
 
 fn genre_facet_benchmark(c: &mut Criterion) {
-    let record = Record::from_xml_file("../../spec/fixtures/99100026953506421.mrx")
-        .unwrap()
-        .next()
-        .unwrap()
-        .unwrap();
+    let record = fixture_record("../../spec/fixtures/99100026953506421.mrx");
     c.bench_function("genres", |b| {
         b.iter(|| {
             assert_eq!(genres(&record), vec!["Periodicals", "Facsimiles"]);
@@ -36,11 +28,7 @@ fn genre_facet_benchmark(c: &mut Criterion) {
 }
 
 fn call_number_benchmark(c: &mut Criterion) {
-    let record = Record::from_xml_file("../../spec/fixtures/99100026953506421.mrx")
-        .unwrap()
-        .next()
-        .unwrap()
-        .unwrap();
+    let record = fixture_record("../../spec/fixtures/99100026953506421.mrx");
     c.bench_function("call_number_labels_for_display", |b| {
         b.iter(|| {
             assert_eq!(
@@ -51,10 +39,33 @@ fn call_number_benchmark(c: &mut Criterion) {
     });
 }
 
+fn cataloged_date_benchmark(c: &mut Criterion) {
+    let record = fixture_record("../../spec/fixtures/99100026953506421.mrx");
+    c.bench_function("cataloged_date", |b| {
+        b.iter(|| {
+            assert_eq!(
+                cataloged_date(&record),
+                Some("2020-12-03T01:08:56Z".to_string())
+            );
+        })
+    });
+}
+
 criterion_group!(
     benches,
     author_role_benchmark,
     call_number_benchmark,
+    cataloged_date_benchmark,
     genre_facet_benchmark
 );
 criterion_main!(benches);
+
+// Helper functions
+
+fn fixture_record(filename: &str) -> Record {
+    Record::from_xml_file(filename)
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+}

--- a/lib/bibdata_rs/src/marc.rs
+++ b/lib/bibdata_rs/src/marc.rs
@@ -2,10 +2,12 @@ use itertools::Itertools;
 use magnus::Ruby;
 use marctk::Record;
 
+pub mod alma;
 pub mod call_number;
 pub mod cjk;
 pub mod contributors;
 pub mod control_field;
+pub mod date;
 pub mod fixed_field;
 pub mod genre;
 pub mod identifier;
@@ -22,6 +24,8 @@ mod string_normalize;
 
 pub use ruby_bindings::register_ruby_methods;
 pub use string_normalize::trim_punctuation;
+
+use crate::marc::alma::AlmaHoldingId;
 
 pub fn holding_id(
     ruby: &Ruby,
@@ -42,7 +46,7 @@ pub fn holding_id(
 }
 
 pub fn alma_code_start_22(code: String) -> bool {
-    code.starts_with("22") && code.ends_with("06421")
+    AlmaHoldingId(&code).is_valid()
 }
 pub fn genres(ruby: &Ruby, record_string: String) -> Result<Vec<String>, magnus::Error> {
     let record = get_record(ruby, &record_string)?;

--- a/lib/bibdata_rs/src/marc/alma.rs
+++ b/lib/bibdata_rs/src/marc/alma.rs
@@ -1,0 +1,61 @@
+use marctk::{Field, Subfield};
+
+pub struct AlmaHoldingId<'a>(pub &'a str);
+
+impl<'a> AlmaHoldingId<'a> {
+    pub fn is_valid(&self) -> bool {
+        self.0.starts_with("22") && self.0.ends_with("06421")
+    }
+}
+
+impl<'a> From<&'a Subfield> for AlmaHoldingId<'a> {
+    fn from(subfield: &'a Subfield) -> Self {
+        Self(subfield.content())
+    }
+}
+
+#[derive(Default, PartialEq)]
+pub enum AlmaElectronicPortfolio {
+    Active,
+    #[default]
+    Inactive,
+}
+
+impl From<&Subfield> for AlmaElectronicPortfolio {
+    fn from(subfield: &Subfield) -> Self {
+        if subfield.content() == "Available" {
+            Self::Active
+        } else {
+            Self::Inactive
+        }
+    }
+}
+
+impl AlmaElectronicPortfolio {
+    pub fn is_valid_portfolio_id(id: &str) -> bool {
+        id.starts_with("53") && id.ends_with("06421")
+    }
+}
+
+pub struct InvalidPortfolioData;
+
+impl<'a> TryFrom<&'a Field> for AlmaElectronicPortfolio {
+    type Error = InvalidPortfolioData;
+
+    fn try_from(field: &'a Field) -> Result<Self, Self::Error> {
+        if field.tag() != "951" {
+            return Err(InvalidPortfolioData);
+        };
+        field
+            .first_subfield("8")
+            .and_then(|id_subfield| {
+                let id = id_subfield.content();
+                if Self::is_valid_portfolio_id(id) {
+                    field.first_subfield("a").map(Self::from)
+                } else {
+                    None
+                }
+            })
+            .ok_or(InvalidPortfolioData)
+    }
+}

--- a/lib/bibdata_rs/src/marc/date.rs
+++ b/lib/bibdata_rs/src/marc/date.rs
@@ -1,0 +1,126 @@
+use itertools::Itertools;
+use jiff::{Timestamp, Zoned, tz::TimeZone};
+use marctk::{Record, Subfield};
+use parse_datetime::parse_datetime_at_date;
+
+use crate::marc::{
+    alma::{AlmaElectronicPortfolio, AlmaHoldingId},
+    scsb::is_scsb,
+    variable_length_field::extract_field_values_by,
+};
+
+pub fn cataloged_date(record: &Record) -> Option<String> {
+    if is_scsb(record) {
+        return None;
+    }
+
+    let item_edit_date = extract_field_values_by(
+        record,
+        |field| {
+            field.tag() == "876"
+                && field
+                    .first_subfield("0")
+                    .is_some_and(|subfield| AlmaHoldingId::from(subfield).is_valid())
+        },
+        |field| field.first_subfield("d").map(Subfield::content),
+    )
+    .sorted();
+
+    let electronic_edit_date = extract_field_values_by(
+        record,
+        |field| {
+            matches!(
+                AlmaElectronicPortfolio::try_from(field),
+                Ok(AlmaElectronicPortfolio::Active)
+            )
+        },
+        |field| field.first_subfield("w").map(Subfield::content),
+    )
+    .sorted();
+
+    let record_edit_date = extract_field_values_by(
+        record,
+        |field| field.tag() == "950",
+        |field| field.first_subfield("b").map(Subfield::content),
+    )
+    .sorted();
+
+    item_edit_date
+        .chain(electronic_edit_date)
+        .chain(record_edit_date)
+        .filter_map(|raw_date| {
+            parse_datetime_at_date(Zoned::new(Timestamp::UNIX_EPOCH, TimeZone::UTC), raw_date)
+                .ok()
+                .map(|parsed| {
+                    parsed
+                        .timestamp()
+                        .strftime("%Y-%m-%dT%H:%M:%SZ")
+                        .to_string()
+                })
+        })
+        .next()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_gets_cataloged_date_from_876() {
+        let record =
+            Record::from_breaker("=876 \\$022710806450006421$d2021-07-13 12:24:58").unwrap();
+        assert_eq!(
+            cataloged_date(&record),
+            Some("2021-07-13T12:24:58Z".to_owned())
+        )
+    }
+
+    #[test]
+    fn it_gets_first_date_when_multiple_876() {
+        let record = Record::from_breaker(
+            "=876 \\$022710806450006421$d2021-07-15 12:24:58
+=876 \\$022710806450006421$d2021-07-13 12:24:58
+=876 \\$022710806450006421$d2021-07-17 12:24:58
+=876 \\$022710806450006421$d2021-07-16 12:24:58",
+        )
+        .unwrap();
+        assert_eq!(
+            cataloged_date(&record),
+            Some("2021-07-13T12:24:58Z".to_owned())
+        )
+    }
+
+    #[test]
+    fn it_gets_cataloged_date_from_active_951_portfolio() {
+        let record =
+            Record::from_breaker("=951 \\$aAvailable$8531026240820006421$w2021-07-13 12:24:58")
+                .unwrap();
+        assert_eq!(
+            cataloged_date(&record),
+            Some("2021-07-13T12:24:58Z".to_owned())
+        )
+    }
+
+    #[test]
+    fn it_gets_cataloged_date_from_950_record_date() {
+        let record = Record::from_breaker("=950 \\$b2021-07-13 12:24:58").unwrap();
+        assert_eq!(
+            cataloged_date(&record),
+            Some("2021-07-13T12:24:58Z".to_owned())
+        )
+    }
+
+    #[test]
+    fn it_prefers_the_876_date() {
+        let record = Record::from_breaker(
+            "=876 \\$022710806450006421$d2021-07-13 12:24:58
+=951 \\$aAvailable$8531026240820006421$1995-07-13 12:24:58
+=950 \\$b2030-07-13 12:24:58",
+        )
+        .unwrap();
+        assert_eq!(
+            cataloged_date(&record),
+            Some("2021-07-13T12:24:58Z".to_owned())
+        )
+    }
+}

--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -22,6 +22,7 @@ pub fn register_ruby_methods(parent_module: &RModule) -> Result<(), magnus::Erro
         "call_number_labels_for_display",
         function!(call_number_labels_for_display_from_marc_breaker, 1),
     )?;
+    submodule_marc.define_singleton_method("cataloged_date", function!(cataloged_date, 1))?;
     submodule_marc
         .define_singleton_method("current_location_code", function!(current_location_code, 1))?;
     submodule_marc.define_singleton_method("format_facets", function!(format_facets, 1))?;
@@ -97,6 +98,11 @@ fn author_roles_from_marc_breaker(
             format!("Found error {} while serializing author roles", err),
         )
     })
+}
+
+fn cataloged_date(ruby: &Ruby, record_string: String) -> Result<Option<String>, magnus::Error> {
+    let record = get_record(ruby, &record_string)?;
+    Ok(date::cataloged_date(&record))
 }
 
 #[cfg(test)]

--- a/lib/bibdata_rs/src/marc/variable_length_field.rs
+++ b/lib/bibdata_rs/src/marc/variable_length_field.rs
@@ -1,5 +1,23 @@
 use itertools::Itertools;
-use marctk::{Field, Subfield};
+use marctk::{Field, Record, Subfield};
+
+pub fn extract_field_values_by<'a, C, E, T>(
+    record: &'a Record,
+    criteria: C,
+    extractor: E,
+) -> impl Iterator<Item = T>
+where
+    C: 'a + Fn(&'a Field) -> bool,
+    E: 'a + Fn(&'a Field) -> Option<T>,
+{
+    record.fields().iter().filter_map(move |field| {
+        if criteria(field) {
+            extractor(field)
+        } else {
+            None
+        }
+    })
+}
 
 pub fn join_all_subfields(field: &Field) -> String {
     join_subfields(field.subfields().iter())

--- a/marc_to_solr/lib/princeton_marc.rb
+++ b/marc_to_solr/lib/princeton_marc.rb
@@ -439,10 +439,6 @@ def alma_852(record)
   record.fields('852').select { |f| alma_code_start_22?(f['8']) }
 end
 
-def alma_876(record)
-  record.fields('876').select { |f| alma_code_start_22?(f['0']) }
-end
-
 def alma_951_active(record)
   alma_951 = record.fields('951').select { |f| alma_code_start_53?(f['8']) }
   alma_951&.select { |f| f['a'] == 'Available' }
@@ -454,11 +450,6 @@ end
 
 def alma_954(record)
   record.fields('954').select { |f| alma_code_start_53?(f['a']) }
-end
-
-def alma_950(record)
-  field_950_a = record.fields('950').select { |f| %w[true false].include?(f['a']) }
-  field_950_a.map { |f| f['b'] }.first if field_950_a.present?
 end
 
 def process_holdings(record, marc_breaker)

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -329,23 +329,8 @@ end
 # Bibliographic Enrichment -> Create date subfield 950b
 # Physical Items Enrichment -> Create date subfield 876d
 # Electronic Inventory Enrichment -> Activation date subfield 951w
-to_field 'cataloged_tdt' do |record, accumulator|
-  extractor_doc_id = MarcExtractor.cached('001')
-  doc_id = extractor_doc_id.extract(record).first
-  unless /^SCSB-\d+/.match?(doc_id)
-    cataloged_date = if alma_876(record)&.any? { |f| f['d'] }
-                       alma_876(record).map { |f| f['d'] }.sort.first
-                     elsif alma_951_active(record)&.any? { |f| f['w'] }
-                       alma_951_active(record).map { |f| f['w'] }.compact.sort.first
-                     else
-                       alma_950(record)
-                     end
-    begin
-      accumulator[0] = Time.parse(cataloged_date).utc.strftime('%Y-%m-%dT%H:%M:%SZ') unless cataloged_date.nil?
-    rescue StandardError
-      logger.error "#{record['001']} - error parsing cataloged date #{cataloged_date}"
-    end
-  end
+to_field 'cataloged_tdt' do |_record, accumulator, context|
+  accumulator[0] = BibdataRs::Marc.cataloged_date(context.clipboard[:marc_breaker])
 end
 
 # format - allow multiple - "first" one is used for thumbnail

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -199,55 +199,6 @@ describe 'From traject_config.rb', :indexing do
       end
     end
 
-    describe 'the cataloged_date from publishing job' do
-      describe 'the date cataloged facets' do
-        context 'When the record has 950, 876 and 951 fields' do
-          it 'indexes the oldest 876d field' do
-            marc_record = fixture_record('99299653506421_custom_951')
-            fields_876_sorted = alma_876(marc_record).map { |f| f['d'] }.sort
-            expect(marc_record['876']['d']).to be_truthy
-            expect(marc_record['951']['w']).to be_truthy
-            expect(marc_record['950']['b']).to be_truthy
-            expect(Time.parse(@added_custom_951['cataloged_tdt'].first)).to eq Time.parse(fields_876_sorted.first).utc
-          end
-        end
-
-        context 'When the record has only a 950b field' do
-          it 'indexes the 950b field' do
-            record = fixture_record('9939339473506421')
-            expect(record['950']['b']).to be_truthy
-            expect(record['876']).to be_falsey
-            expect(record['951']).to be_falsey
-            expect(Time.parse(@sample42['cataloged_tdt'].first)).to eq Time.parse(record['950']['b']).utc
-          end
-        end
-
-        context 'When the record fails to parse the time' do
-          it 'logs the error and moves on' do
-            allow(Time).to receive(:parse).and_raise(ArgumentError)
-            expect { @indexer.map_record(fixture_record('9992320213506421')) }.not_to raise_error
-          end
-        end
-      end
-
-      context 'When it is a SCSB partner record' do
-        it 'does not have a date cataloged facet' do
-          expect(@scsb_nypl['cataloged_tdt']).to be_nil
-        end
-      end
-
-      context 'When it is an electronic record' do
-        it 'indexes the 951w field' do
-          record = fixture_record('99122424622606421')
-          indexed_record = @indexer.map_record(record)
-          expect(record['951']['w']).to be_truthy
-          expect(record['876']).to be_falsey
-          expect(record['950']).to be_truthy
-          expect(Time.parse(indexed_record['cataloged_tdt'].first)).to eq Time.parse(record['951']['w']).utc
-        end
-      end
-    end
-
     describe 'summary_note_display' do
       it 'returns the summary_note_display field' do
         record = fixture_record('9948545023506421')


### PR DESCRIPTION
It is ever so slightly faster than Ruby:

```
require 'benchmark/ips'
record = MARC::XMLReader.new('spec/fixtures/marc_to_solr/9939238033506421.mrx').first
marc_breaker = MarcBreaker.break(record)
Benchmark.ips do |x|
  x.report("ruby") { cataloged_tdt_impl(record) }
  x.report("rust") { BibdataRs::Marc.cataloged_date(marc_breaker) }
  x.compare!
end
```

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
                ruby     4.156k i/100ms
                rust     4.717k i/100ms
Calculating -------------------------------------
                ruby     41.640k (± 2.3%) i/s   (24.02 μs/i) -    211.956k in   5.093006s
                rust     47.069k (± 0.9%) i/s   (21.25 μs/i) -    235.850k in   5.011126s

Comparison:
                rust:    47069.3 i/s
                ruby:    41640.0 i/s - 1.13x  slower
```