### PR TITLE
Re-implement some of AugmentTheSubject in rust

### DIFF
--- a/lib/bibdata_rs/src/marc.rs
+++ b/lib/bibdata_rs/src/marc.rs
@@ -12,6 +12,7 @@ pub mod extract_values;
 pub mod fixed_field;
 pub mod genre;
 pub mod identifier;
+pub mod indigenous_studies;
 pub mod language;
 pub mod note;
 pub mod publication;

--- a/lib/bibdata_rs/src/marc/indigenous_studies.rs
+++ b/lib/bibdata_rs/src/marc/indigenous_studies.rs
@@ -1,0 +1,83 @@
+use crate::marc::subject::SEPARATOR;
+use serde::{Deserialize, Deserializer};
+use std::{collections::HashSet, sync::LazyLock};
+
+// This file can be re-created using `bundle exec rake augment:recreate_fixtures`
+const MAIN_TERMS_JSON: &str =
+    include_str!("../../../../marc_to_solr/lib/augment_the_subject/standalone_subfield_a.json");
+// This file must be created by hand from file provided by metadata librarians
+const SUBFIELDS_JSON: &str =
+    include_str!("../../../../marc_to_solr/lib/augment_the_subject/standalone_subfield_x.json");
+
+fn normalize(raw: &str) -> String {
+    raw.to_lowercase()
+}
+
+// Normalize terms as we deserialize, so that we don't have to do it for every comparison
+fn normalize_lcsh<'de, D>(deserializer: D) -> Result<HashSet<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashSet<String> = HashSet::deserialize(deserializer)?;
+    Ok(raw.iter().map(|str| normalize(str)).collect())
+}
+
+#[derive(Deserialize)]
+struct LcshIndigenousStudiesMainTerms {
+    #[serde(deserialize_with = "normalize_lcsh")]
+    standalone_subfield_a: HashSet<String>,
+}
+
+impl LcshIndigenousStudiesMainTerms {
+    pub fn contains(&self, term: &str) -> bool {
+        self.standalone_subfield_a.contains(term)
+    }
+}
+
+#[derive(Deserialize)]
+struct LcshIndigenousStudiesSubfields {
+    #[serde(deserialize_with = "normalize_lcsh")]
+    standalone_subfield_x: HashSet<String>,
+}
+
+impl LcshIndigenousStudiesSubfields {
+    pub fn contains(&self, term: &str) -> bool {
+        self.standalone_subfield_x.contains(term)
+    }
+}
+
+static LCSH_MAIN_TERMS: LazyLock<LcshIndigenousStudiesMainTerms> = LazyLock::new(|| {
+    serde_json::from_str(MAIN_TERMS_JSON)
+        .expect("Could not parse AugmentTheSubject standalone_subfield_a file")
+});
+
+static LCSH_SUBFIELDS: LazyLock<LcshIndigenousStudiesSubfields> = LazyLock::new(|| {
+    serde_json::from_str(SUBFIELDS_JSON)
+        .expect("Could not parse AugmentTheSubject standalone_subfield_x file")
+});
+
+pub fn has_subfield_related_to_indigenous_studies(term: &str) -> bool {
+    term.split(SEPARATOR)
+        .any(|subfield| LCSH_SUBFIELDS.contains(&subfield.to_lowercase()))
+}
+
+pub fn has_main_term_related_to_indigenous_studies(term: &str) -> bool {
+    term.split(SEPARATOR).next().is_some_and(|main_term| {
+        LCSH_MAIN_TERMS.contains(normalize(main_term).trim_end_matches('.'))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_has_the_expected_number_of_main_terms() {
+        assert_eq!(LCSH_MAIN_TERMS.standalone_subfield_a.len(), 5599);
+    }
+
+    #[test]
+    fn it_has_the_expected_number_of_subfields() {
+        assert_eq!(LCSH_SUBFIELDS.standalone_subfield_x.len(), 26);
+    }
+}

--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -27,6 +27,14 @@ pub fn register_ruby_methods(parent_module: &RModule) -> Result<(), magnus::Erro
         .define_singleton_method("current_location_code", function!(current_location_code, 1))?;
     submodule_marc.define_singleton_method("format_facets", function!(format_facets, 1))?;
     submodule_marc.define_singleton_method("genres", function!(genres, 1))?;
+    submodule_marc.define_singleton_method(
+        "has_main_term_related_to_indigenous_studies",
+        function!(has_main_term_related_to_indigenous_studies, 1),
+    )?;
+    submodule_marc.define_singleton_method(
+        "has_subfield_related_to_indigenous_studies",
+        function!(has_subfield_related_to_indigenous_studies, 1),
+    )?;
     submodule_marc.define_singleton_method("holding_id", function!(holding_id, 2))?;
     submodule_marc.define_module_function(
         "icpsr_subjects",
@@ -110,6 +118,14 @@ fn cataloged_date(ruby: &Ruby, record_string: String) -> Result<Option<String>, 
 fn siku_subjects_display(ruby: &Ruby, record_string: String) -> Result<Vec<String>, magnus::Error> {
     let record = get_record(ruby, &record_string)?;
     Ok(subject::siku_subjects_display(&record).collect())
+}
+
+fn has_subfield_related_to_indigenous_studies(term: String) -> Result<bool, magnus::Error> {
+    Ok(indigenous_studies::has_subfield_related_to_indigenous_studies(&term))
+}
+
+fn has_main_term_related_to_indigenous_studies(term: String) -> Result<bool, magnus::Error> {
+    Ok(indigenous_studies::has_main_term_related_to_indigenous_studies(&term))
 }
 
 #[cfg(test)]

--- a/lib/bibdata_rs/src/marc/subject.rs
+++ b/lib/bibdata_rs/src/marc/subject.rs
@@ -5,7 +5,7 @@ use crate::marc::{
     extract_values::ExtractValues, trim_punctuation, variable_length_field::multiscript_tag_eq,
 };
 
-const SEPARATOR: char = '—';
+pub const SEPARATOR: char = '—';
 
 enum SubjectVocabulary {
     Icpsr,

--- a/marc_to_solr/lib/augment_the_subject.rb
+++ b/marc_to_solr/lib/augment_the_subject.rb
@@ -5,42 +5,14 @@
 class AugmentTheSubject
   LCSH_TERMS_CSV_FILE = File.join(File.dirname(__FILE__), 'augment_the_subject', 'indigenous_studies.csv')
   # Can be re-created using `bundle exec rake augment:recreate_fixtures`
-  LCSH_STANDALONE_A_FILE = File.join(File.dirname(__FILE__), 'augment_the_subject', 'standalone_subfield_a.json')
-  # Must be created by hand from file provided by metadata librarians
-  LCSH_STANDALONE_X_FILE = File.join(File.dirname(__FILE__), 'augment_the_subject', 'standalone_subfield_x.json')
-  # Can be re-created using `bundle exec rake augment:recreate_fixtures`
   LCSH_REQUIRED_SUBFIELDS = File.join(File.dirname(__FILE__), 'augment_the_subject', 'indigenous_studies_required.json')
 
   ##
   # Ensure the needed config files exist
   def initialize
     raise "Cannot find lcsh csv file at #{LCSH_TERMS_CSV_FILE}" unless File.exist?(LCSH_TERMS_CSV_FILE)
-    unless File.exist?(LCSH_STANDALONE_A_FILE)
-      raise "Cannot find lcsh standalone subfield a file at #{LCSH_STANDALONE_A_FILE}"
-    end
-    unless File.exist?(LCSH_STANDALONE_X_FILE)
-      raise "Cannot find lcsh standalone subfield x file at #{LCSH_STANDALONE_X_FILE}"
-    end
     unless File.exist?(LCSH_REQUIRED_SUBFIELDS)
       raise "Cannot find lcsh required subfields file at #{LCSH_REQUIRED_SUBFIELDS}"
-    end
-  end
-
-  def standalone_subfield_a_terms
-    @standalone_subfield_a_terms ||= begin
-      parsed_json = JSON.parse(File.read(LCSH_STANDALONE_A_FILE), { symbolize_names: true })
-      parsed_json[:standalone_subfield_a].to_set do |term|
-        normalize(term)
-      end
-    end
-  end
-
-  def standalone_subfield_x_terms
-    @standalone_subfield_x_terms ||= begin
-      parsed_json = JSON.parse(File.read(LCSH_STANDALONE_X_FILE), { symbolize_names: true })
-      parsed_json[:standalone_subfield_x].map do |term|
-        normalize(term)
-      end
     end
   end
 
@@ -99,17 +71,14 @@ class AugmentTheSubject
   # be assigned an Indigenous Studies term even though that entire term doesn't
   # appear in our terms list.
   def subfield_a_match?(term)
-    subfield_a = normalize(term.split(SEPARATOR).first).gsub(/\.$/, '')
-    standalone_subfield_a_terms.include?(subfield_a)
+    BibdataRs::Marc.has_main_term_related_to_indigenous_studies(term)
   end
 
   ##
   # For some subfield terms, only a single subfield needs to match.
   # E.g., any subject term that includes "Indian authors" should be assigned Indigenous Studies
   def subfield_x_match?(term)
-    subfields = term.split(SEPARATOR)
-    subfields = subfields.map { |subfield| normalize(subfield) }
-    !!standalone_subfield_x_terms.intersect?(subfields)
+    BibdataRs::Marc.has_subfield_related_to_indigenous_studies(term)
   end
 
   ##

--- a/spec/marc_to_solr/lib/augment_the_subject_spec.rb
+++ b/spec/marc_to_solr/lib/augment_the_subject_spec.rb
@@ -16,11 +16,6 @@ RSpec.describe AugmentTheSubject, :indexing do
       expect(subfields[:standalone_subfield_a].length).to eq 5599
     end
 
-    it 'caches a list of terms from the json' do
-      expect(ats.standalone_subfield_a_terms).to be
-      expect(ats.standalone_subfield_a_terms.length).to eq 5599
-    end
-
     context 'mismatched capitalization' do
       let(:subject_term) { 'Abipon Language' }
 
@@ -39,11 +34,6 @@ RSpec.describe AugmentTheSubject, :indexing do
   end
 
   context "subfield x's that match by themselves" do
-    it 'caches a list of terms from the json' do
-      expect(ats.standalone_subfield_x_terms).to be
-      expect(ats.standalone_subfield_x_terms.length).to eq 26
-    end
-
     context 'only the subfield x is relevant' do
       let(:subject_terms) { ["Whatever#{SEPARATOR}Indian authors#{SEPARATOR}History"] }
 


### PR DESCRIPTION
This triples the speed of AugmentTheSubject in the worst case (i.e. no subjects match), which is also the most common case:

```
require 'benchmark/ips'
# Record that contains no indigenous studies headings
record = MARC::XMLReader.new('spec/fixtures/marc_to_solr/9918309193506421.mrx').first
augment_the_subject = AugmentTheSubject.new
headings = process_hierarchy(record, '600|*0|abcdfklmnopqrtvxyz:610|*0|abfklmnoprstvxyz:611|*0|abcdefgklnpqstvxyz:630|*0|adfgklmnoprstvxyz:650|*0|abcvxyz:651|*0|avxyz')
Benchmark.ips do |x|
  x.report { augment_the_subject.add_indigenous_studies(headings) }
end
```

```
Before
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
                        21.499k i/100ms
Calculating -------------------------------------
                        214.290k (± 1.1%) i/s    (4.67 μs/i) -      1.075M in   5.017005s

After
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
                        61.096k i/100ms
Calculating -------------------------------------
                        616.234k (± 0.9%) i/s    (1.62 μs/i) -      3.116M in   5.056770s
```

Helps with #2871