### PR TITLE
Exclude rust and js-related directories from rubocop check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,11 +15,14 @@ AllCops:
     - 'bin/*'
     - 'config/deploy.rb'
     - 'config/initializers/*'
+    - 'lib/bibdata_rs/src/**/*'
     - 'vendor/**/*'
     - 'tmp/**/*'
     - 'marc_to_solr/translation_maps/location_display.rb'
     - 'marc_to_solr/translation_maps/locations.rb'
     - 'marc_to_solr/translation_maps/holding_library.rb'
+    - 'node_modules/**/*'
+    - 'target/**/*'
 
 FactoryBot/AssociationStyle:
   Enabled: false


### PR DESCRIPTION
On main, running `bundle exec rubocop` takes 33 seconds for me. With this branch, it takes 3 seconds.