### PR TITLE
Before trying to symlink check if figgy_mms_ids.yaml file exists

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -35,7 +35,7 @@ set :linked_dirs, %w{
   log
 }
 
-set :linked_files, ['marc_to_solr/translation_maps/figgy_mms_ids.yaml']
+set :linked_files, ['marc_to_solr/translation_maps/figgy_mms_ids.yaml'] if File.exist?('marc_to_solr/translation_maps/figgy_mms_ids.yaml')
 
 set :default_env, {
   CARGO_HOME: '/usr/local/cargo',


### PR DESCRIPTION
Before trying to symlink check if figgy_mms_ids.yaml file exists
When deploying in a new VM the file is not there and the cap deploy fails to complete