### PR TITLE
Re-implement publication_citation_display in Rust

### DIFF
--- a/lib/bibdata_rs/benches/marc_bench.rs
+++ b/lib/bibdata_rs/benches/marc_bench.rs
@@ -1,7 +1,7 @@
 use bibdata_rs::{
     marc::{
         call_number::call_number_labels_for_display, date::cataloged_date, genre::genres,
-        subject::siku_subjects_display,
+        publication::pub_citation_display, subject::siku_subjects_display,
     },
     solr::AuthorRoles,
 };
@@ -54,6 +54,18 @@ fn cataloged_date_benchmark(c: &mut Criterion) {
     });
 }
 
+fn publisher_citation_benchmark(c: &mut Criterion) {
+    let record = fixture_record("../../spec/fixtures/marc_to_solr/9939238033506421.mrx");
+    c.bench_function("publisher_citation", |b| {
+        b.iter(|| {
+            assert_eq!(
+                pub_citation_display(&record).collect::<Vec<String>>(),
+                vec!["China: s.n.".to_string()]
+            );
+        })
+    });
+}
+
 fn siku_subjects_display_benchmark(c: &mut Criterion) {
     let record = fixture_record("../../spec/fixtures/marc_to_solr/9918309193506421.mrx");
     c.bench_function("siku_subjects_display", |b| {
@@ -74,6 +86,7 @@ criterion_group!(
     call_number_benchmark,
     cataloged_date_benchmark,
     genre_facet_benchmark,
+    publisher_citation_benchmark,
     siku_subjects_display_benchmark
 );
 criterion_main!(benches);

--- a/lib/bibdata_rs/src/marc.rs
+++ b/lib/bibdata_rs/src/marc.rs
@@ -206,14 +206,6 @@ pub fn identifiers_of_all_versions(
     Ok(identifier::identifiers_of_all_versions(&record))
 }
 
-pub fn publication_statements(
-    ruby: &Ruby,
-    record_string: String,
-) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(ruby, &record_string)?;
-    Ok(publication::publication_statements(&record).collect())
-}
-
 pub fn strip_non_numeric(string: String) -> String {
     string_normalize::strip_non_numeric(&string)
 }

--- a/lib/bibdata_rs/src/marc/publication.rs
+++ b/lib/bibdata_rs/src/marc/publication.rs
@@ -1,5 +1,10 @@
 // This module handles publication-related MARC fields like 260 and 264
 
+use crate::marc::{
+    extract_values::ExtractValues, trim_punctuation,
+    variable_length_field::latin_or_non_latin_tag_eq,
+};
+
 use super::{
     fixed_field::dates::{DateType, EndDate},
     variable_length_field::{join_all_subfields, join_subfields},
@@ -7,11 +12,30 @@ use super::{
 use itertools::Itertools;
 use marctk::Record;
 
-pub fn publication_statements(record: &Record) -> impl Iterator<Item = String> + use<'_> {
+pub fn pub_created_display(record: &Record) -> impl Iterator<Item = String> + use<'_> {
     statements_from_260(record)
         .chain(statements_from_parallel_260(record))
         .chain(statements_from_264(record))
         .chain(statements_from_parallel_264(record))
+}
+
+pub fn pub_citation_display(record: &Record) -> impl Iterator<Item = String> {
+    record
+        .extract_field_values_by(latin_or_non_latin_tag_eq(&["260", "264"]), |field| {
+            let place = field.first_subfield("a");
+            let name = field.first_subfield("b");
+            match (place, name) {
+                (Some(place), None) => Some(trim_punctuation(place.content())),
+                (None, Some(name)) => Some(trim_punctuation(name.content())),
+                (Some(place), Some(name)) => Some(format!(
+                    "{}: {}",
+                    trim_punctuation(place.content()),
+                    trim_punctuation(name.content())
+                )),
+                _ => None,
+            }
+        })
+        .unique()
 }
 
 fn statements_from_264(record: &Record) -> impl Iterator<Item = String> + use<'_> {
@@ -79,7 +103,7 @@ mod tests {
     fn it_gets_publication_statements_from_260() {
         let record =
             Record::from_breaker("=260 \\ $aMilano : $b Armenia Editore, $c 1976-1979.").unwrap();
-        let mut statements = publication_statements(&record);
+        let mut statements = pub_created_display(&record);
 
         assert_eq!(
             statements.next(),
@@ -95,7 +119,7 @@ mod tests {
 =880 00 $6245-01$a2006-2025 서울, 도시건축 혁신의 기록 : 일상을 빛내는 서울의 도시건축 프로젝트 66.
 =260 \\ $6880-02$a Sŏul: $b Sŏul T'ŭkpyŏlsi, $c 2025.
 =880 \\ $6260-02$a 서울: $b 서울특별시, $c 2025.").unwrap();
-        let mut statements = publication_statements(&record);
+        let mut statements = pub_created_display(&record);
 
         assert_eq!(
             statements.next(),
@@ -115,7 +139,7 @@ mod tests {
 =880 00 $6245-01$aমহাকালের তর্জনী : $b বঙ্গবন্ধু শেখ মুজিবকে নিবেদিত কবিতা / $c সম্পাদনা, কামাল চৌধুরী = Mohakaler torjoni : Bangabandhu Sheikh Mujibke nibedito kobita.
 =264 \1 $6880-02$a Ḍhākā : $b Di Iunibhārsiṭi Presa Limiṭeḍa, $c Mārca 2022.
 =880 \1 $6264-02$a ঢাকা : $b ডি ইউনিভার্সিটি প্রেস লিমিটেড, $c মার্চ ২০২২.").unwrap();
-        let mut statements = publication_statements(&record);
+        let mut statements = pub_created_display(&record);
 
         assert_eq!(
             statements.next(),
@@ -135,12 +159,82 @@ mod tests {
 =260 \\ $aCincinnati, Ohio : $bAmerican Drama Institute,$cc1991-",
         )
         .unwrap();
-        let mut statements = publication_statements(&record);
+        let mut statements = pub_created_display(&record);
 
         assert_eq!(
             statements.next(),
             Some("Cincinnati, Ohio : American Drama Institute, c1991-2007".to_owned())
         );
         assert_eq!(statements.next(), None);
+    }
+
+    #[test]
+    fn it_can_create_a_publisher_citation_with_a_place() {
+        let record = Record::from_breaker(
+            r#"=260 \\ $a Princeton
+=264 \\ $a Brooklyn"#,
+        )
+        .unwrap();
+        let mut publisher_citations = pub_citation_display(&record);
+        assert_eq!(publisher_citations.next(), Some("Princeton".to_string()));
+        assert_eq!(publisher_citations.next(), Some("Brooklyn".to_string()));
+        assert!(publisher_citations.next().is_none());
+    }
+
+    #[test]
+    fn it_can_create_a_publisher_citation_with_a_name() {
+        let record = Record::from_breaker(
+            r#"=260 \\ $b Princeton University Press
+=264 \\ $b Archipelago Books"#,
+        )
+        .unwrap();
+        let mut publisher_citations = pub_citation_display(&record);
+        assert_eq!(
+            publisher_citations.next(),
+            Some("Princeton University Press".to_string())
+        );
+        assert_eq!(
+            publisher_citations.next(),
+            Some("Archipelago Books".to_string())
+        );
+        assert!(publisher_citations.next().is_none());
+    }
+
+    #[test]
+    fn it_can_create_a_publisher_citation_with_a_place_and_a_name() {
+        let record = Record::from_breaker(
+            r#"=260 \\ $a Princeton : $b Princeton University Press
+=264 \\ $a Brooklyn $b Archipelago Books"#,
+        )
+        .unwrap();
+        let mut publisher_citations = pub_citation_display(&record);
+        assert_eq!(
+            publisher_citations.next(),
+            Some("Princeton: Princeton University Press".to_string())
+        );
+        assert_eq!(
+            publisher_citations.next(),
+            Some("Brooklyn: Archipelago Books".to_string())
+        );
+        assert!(publisher_citations.next().is_none());
+    }
+
+    #[test]
+    fn it_can_create_a_non_latin_publisher_citation() {
+        let record = Record::from_breaker(
+            r#"=264 \1 $6 880-04 $a Kunming : $b Yunnan da xue chu ban she, $c 2014.
+=880 \1 $6 264-04 $a 昆明 : $b 云南大学出版社, $c 2014."#,
+        )
+        .unwrap();
+        let mut publisher_citations = pub_citation_display(&record);
+        assert_eq!(
+            publisher_citations.next(),
+            Some("Kunming: Yunnan da xue chu ban she".to_string())
+        );
+        assert_eq!(
+            publisher_citations.next(),
+            Some("昆明: 云南大学出版社".to_string())
+        );
+        assert!(publisher_citations.next().is_none());
     }
 }

--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::marc::fixed_field::dates::EndDate;
 use crate::solr::AuthorRoles;
-use magnus::{Module, Object, RModule, function};
+use magnus::{Module, Object, RHash, RModule, function};
 
 // This module is responsible for the communication between Ruby and Rust code on the topic of MARC
 // (specifically the BibdataRs::Marc Ruby module and the crate::marc Rust module)
@@ -59,10 +59,7 @@ pub fn register_ruby_methods(parent_module: &RModule) -> Result<(), magnus::Erro
     )?;
     submodule_marc.define_singleton_method("private_items?", function!(private_items, 2))?;
     submodule_marc.define_singleton_method("pub_date_end_sort", function!(pub_date_end_sort, 1))?;
-    submodule_marc.define_singleton_method(
-        "publication_statements",
-        function!(publication_statements, 1),
-    )?;
+    submodule_marc.define_singleton_method("publication_data", function!(publication_data, 1))?;
     submodule_marc
         .define_singleton_method("recap_partner_notes", function!(recap_partner_notes, 1))?;
     submodule_marc.define_singleton_method("strip_non_numeric", function!(strip_non_numeric, 1))?;
@@ -134,6 +131,20 @@ fn has_subfield_related_to_indigenous_studies(term: String) -> Result<bool, magn
 
 fn has_main_term_related_to_indigenous_studies(term: String) -> Result<bool, magnus::Error> {
     Ok(indigenous_studies::has_main_term_related_to_indigenous_studies(&term))
+}
+
+// Create a ruby hash of various data related to the publication, so that
+// we don't have the overhead of repeated function calls between Ruby and
+// Rust to get each value separately
+fn publication_data(ruby: &Ruby, record_string: String) -> Result<RHash, magnus::Error> {
+    let record = get_record(ruby, &record_string)?;
+    let pub_citation_display: Vec<_> = publication::pub_citation_display(&record).collect();
+    let pub_created_display: Vec<_> = publication::pub_created_display(&record).collect();
+
+    let hash = ruby.hash_new();
+    hash.aset("pub_citation_display", pub_citation_display)?;
+    hash.aset("pub_created_display", pub_created_display)?;
+    Ok(hash)
 }
 
 #[cfg(test)]

--- a/lib/bibdata_rs/src/marc/variable_length_field.rs
+++ b/lib/bibdata_rs/src/marc/variable_length_field.rs
@@ -1,6 +1,13 @@
 use itertools::Itertools;
 use marctk::{Field, Subfield};
 
+pub fn latin_or_non_latin_tag_eq(tags: &[&str]) -> impl Fn(&Field) -> bool {
+    |field| {
+        tags.iter()
+            .any(|tag| *tag == field.tag() || multiscript_tag_eq(field, tag))
+    }
+}
+
 pub fn multiscript_tag_eq(field: &Field, tag: &str) -> bool {
     field.tag() == tag
         || (field.tag() == "880"

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -59,6 +59,7 @@ end
 
 each_record do |record, context|
   context.clipboard[:marc_breaker] = MarcBreaker.break record
+  context.clipboard[:publication_data] = BibdataRs::Marc.publication_data(context.clipboard[:marc_breaker])
   context.clipboard[:is_scsb] = BibdataRs::Marc.is_scsb?(context.clipboard[:marc_breaker])
 end
 
@@ -290,14 +291,13 @@ to_field 'pub_created_vern_display', extract_marc('260abcefg:264abcefg3', altern
 #    260 XX abcefg
 #    264 XX abc
 to_field 'pub_created_display' do |_record, accumulator, context|
-  accumulator.replace(BibdataRs::Marc.publication_statements(context.clipboard[:marc_breaker]))
+  accumulator.replace(context.clipboard[:publication_data]['pub_created_display'])
 end
 
 to_field 'pub_created_s', extract_marc('260abcefg:264abcefg3')
 
-to_field 'pub_citation_display' do |record, accumulator|
-  pub_info = set_pub_citation(record)
-  accumulator.replace(pub_info)
+to_field 'pub_citation_display' do |_record, accumulator, context|
+  accumulator.replace(context.clipboard[:publication_data]['pub_citation_display'])
 end
 
 to_field 'publication_location_citation_display', extract_marc('260a:264|*1|a', trim_punctuation: true, first: true)

--- a/spec/marc_to_solr/lib/princeton_marc_spec.rb
+++ b/spec/marc_to_solr/lib/princeton_marc_spec.rb
@@ -522,45 +522,6 @@ describe 'From princeton_marc.rb' do
     end
   end
 
-  describe 'set_pub_citation' do
-    before(:all) do
-      @place1 = 'Princeton'
-      @name1 = 'Princeton University Press'
-      @place2 = 'Brooklyn'
-      @name2 = 'Archipelago Books'
-
-      @p260_a = { '260' => { 'ind1' => ' ', 'ind2' => ' ', 'subfields' => [{ 'a' => @place1 }] } }
-      @p260_b = { '260' => { 'ind1' => ' ', 'ind2' => ' ', 'subfields' => [{ 'b' => @name1 }] } }
-      @p260_a_b = { '260' => { 'ind1' => ' ', 'ind2' => ' ', 'subfields' => [{ 'a' => @place1 }, { 'b' => @name1 }] } }
-      @p264_a = { '264' => { 'ind1' => ' ', 'ind2' => ' ', 'subfields' => [{ 'a' => @place2 }] } }
-      @p264_b = { '264' => { 'ind1' => ' ', 'ind2' => ' ', 'subfields' => [{ 'b' => @name2 }] } }
-      @p264_a_b = { '264' => { 'ind1' => ' ', 'ind2' => ' ', 'subfields' => [{ 'a' => @place2 }, { 'b' => @name2 }] } }
-
-      @sample_marc_a = MARC::Record.new_from_hash('fields' => [@p260_a, @p264_a])
-      @sample_marc_b = MARC::Record.new_from_hash('fields' => [@p260_b, @p264_b])
-      @sample_marc_a_b = MARC::Record.new_from_hash('fields' => [@p260_a_b, @p264_a_b])
-
-      @citation_a = set_pub_citation(@sample_marc_a)
-      @citation_b = set_pub_citation(@sample_marc_b)
-      @citation_a_b = set_pub_citation(@sample_marc_a_b)
-    end
-
-    it 'record with fields 260 or 264 and only subfield a will have a place-only citation' do
-      expect(@citation_a).to include @place1
-      expect(@citation_a).to include @place2
-    end
-
-    it 'record with fields 260 or 264 and only subfield b will have a name-only citation' do
-      expect(@citation_b).to include @name1
-      expect(@citation_b).to include @name2
-    end
-
-    it 'record with fields 260 or 264 with subfield a and b will have a concatenated citation' do
-      expect(@citation_a_b).to include "#{@place1}: #{@name1}"
-      expect(@citation_a_b).to include "#{@place2}: #{@name2}"
-    end
-  end
-
   describe '#process_holdings' do
     # alma record: https://catalog.princeton.edu/catalog/9914141453506421
     before(:all) do


### PR DESCRIPTION
My first attempt was slower than the ruby version, due to the overhead of re-parsing the MARC record for every call to Rust.

However, by grouping all the publication data together as a hash, we only need to experience that overhead once per record, and we get a nice speedup:

```
require 'benchmark/ips'
record = MARC::XMLReader.new('spec/fixtures/marc_to_solr/9939238033506421.mrx').first
marc_breaker = MarcBreaker.break(record)
Benchmark.ips do |x|
  x.report("before") { set_pub_citation(record) && BibdataRs::Marc.publication_statements(marc_breaker) }
  x.report("after") { BibdataRs::Marc.publication_data(marc_breaker) }
end
```

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
              before     2.837k i/100ms
Calculating -------------------------------------
              before     27.827k (± 2.0%) i/s   (35.94 μs/i) -    141.850k in   5.099585s
```

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after     4.137k i/100ms
Calculating -------------------------------------
               after     41.399k (± 1.6%) i/s   (24.16 μs/i) -    210.987k in   5.097755s
```