### PR TITLE
Re-implement siku_subjects_display in Rust

### DIFF
--- a/lib/bibdata_rs/benches/marc_bench.rs
+++ b/lib/bibdata_rs/benches/marc_bench.rs
@@ -1,5 +1,8 @@
 use bibdata_rs::{
-    marc::{call_number::call_number_labels_for_display, date::cataloged_date, genre::genres},
+    marc::{
+        call_number::call_number_labels_for_display, date::cataloged_date, genre::genres,
+        subject::siku_subjects_display,
+    },
     solr::AuthorRoles,
 };
 use criterion::{Criterion, criterion_group, criterion_main};
@@ -51,12 +54,27 @@ fn cataloged_date_benchmark(c: &mut Criterion) {
     });
 }
 
+fn siku_subjects_display_benchmark(c: &mut Criterion) {
+    let record = fixture_record("../../spec/fixtures/marc_to_solr/9918309193506421.mrx");
+    c.bench_function("siku_subjects_display", |b| {
+        b.iter(|| {
+            let mut subjects = siku_subjects_display(&record);
+            assert!(subjects.next().is_some());
+            assert!(subjects.next().is_some());
+            assert!(subjects.next().is_some());
+            assert!(subjects.next().is_some());
+            assert!(subjects.next().is_none());
+        })
+    });
+}
+
 criterion_group!(
     benches,
     author_role_benchmark,
     call_number_benchmark,
     cataloged_date_benchmark,
-    genre_facet_benchmark
+    genre_facet_benchmark,
+    siku_subjects_display_benchmark
 );
 criterion_main!(benches);
 

--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -57,6 +57,8 @@ pub fn register_ruby_methods(parent_module: &RModule) -> Result<(), magnus::Erro
     submodule_marc
         .define_singleton_method("recap_partner_notes", function!(recap_partner_notes, 1))?;
     submodule_marc.define_singleton_method("strip_non_numeric", function!(strip_non_numeric, 1))?;
+    submodule_marc
+        .define_singleton_method("siku_subjects_display", function!(siku_subjects_display, 1))?;
     submodule_marc.define_singleton_method("subjects_cjk", function!(subjects_cjk, 1))?;
     submodule_marc
         .define_module_function("trim_punctuation", function!(trim_punctuation_owned, 1))?;
@@ -103,6 +105,11 @@ fn author_roles_from_marc_breaker(
 fn cataloged_date(ruby: &Ruby, record_string: String) -> Result<Option<String>, magnus::Error> {
     let record = get_record(ruby, &record_string)?;
     Ok(date::cataloged_date(&record))
+}
+
+fn siku_subjects_display(ruby: &Ruby, record_string: String) -> Result<Vec<String>, magnus::Error> {
+    let record = get_record(ruby, &record_string)?;
+    Ok(subject::siku_subjects_display(&record).collect())
 }
 
 #[cfg(test)]

--- a/lib/bibdata_rs/src/marc/string_normalize.rs
+++ b/lib/bibdata_rs/src/marc/string_normalize.rs
@@ -1,4 +1,4 @@
-use std::sync::LazyLock;
+use std::{borrow::Cow, sync::LazyLock};
 
 use regex::Regex;
 
@@ -15,17 +15,27 @@ pub fn trim_punctuation(string: &str) -> String {
     static TRAILING_PERIOD: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"( *\w{3,}) *\.*\z").unwrap());
 
-    // single square bracket characters if they are the start and/or end
-    //   chars and there are no internal square brackets.
-    static SINGLE_SQUARE_BRACKET: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"\A\[?([^\[\]]+)\]?\z").unwrap());
-
     let no_trailing = TRAILING.replace(string, "");
     let no_trailing_period = TRAILING_PERIOD.replace(&no_trailing, "$1");
-    SINGLE_SQUARE_BRACKET
-        .replace(&no_trailing_period, "$1")
+    trim_starting_and_ending_brackets(&no_trailing_period)
         .trim()
         .to_owned()
