### PR TITLE
Migrate some uses of Traject TranslationMaps to Rust

### DIFF
--- a/lib/bibdata_rs/src/marc.rs
+++ b/lib/bibdata_rs/src/marc.rs
@@ -11,6 +11,7 @@ pub mod date;
 pub mod extract_values;
 pub mod fixed_field;
 pub mod genre;
+pub mod holdings;
 pub mod identifier;
 pub mod indigenous_studies;
 pub mod language;

--- a/lib/bibdata_rs/src/marc/holdings.rs
+++ b/lib/bibdata_rs/src/marc/holdings.rs
@@ -1,0 +1,1 @@
+pub mod holding_location;

--- a/lib/bibdata_rs/src/marc/holdings/holding_location.rs
+++ b/lib/bibdata_rs/src/marc/holdings/holding_location.rs
@@ -1,0 +1,51 @@
+use std::{collections::HashMap, sync::LazyLock};
+
+use serde::Deserialize;
+
+const HOLDING_LOCATION_JSON: &str =
+    include_str!("../../../../../config/locations/holding_locations.json");
+
+#[derive(Deserialize)]
+pub struct Library<'a> {
+    label: &'a str,
+}
+
+#[derive(Deserialize)]
+pub struct Location<'a> {
+    label: &'a str,
+    code: &'a str,
+    library: Library<'a>,
+}
+
+static LOCATIONS: LazyLock<HashMap<&str, Location>> = LazyLock::new(|| {
+    let locations: Vec<Location> = serde_json::from_str(HOLDING_LOCATION_JSON)
+        .expect("Could not parse the holding_locations.json");
+    let mut hash = HashMap::new();
+    for location in locations {
+        hash.insert(location.code, location);
+    }
+    hash
+});
+
+pub fn location_label(code: &str) -> Option<&str> {
+    LOCATIONS.get(code).map(|location| location.label)
+}
+
+pub fn library_label(code: &str) -> Option<&str> {
+    LOCATIONS.get(code).map(|location| location.library.label)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_can_get_the_location_label() {
+        assert_eq!(location_label("scsbcul"), Some("Remote Storage"));
+    }
+
+    #[test]
+    fn it_can_get_the_library_label() {
+        assert_eq!(library_label("scsbcul"), Some("ReCAP"));
+    }
+}

--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -29,6 +29,8 @@ pub fn register_ruby_methods(parent_module: &RModule) -> Result<(), magnus::Erro
     submodule_marc.define_module_function("solr_fields", function!(solr_fields, 1))?;
     submodule_marc.define_singleton_method("is_oclc_number?", function!(is_oclc_number, 1))?;
     submodule_marc.define_singleton_method("is_scsb?", function!(is_scsb, 1))?;
+    submodule_marc.define_singleton_method("library_label", function!(library_label, 1))?;
+    submodule_marc.define_singleton_method("location_label", function!(location_label, 1))?;
     submodule_marc
         .define_singleton_method("normalize_oclc_number", function!(normalize_oclc_number, 1))?;
     submodule_marc.define_singleton_method(
@@ -115,6 +117,14 @@ fn has_subfield_related_to_indigenous_studies(term: String) -> Result<bool, magn
 
 fn has_main_term_related_to_indigenous_studies(term: String) -> Result<bool, magnus::Error> {
     Ok(indigenous_studies::has_main_term_related_to_indigenous_studies(&term))
+}
+
+fn library_label(code: String) -> Option<String> {
+    holdings::holding_location::library_label(&code).map(|label| label.to_owned())
+}
+
+fn location_label(code: String) -> Option<String> {
+    holdings::holding_location::location_label(&code).map(|label| label.to_owned())
 }
 
 #[cfg(test)]

--- a/marc_to_solr/lib/princeton_marc.rb
+++ b/marc_to_solr/lib/princeton_marc.rb
@@ -505,7 +505,9 @@ def add_item_to_holding(field_852, field_876, holding_key, holdings_helpers, all
 end
 
 def invalid_location?(code)
-  Traject::TranslationMap.new('locations')[code].nil?
+  return true unless code
+
+  BibdataRs::Marc.location_label(code).nil?
 end
 
 def local_heading?(field)

--- a/marc_to_solr/lib/process_holdings_helpers.rb
+++ b/marc_to_solr/lib/process_holdings_helpers.rb
@@ -100,12 +100,16 @@ class ProcessHoldingsHelpers
     holding = {}
     if permanent
       holding['location_code'] = permanent_location_code(field_852)
-      holding['location'] = Traject::TranslationMap.new('locations', default: '__passthrough__')[holding['location_code']]
-      holding['library'] = Traject::TranslationMap.new('location_display', default: '__passthrough__')[holding['location_code']]
+      if holding['location_code']
+        holding['location'] = BibdataRs::Marc.location_label(holding['location_code'])
+        holding['library'] = BibdataRs::Marc.library_label(holding['location_code'])
+      end
     else
       holding['location_code'] = current_location_code(field_876)
-      holding['current_location'] = Traject::TranslationMap.new('locations', default: '__passthrough__')[holding['location_code']]
-      holding['current_library'] = Traject::TranslationMap.new('location_display', default: '__passthrough__')[holding['location_code']]
+      if holding['location_code']
+        holding['current_location'] = BibdataRs::Marc.location_label(holding['location_code'])
+        holding['current_library'] = BibdataRs::Marc.library_label(holding['location_code'])
+      end
     end
 
     holding['call_number'] = build_call_number(field_852)


### PR DESCRIPTION
The rust binary includes the holdings json, so once we finish this migration, we will not need these two translation map files.

```
require 'benchmark/ips'
RubyVM::YJIT.enable
code = 'scsbcul'
Benchmark.ips do |x|
  x.report('rust - location label') { BibdataRs::Marc.location_label(code) }
  x.report('ruby - location label') { Traject::TranslationMap.new('locations')[code] }
  x.compare!
end
Benchmark.ips do |x|
  x.report('rust - library label') { BibdataRs::Marc.library_label(code) }
  x.report('ruby - library label') { Traject::TranslationMap.new('location_display')[code] }
  x.compare!
end
```

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
rust - location label
                       684.446k i/100ms
ruby - location label
                       310.022k i/100ms
Calculating -------------------------------------
rust - location label
                          6.820M (± 0.9%) i/s  (146.63 ns/i) -     34.222M in   5.018583s
ruby - location label
                          3.057M (± 1.9%) i/s  (327.15 ns/i) -     15.501M in   5.073030s

Comparison:
rust - location label:  6819710.2 i/s
ruby - location label:  3056727.2 i/s - 2.23x  slower

ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
rust - library label   677.720k i/100ms
ruby - library label   310.036k i/100ms
Calculating -------------------------------------
rust - library label      6.808M (± 2.1%) i/s  (146.88 ns/i) -     34.564M in   5.079184s
ruby - library label      3.109M (± 1.7%) i/s  (321.69 ns/i) -     15.812M in   5.088198s

Comparison:
rust - library label:  6808218.2 i/s
ruby - library label:  3108549.8 i/s - 2.19x  slower
```