### PR TITLE
Refactor: use extract_field_values_by as a method rather than a function

### DIFF
--- a/lib/bibdata_rs/src/marc.rs
+++ b/lib/bibdata_rs/src/marc.rs
@@ -8,6 +8,7 @@ pub mod cjk;
 pub mod contributors;
 pub mod control_field;
 pub mod date;
+pub mod extract_values;
 pub mod fixed_field;
 pub mod genre;
 pub mod identifier;

--- a/lib/bibdata_rs/src/marc/date.rs
+++ b/lib/bibdata_rs/src/marc/date.rs
@@ -5,8 +5,8 @@ use parse_datetime::parse_datetime_at_date;
 
 use crate::marc::{
     alma::{AlmaElectronicPortfolio, AlmaHoldingId},
+    extract_values::ExtractValues,
     scsb::is_scsb,
-    variable_length_field::extract_field_values_by,
 };
 
 pub fn cataloged_date(record: &Record) -> Option<String> {
@@ -14,36 +14,36 @@ pub fn cataloged_date(record: &Record) -> Option<String> {
         return None;
     }
 
-    let item_edit_date = extract_field_values_by(
-        record,
-        |field| {
-            field.tag() == "876"
-                && field
-                    .first_subfield("0")
-                    .is_some_and(|subfield| AlmaHoldingId::from(subfield).is_valid())
-        },
-        |field| field.first_subfield("d").map(Subfield::content),
-    )
-    .sorted();
+    let item_edit_date = record
+        .extract_field_values_by(
+            |field| {
+                field.tag() == "876"
+                    && field
+                        .first_subfield("0")
+                        .is_some_and(|subfield| AlmaHoldingId::from(subfield).is_valid())
+            },
+            |field| field.first_subfield("d").map(Subfield::content),
+        )
+        .sorted();
 
-    let electronic_edit_date = extract_field_values_by(
-        record,
-        |field| {
-            matches!(
-                AlmaElectronicPortfolio::try_from(field),
-                Ok(AlmaElectronicPortfolio::Active)
-            )
-        },
-        |field| field.first_subfield("w").map(Subfield::content),
-    )
-    .sorted();
+    let electronic_edit_date = record
+        .extract_field_values_by(
+            |field| {
+                matches!(
+                    AlmaElectronicPortfolio::try_from(field),
+                    Ok(AlmaElectronicPortfolio::Active)
+                )
+            },
+            |field| field.first_subfield("w").map(Subfield::content),
+        )
+        .sorted();
 
-    let record_edit_date = extract_field_values_by(
-        record,
-        |field| field.tag() == "950",
-        |field| field.first_subfield("b").map(Subfield::content),
-    )
-    .sorted();
+    let record_edit_date = record
+        .extract_field_values_by(
+            |field| field.tag() == "950",
+            |field| field.first_subfield("b").map(Subfield::content),
+        )
+        .sorted();
 
     item_edit_date
         .chain(electronic_edit_date)

--- a/lib/bibdata_rs/src/marc/extract_values.rs
+++ b/lib/bibdata_rs/src/marc/extract_values.rs
@@ -1,0 +1,24 @@
+use marctk::{Field, Record};
+
+pub trait ExtractValues<'a> {
+    fn extract_field_values_by<C, E, T>(self, criteria: C, extractor: E) -> impl Iterator<Item = T>
+    where
+        C: Fn(&'a Field) -> bool,
+        E: Fn(&'a Field) -> Option<T>;
+}
+
+impl<'a> ExtractValues<'a> for &'a Record {
+    fn extract_field_values_by<C, E, T>(self, criteria: C, extractor: E) -> impl Iterator<Item = T>
+    where
+        C: Fn(&'a Field) -> bool,
+        E: Fn(&'a Field) -> Option<T>,
+    {
+        self.fields().iter().filter_map(move |field| {
+            if criteria(field) {
+                extractor(field)
+            } else {
+                None
+            }
+        })
+    }
+}

--- a/lib/bibdata_rs/src/marc/subject.rs
+++ b/lib/bibdata_rs/src/marc/subject.rs
@@ -2,8 +2,7 @@ use itertools::Itertools;
 use marctk::{Field, Record, Subfield};
 
 use crate::marc::{
-    trim_punctuation,
-    variable_length_field::{extract_field_values_by, multiscript_tag_eq},
+    extract_values::ExtractValues, trim_punctuation, variable_length_field::multiscript_tag_eq,
 };
 
 const SEPARATOR: char = '—';
@@ -57,8 +56,7 @@ pub fn icpsr_subjects(record: &Record) -> Vec<String> {
 }
 
 pub fn siku_subjects_display(record: &Record) -> impl Iterator<Item = String> {
-    extract_field_values_by(
-        record,
+    record.extract_field_values_by(
         |field| {
             multiscript_tag_eq(field, "650")
                 && matches!(SubjectVocabulary::from(field), SubjectVocabulary::Siku)

--- a/lib/bibdata_rs/src/marc/variable_length_field.rs
+++ b/lib/bibdata_rs/src/marc/variable_length_field.rs
@@ -1,23 +1,5 @@
 use itertools::Itertools;
-use marctk::{Field, Record, Subfield};
-
-pub fn extract_field_values_by<'a, C, E, T>(
-    record: &'a Record,
-    criteria: C,
-    extractor: E,
-) -> impl Iterator<Item = T>
-where
-    C: 'a + Fn(&'a Field) -> bool,
-    E: 'a + Fn(&'a Field) -> Option<T>,
-{
-    record.fields().iter().filter_map(move |field| {
-        if criteria(field) {
-            extractor(field)
-        } else {
-            None
-        }
-    })
-}
+use marctk::{Field, Subfield};
 
 pub fn multiscript_tag_eq(field: &Field, tag: &str) -> bool {
     field.tag() == tag


### PR DESCRIPTION
I think it's a little more ergonomic as a method. That way, we can say:

```
record.extract_field_values_by(|field| field.tag == '500', join_all_subfields)
```

rather than:

```
extract_field_values_by(record, |field| field.tag == '500', join_all_subfields)
```