+}
+
+fn trim_starting_and_ending_brackets(original: &str) -> Cow<'_, str> {
+    let trimmed = original
+        .strip_prefix('[')
+        .map(|start_trimmed| start_trimmed.strip_suffix(']').unwrap_or(start_trimmed))
+        .or(original.strip_suffix(']'));
+    match trimmed {
+        // Make sure the string does not contain any remaining [], since they might have
+        // been paired with the ones we just removed, in which case the trimmed string
+        // won't make sense and we should return the original.
+        Some(trimmed) if !trimmed.contains('[') && !trimmed.contains(']') => {
+            Cow::Owned(trimmed.to_owned())
+        }
+        _ => Cow::Borrowed(original),
+    }
 }
 
 pub fn strip_non_numeric(string: &str) -> String {

--- a/lib/bibdata_rs/src/marc/subject.rs
+++ b/lib/bibdata_rs/src/marc/subject.rs
@@ -1,17 +1,50 @@
 use itertools::Itertools;
-use marctk::Record;
+use marctk::{Field, Record, Subfield};
 
-use crate::marc::trim_punctuation;
+use crate::marc::{
+    trim_punctuation,
+    variable_length_field::{extract_field_values_by, multiscript_tag_eq},
+};
+
+const SEPARATOR: char = '—';
+
+enum SubjectVocabulary {
+    Icpsr,
+    Siku,
+    UnknownVocabulary,
+    VocabularyNotSpecified,
+}
+
+impl From<&Field> for SubjectVocabulary {
+    // can convert a MARC 650 (Topic Subject) field into a SubjectVocabulary
+    fn from(field: &Field) -> Self {
+        if field.ind2() == "7" {
+            match field.first_subfield("2") {
+                Some(subfield) => Self::from(subfield.content()),
+                _ => Self::VocabularyNotSpecified,
+            }
+        } else {
+            Self::UnknownVocabulary
+        }
+    }
+}
+
+impl From<&str> for SubjectVocabulary {
+    fn from(value: &str) -> Self {
+        match value.trim() {
+            "icpsr" => Self::Icpsr,
+            "sk" => Self::Siku,
+            "skbb" => Self::Siku,
+            _ => Self::UnknownVocabulary,
+        }
+    }
+}
 
 pub fn icpsr_subjects(record: &Record) -> Vec<String> {
     record
         .get_fields("650")
         .iter()
-        .filter(|field| {
-            field
-                .first_subfield("2")
-                .is_some_and(|subfield| subfield.content().trim() == "icpsr")
-        })
+        .filter(|field| matches!(SubjectVocabulary::from(**field), SubjectVocabulary::Icpsr))
         .map(|field| {
             field
                 .get_subfields("a")
@@ -21,6 +54,43 @@ pub fn icpsr_subjects(record: &Record) -> Vec<String> {
         })
         .map(|heading| trim_punctuation(&heading))
         .collect()
+}
+
+pub fn siku_subjects_display(record: &Record) -> impl Iterator<Item = String> {
+    extract_field_values_by(
+        record,
+        |field| {
+            multiscript_tag_eq(field, "650")
+                && matches!(SubjectVocabulary::from(field), SubjectVocabulary::Siku)
+        },
+        |field| {
+            Some(hierarchical_heading(
+                field,
+                &["a", "b", "c", "v", "x", "y", "z"],
+                |subfield| ["t", "v", "x", "y", "z"].contains(&subfield.code()),
+            ))
+        },
+    )
+}
+
+// Creates a concatenated heading with separators before the desired subfields, for example:
+// German language—Foreign words and phrases
+fn hierarchical_heading(
+    field: &Field,
+    subfields_to_include: &[&str],
+    place_separator_before: fn(&Subfield) -> bool,
+) -> String {
+    field
+        .subfields()
+        .iter()
+        .filter(|subfield| subfields_to_include.contains(&subfield.code()))
+        .fold(String::default(), |mut accumulator, subfield| {
+            if place_separator_before(subfield) {
+                accumulator.push(SEPARATOR);
+            }
+            accumulator.push_str(&trim_punctuation(subfield.content()));
+            accumulator
+        })
 }
 
 #[cfg(test)]
@@ -38,6 +108,22 @@ mod tests {
         assert_eq!(
             icpsr_subjects(&record),
             ["Auto theft".to_owned(), "Economic indicators".to_owned()]
+        );
+    }
+
+    #[test]
+    fn it_can_concatenate_a_hierarchical_heading() {
+        let record =
+            Record::from_breaker("=650 \0 $a German language $x Grammar, Historical.").unwrap();
+        let field = record
+            .fields()
+            .iter()
+            .filter(|field| field.tag() == "650")
+            .next()
+            .unwrap();
+        assert_eq!(
+            hierarchical_heading(field, &["a", "x"], |subfield| subfield.code() == "x"),
+            "German language—Grammar, Historical"
         );
     }
 }

--- a/lib/bibdata_rs/src/marc/variable_length_field.rs
+++ b/lib/bibdata_rs/src/marc/variable_length_field.rs
@@ -19,6 +19,14 @@ where
     })
 }
 
+pub fn multiscript_tag_eq(field: &Field, tag: &str) -> bool {
+    field.tag() == tag
+        || (field.tag() == "880"
+            && field
+                .first_subfield("6")
+                .is_some_and(|subfield| subfield.content().trim().starts_with(tag)))
+}
+
 pub fn join_all_subfields(field: &Field) -> String {
     join_subfields(field.subfields().iter())
 }

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -846,9 +846,8 @@ to_field 'lc_subject_include_archaic_search_terms_index' do |record, accumulator
   accumulator.replace(combined_subjects)
 end
 
-to_field 'siku_subject_display' do |record, accumulator|
-  subjects = process_hierarchy(record, '650|*7|abcvxyz') { |field| siku_heading? field }
-  accumulator.replace(subjects)
+to_field 'siku_subject_display' do |_record, accumulator, context|
+  accumulator.replace(BibdataRs::Marc.siku_subjects_display(context.clipboard[:marc_breaker]))
 end
 
 # used for the Browse lists and hierarchical subject facet


### PR DESCRIPTION
This implementation is about the same speed as the Ruby implementation.

This commit also includes an optimization for the trim_punctuation function -- we can avoid a regular expression in favor of Rust's string methods like strip_prefix.