### PR TITLE
BibdataRs: return a Ruby hash containing all solr fields that have been implemented in Rust

### DIFF
--- a/lib/bibdata_rs/src/marc.rs
+++ b/lib/bibdata_rs/src/marc.rs
@@ -50,37 +50,6 @@ pub fn holding_id(
 pub fn alma_code_start_22(code: String) -> bool {
     AlmaHoldingId(&code).is_valid()
 }
-pub fn genres(ruby: &Ruby, record_string: String) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(ruby, &record_string)?;
-    Ok(genre::genres(&record))
-}
-
-pub fn original_languages_of_translation(
-    ruby: &Ruby,
-    record_string: String,
-) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(ruby, &record_string)?;
-    Ok(language::original_languages_of_translation(&record)
-        .iter()
-        .map(|language| language.english_name.to_owned())
-        .collect())
-}
-
-pub fn access_notes(
-    ruby: &Ruby,
-    record_string: String,
-) -> Result<Option<Vec<String>>, magnus::Error> {
-    let record = get_record(ruby, &record_string)?;
-    Ok(note::access_notes(&record))
-}
-
-pub fn recap_partner_notes(
-    ruby: &Ruby,
-    record_string: String,
-) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(ruby, &record_string)?;
-    Ok(scsb::recap_partner::recap_partner_notes(&record))
-}
 
 pub fn is_scsb(ruby: &Ruby, record_string: String) -> Result<bool, magnus::Error> {
     let record = get_record(ruby, &record_string)?;
@@ -157,13 +126,6 @@ pub fn build_call_number(
     Ok(call_number.filter(|s| !s.is_empty()))
 }
 
-pub fn format_facets(ruby: &Ruby, record_string: String) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(ruby, &record_string)?;
-    Ok(record_facet_mapping::format_facets(&record)
-        .iter()
-        .map(|facet| format!("{facet}"))
-        .collect())
-}
 pub fn private_items(
     ruby: &Ruby,
     record_string: String,
@@ -180,30 +142,12 @@ pub fn private_items(
     }))
 }
 
-pub fn notes_cjk(ruby: &Ruby, record_string: String) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(ruby, &record_string)?;
-    Ok(cjk::notes_cjk(&record).collect())
-}
-
-pub fn subjects_cjk(ruby: &Ruby, record_string: String) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(ruby, &record_string)?;
-    Ok(cjk::subjects_cjk(&record).collect())
-}
-
 pub fn normalize_oclc_number(string: String) -> String {
     identifier::normalize_oclc_number(&string)
 }
 
 pub fn is_oclc_number(string: String) -> bool {
     identifier::is_oclc_number(&string)
-}
-
-pub fn identifiers_of_all_versions(
-    ruby: &Ruby,
-    record_string: String,
-) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(ruby, &record_string)?;
-    Ok(identifier::identifiers_of_all_versions(&record))
 }
 
 pub fn strip_non_numeric(string: String) -> String {

--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -1,5 +1,9 @@
 use super::*;
-use crate::marc::fixed_field::dates::EndDate;
+use crate::marc::call_number::{call_number_labels_for_browse, call_number_labels_for_display};
+use crate::marc::date::cataloged_date;
+use crate::marc::identifier::identifiers_of_all_versions;
+use crate::marc::note::access_notes;
+use crate::marc::{fixed_field::dates::EndDate, scsb::recap_partner::recap_partner_notes};
 use crate::solr::AuthorRoles;
 use magnus::{Module, Object, RHash, RModule, function};
 
@@ -8,25 +12,11 @@ use magnus::{Module, Object, RHash, RModule, function};
 
 pub fn register_ruby_methods(parent_module: &RModule) -> Result<(), magnus::Error> {
     let submodule_marc = parent_module.define_module("Marc")?;
-    submodule_marc.define_singleton_method("access_notes", function!(access_notes, 1))?;
     submodule_marc
         .define_singleton_method("alma_code_start_22?", function!(alma_code_start_22, 1))?;
-    submodule_marc
-        .define_singleton_method("author_roles", function!(author_roles_from_marc_breaker, 1))?;
     submodule_marc.define_singleton_method("build_call_number", function!(build_call_number, 1))?;
-    submodule_marc.define_singleton_method(
-        "call_number_labels_for_browse",
-        function!(call_number_labels_for_browse_from_marc_breaker, 1),
-    )?;
-    submodule_marc.define_singleton_method(
-        "call_number_labels_for_display",
-        function!(call_number_labels_for_display_from_marc_breaker, 1),
-    )?;
-    submodule_marc.define_singleton_method("cataloged_date", function!(cataloged_date, 1))?;
     submodule_marc
         .define_singleton_method("current_location_code", function!(current_location_code, 1))?;
-    submodule_marc.define_singleton_method("format_facets", function!(format_facets, 1))?;
-    submodule_marc.define_singleton_method("genres", function!(genres, 1))?;
     submodule_marc.define_singleton_method(
         "has_main_term_related_to_indigenous_studies",
         function!(has_main_term_related_to_indigenous_studies, 1),
@@ -36,93 +26,87 @@ pub fn register_ruby_methods(parent_module: &RModule) -> Result<(), magnus::Erro
         function!(has_subfield_related_to_indigenous_studies, 1),
     )?;
     submodule_marc.define_singleton_method("holding_id", function!(holding_id, 2))?;
-    submodule_marc.define_module_function(
-        "icpsr_subjects",
-        function!(icpsr_subjects_from_marc_breaker, 1),
-    )?;
-    submodule_marc.define_singleton_method(
-        "identifiers_of_all_versions",
-        function!(identifiers_of_all_versions, 1),
-    )?;
+    submodule_marc.define_module_function("solr_fields", function!(solr_fields, 1))?;
     submodule_marc.define_singleton_method("is_oclc_number?", function!(is_oclc_number, 1))?;
     submodule_marc.define_singleton_method("is_scsb?", function!(is_scsb, 1))?;
     submodule_marc
         .define_singleton_method("normalize_oclc_number", function!(normalize_oclc_number, 1))?;
-    submodule_marc.define_singleton_method("notes_cjk", function!(notes_cjk, 1))?;
-    submodule_marc.define_singleton_method(
-        "original_languages_of_translation",
-        function!(original_languages_of_translation, 1),
-    )?;
     submodule_marc.define_singleton_method(
         "permanent_location_code",
         function!(permanent_location_code, 1),
     )?;
     submodule_marc.define_singleton_method("private_items?", function!(private_items, 2))?;
-    submodule_marc.define_singleton_method("pub_date_end_sort", function!(pub_date_end_sort, 1))?;
-    submodule_marc.define_singleton_method("publication_data", function!(publication_data, 1))?;
-    submodule_marc
-        .define_singleton_method("recap_partner_notes", function!(recap_partner_notes, 1))?;
     submodule_marc.define_singleton_method("strip_non_numeric", function!(strip_non_numeric, 1))?;
-    submodule_marc
-        .define_singleton_method("siku_subjects_display", function!(siku_subjects_display, 1))?;
-    submodule_marc.define_singleton_method("subjects_cjk", function!(subjects_cjk, 1))?;
     submodule_marc
         .define_module_function("trim_punctuation", function!(trim_punctuation_owned, 1))?;
     Ok(())
 }
 
-fn call_number_labels_for_display_from_marc_breaker(
-    ruby: &Ruby,
-    record_string: String,
-) -> Result<Vec<String>, magnus::Error> {
+fn solr_fields(ruby: &Ruby, record_string: String) -> Result<RHash, magnus::Error> {
     let record = get_record(ruby, &record_string)?;
-    Ok(call_number::call_number_labels_for_display(&record))
-}
 
-fn call_number_labels_for_browse_from_marc_breaker(
-    ruby: &Ruby,
-    record_string: String,
-) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(ruby, &record_string)?;
-    Ok(call_number::call_number_labels_for_browse(&record))
-}
-
-fn pub_date_end_sort(ruby: &Ruby, record_string: String) -> Result<Option<String>, magnus::Error> {
-    let record = get_record(ruby, &record_string)?;
-    Ok(EndDate::try_from(&record)
+    let author_roles_1display =
+        serde_json::to_string(&AuthorRoles::from(&record)).map_err(|err| {
+            magnus::Error::new(
+                ruby.exception_runtime_error(),
+                format!("Found error {} while serializing author roles", err),
+            )
+        })?;
+    let format: Vec<_> = record_facet_mapping::format_facets(&record)
+        .iter()
+        .map(|facet| format!("{facet}"))
+        .collect();
+    let icpsr_subject_unstem_search = subject::icpsr_subjects(&record);
+    let original_language_of_translation_facet: Vec<_> =
+        language::original_languages_of_translation(&record)
+            .iter()
+            .map(|language| language.english_name.to_owned())
+            .collect();
+    let pub_date_end_sort = EndDate::try_from(&record)
         .ok()
-        .and_then(|date| date.maybe_to_string()))
-}
+        .and_then(|date| date.maybe_to_string());
 
-fn icpsr_subjects_from_marc_breaker(
-    ruby: &Ruby,
-    record_string: String,
-) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(ruby, &record_string)?;
-    Ok(subject::icpsr_subjects(&record))
-}
+    let hash = ruby.hash_new_capa(17);
+    hash.aset("access_restrictions_note_display", access_notes(&record))?;
+    hash.aset("author_roles_1display", author_roles_1display)?;
+    hash.aset(
+        "call_number_browse_s",
+        call_number_labels_for_browse(&record),
+    )?;
+    hash.aset(
+        "call_number_display",
+        call_number_labels_for_display(&record),
+    )?;
+    hash.aset("cataloged_date_tdt", cataloged_date(&record))?;
+    hash.aset("cjk_notes", ruby.ary_from_iter(cjk::notes_cjk(&record)))?;
+    hash.aset(
+        "cjk_subject",
+        ruby.ary_from_iter(cjk::subjects_cjk(&record)),
+    )?;
+    hash.aset("format", format)?;
+    hash.aset("genre_facet", genre::genres(&record))?;
+    hash.aset("icpsr_subject_unstem_search", icpsr_subject_unstem_search)?;
+    hash.aset("other_version_s", identifiers_of_all_versions(&record))?;
+    hash.aset(
+        "original_language_of_translation_facet",
+        original_language_of_translation_facet,
+    )?;
+    hash.aset(
+        "pub_citation_display",
+        ruby.ary_from_iter(publication::pub_citation_display(&record)),
+    )?;
+    hash.aset(
+        "pub_created_display",
+        ruby.ary_from_iter(publication::pub_created_display(&record)),
+    )?;
+    hash.aset("pub_date_end_sort", pub_date_end_sort)?;
+    hash.aset("recap_notes_display", recap_partner_notes(&record))?;
+    hash.aset(
+        "siku_subject_display",
+        ruby.ary_from_iter(subject::siku_subjects_display(&record)),
+    )?;
 
-fn author_roles_from_marc_breaker(
-    ruby: &Ruby,
-    record_string: String,
-) -> Result<String, magnus::Error> {
-    let record = get_record(ruby, &record_string)?;
-    serde_json::to_string(&AuthorRoles::from(&record)).map_err(|err| {
-        magnus::Error::new(
-            ruby.exception_runtime_error(),
-            format!("Found error {} while serializing author roles", err),
-        )
-    })
-}
-
-fn cataloged_date(ruby: &Ruby, record_string: String) -> Result<Option<String>, magnus::Error> {
-    let record = get_record(ruby, &record_string)?;
-    Ok(date::cataloged_date(&record))
-}
-
-fn siku_subjects_display(ruby: &Ruby, record_string: String) -> Result<Vec<String>, magnus::Error> {
-    let record = get_record(ruby, &record_string)?;
-    Ok(subject::siku_subjects_display(&record).collect())
+    Ok(hash)
 }
 
 fn has_subfield_related_to_indigenous_studies(term: String) -> Result<bool, magnus::Error> {
@@ -133,20 +117,6 @@ fn has_main_term_related_to_indigenous_studies(term: String) -> Result<bool, mag
     Ok(indigenous_studies::has_main_term_related_to_indigenous_studies(&term))
 }
 
-// Create a ruby hash of various data related to the publication, so that
-// we don't have the overhead of repeated function calls between Ruby and
-// Rust to get each value separately
-fn publication_data(ruby: &Ruby, record_string: String) -> Result<RHash, magnus::Error> {
-    let record = get_record(ruby, &record_string)?;
-    let pub_citation_display: Vec<_> = publication::pub_citation_display(&record).collect();
-    let pub_created_display: Vec<_> = publication::pub_created_display(&record).collect();
-
-    let hash = ruby.hash_new();
-    hash.aset("pub_citation_display", pub_citation_display)?;
-    hash.aset("pub_created_display", pub_created_display)?;
-    Ok(hash)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -154,12 +124,12 @@ mod tests {
     use rb_sys_test_helpers::ruby_test;
 
     #[ruby_test]
-    fn it_binds_icpsr_subjects_method() {
+    fn it_binds_solr_fields_method() {
         let ruby = unsafe { Ruby::get_unchecked() };
         let module = ruby.define_module("MyNiceModule").unwrap();
         register_ruby_methods(&module).unwrap();
         let method_exists: bool = ruby
-            .eval("MyNiceModule::Marc.respond_to? :icpsr_subjects")
+            .eval("MyNiceModule::Marc.respond_to? :solr_fields")
             .unwrap();
         assert!(method_exists);
     }

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -59,7 +59,7 @@ end
 
 each_record do |record, context|
   context.clipboard[:marc_breaker] = MarcBreaker.break record
-  context.clipboard[:publication_data] = BibdataRs::Marc.publication_data(context.clipboard[:marc_breaker])
+  context.clipboard[:solr_fields] = BibdataRs::Marc.solr_fields(context.clipboard[:marc_breaker])
   context.clipboard[:is_scsb] = BibdataRs::Marc.is_scsb?(context.clipboard[:marc_breaker])
 end
 
@@ -116,7 +116,7 @@ end
 # 880 field is "vernacular" and may link to a translation in a 5xx
 # Only add 880 alt script values associated with a 5xx field
 to_field 'cjk_notes' do |_record, accumulator, context|
-  accumulator.replace(BibdataRs::Marc.notes_cjk(context.clipboard[:marc_breaker]))
+  accumulator.replace(context.clipboard[:solr_fields]['cjk_notes'])
 end
 
 to_field 'figgy_1display' do |record, accumulator|
@@ -139,7 +139,7 @@ to_field 'author_sort', extract_marc('100aqbcdk:110abcdfgkln:111abcdfgklnpq', tr
 to_field 'author_citation_display', extract_marc('100a:110a:111a:700a:710a:711a', trim_punctuation: true, alternate_script: false)
 
 to_field 'author_roles_1display' do |_record, accumulator, context|
-  accumulator[0] = BibdataRs::Marc.author_roles(context.clipboard[:marc_breaker])
+  accumulator[0] = context.clipboard[:solr_fields]['author_roles_1display']
 end
 
 to_field 'cjk_author' do |record, accumulator|
@@ -291,13 +291,13 @@ to_field 'pub_created_vern_display', extract_marc('260abcefg:264abcefg3', altern
 #    260 XX abcefg
 #    264 XX abc
 to_field 'pub_created_display' do |_record, accumulator, context|
-  accumulator.replace(context.clipboard[:publication_data]['pub_created_display'])
+  accumulator.replace(context.clipboard[:solr_fields]['pub_created_display'])
 end
 
 to_field 'pub_created_s', extract_marc('260abcefg:264abcefg3')
 
 to_field 'pub_citation_display' do |_record, accumulator, context|
-  accumulator.replace(context.clipboard[:publication_data]['pub_citation_display'])
+  accumulator.replace(context.clipboard[:solr_fields]['pub_citation_display'])
 end
 
 to_field 'publication_location_citation_display', extract_marc('260a:264|*1|a', trim_punctuation: true, first: true)
@@ -312,7 +312,7 @@ to_field 'pub_date_start_sort' do |record, accumulator|
 end
 
 to_field 'pub_date_end_sort' do |_record, accumulator, context|
-  accumulator << BibdataRs::Marc.pub_date_end_sort(context.clipboard[:marc_breaker])
+  accumulator << context.clipboard[:solr_fields]['pub_date_end_sort']
 end
 
 to_field 'publication_date_citation_display' do |record, accumulator|
@@ -330,12 +330,12 @@ end
 # Physical Items Enrichment -> Create date subfield 876d
 # Electronic Inventory Enrichment -> Activation date subfield 951w
 to_field 'cataloged_tdt' do |_record, accumulator, context|
-  accumulator[0] = BibdataRs::Marc.cataloged_date(context.clipboard[:marc_breaker])
+  accumulator[0] = context.clipboard[:solr_fields]['cataloged_tdt']
 end
 
 # format - allow multiple - "first" one is used for thumbnail
 to_field 'format' do |_record, accumulator, context|
-  accumulator.replace BibdataRs::Marc.format_facets(context.clipboard[:marc_breaker])
+  accumulator.replace context.clipboard[:solr_fields]['format']
 end
 
 # Medium/Support:
@@ -709,7 +709,7 @@ to_field 'language_facet' do |record, accumulator|
 end
 
 to_field 'original_language_of_translation_facet' do |_record, accumulator, context|
-  accumulator.replace BibdataRs::Marc.original_languages_of_translation(context.clipboard[:marc_breaker])
+  accumulator.replace context.clipboard[:solr_fields]['original_language_of_translation_facet']
 end
 
 to_field 'publication_place_facet', extract_marc('008[15-17]') do |_record, accumulator, _context|
@@ -847,7 +847,7 @@ to_field 'lc_subject_include_archaic_search_terms_index' do |record, accumulator
 end
 
 to_field 'siku_subject_display' do |_record, accumulator, context|
-  accumulator.replace(BibdataRs::Marc.siku_subjects_display(context.clipboard[:marc_breaker]))
+  accumulator.replace(context.clipboard[:solr_fields]['siku_subject_display'])
 end
 
 # used for the Browse lists and hierarchical subject facet
@@ -910,7 +910,7 @@ to_field 'fast_subject_display' do |record, accumulator|
 end
 
 to_field 'icpsr_subject_unstem_search' do |_record, accumulator, context|
-  accumulator.replace BibdataRs::Marc.icpsr_subjects(context.clipboard[:marc_breaker])
+  accumulator.replace context.clipboard[:solr_fields]['icpsr_subject_unstem_search']
 end
 
 # Adds lc, siku, local, and homoit subject unstem_search fields
@@ -1018,7 +1018,7 @@ to_field 'rbgenr_genre_facet' do |record, accumulator|
 end
 
 to_field 'cjk_subject' do |_record, accumulator, context|
-  accumulator.replace(BibdataRs::Marc.subjects_cjk(context.clipboard[:marc_breaker]))
+  accumulator.replace(context.clipboard[:solr_fields]['cjk_subject'])
 end
 
 # used for split subject topic facet
@@ -1140,7 +1140,7 @@ end
 # 600/610/650/651 $v, $x filtered
 # 655 $a, $v, $x filtered
 to_field 'genre_facet' do |_record, accumulator, context|
-  accumulator.replace(BibdataRs::Marc.genres(context.clipboard[:marc_breaker]))
+  accumulator.replace(context.clipboard[:solr_fields]['genre_facet'])
 end
 
 # Related name(s):
@@ -1348,7 +1348,7 @@ end
 #    3500 020A776Z
 #    3500 776Z020A
 to_field 'other_version_s' do |_record, accumulator, context|
-  accumulator.replace(BibdataRs::Marc.identifiers_of_all_versions(context.clipboard[:marc_breaker]))
+  accumulator.replace(context.clipboard[:solr_fields]['other_version_s'])
 end
 
 # Original language:
@@ -1366,7 +1366,7 @@ end
 
 # Skip SCSB records that include only private items
 each_record do |record, context|
-  recap_notes = BibdataRs::Marc.recap_partner_notes(context.clipboard[:marc_breaker])
+  recap_notes = context.clipboard[:solr_fields]['recap_notes_display']
   next if recap_notes.empty?
   next if recap_notes.map { |note| note.include?('P') }.include?(false)
 
@@ -1376,16 +1376,11 @@ end
 
 ## for recap notes
 to_field 'recap_notes_display' do |_record, accumulator, context|
-  recap_notes = BibdataRs::Marc.recap_partner_notes(context.clipboard[:marc_breaker])
-  unless recap_notes.empty?
-    recap_notes.each_with_index do |value, i|
-      accumulator[i] = value
-    end
-  end
+  accumulator.replace(context.clipboard[:solr_fields]['recap_notes_display'])
 end
 
 to_field 'access_restrictions_note_display' do |_record, accumulator, context|
-  notes = BibdataRs::Marc.access_notes(context.clipboard[:marc_breaker])
+  notes = context.clipboard[:solr_fields]['access_restrictions_note_display']
   accumulator.replace(notes) if notes
 end
 
@@ -1590,13 +1585,13 @@ end
 # Position 852|k in the beginning of the call_number_display
 # The call_number_display is used in the catalog record page.
 to_field 'call_number_display' do |_record, accumulator, context|
-  accumulator.replace(BibdataRs::Marc.call_number_labels_for_display(context.clipboard[:marc_breaker]))
+  accumulator.replace(context.clipboard[:solr_fields]['call_number_display'])
 end
 
 # Position 852|k at the end of the call_number_browse_s
 # The call_number_browse_s is used in the call number browse page in the catalog
 to_field 'call_number_browse_s' do |_record, accumulator, context|
-  accumulator.replace(BibdataRs::Marc.call_number_labels_for_browse(context.clipboard[:marc_breaker]))
+  accumulator.replace(context.clipboard[:solr_fields]['call_number_browse_s'])
 end
 
 # The call_number_locator_display is used in the 'Where to find it' feature in the record page,


### PR DESCRIPTION
Rather than individual function calls (which include the overhead of re-parsing the record in Rust for each function call), we return all of the solr fields at once in a hash.

This approach also means that we have a lot less boilerplate rust code defining all those functions!

Before:
```
INFO finished Traject::Indexer#process: 45288 records in 109.243 seconds; 414.6 records/second overall.
```

After:
```
INFO finished Traject::Indexer#process: 45288 records in 99.357 seconds; 455.8 records/second overall.
```