### PR TITLE
When an Item is requested but also it is available and has a status label Item in Place

### DIFF
--- a/app/adapters/alma_adapter/alma_item.rb
+++ b/app/adapters/alma_adapter/alma_item.rb
@@ -240,7 +240,7 @@ class AlmaAdapter
         id: item_data['pid'],
         holding_id:,
         copy_number: holding_data['copy_id'],
-        status: status[:code],        # Available
+        status: requested_and_item_in_place? ? 'Unavailable' : status[:code], # Available
         status_label: status[:label], # Item in place
         status_source: status[:source], # e.g. work_order, process_type, base_status
         process_type: status[:process_type],
@@ -255,6 +255,10 @@ class AlmaAdapter
         chron_display: chronology, # in Alma there are many chronologies
         requested: item_data['requested']
       }.merge(temp_library_availability_summary)
+    end
+
+    def requested_and_item_in_place?
+      item_data['requested'] == true && calculate_status[:label] == 'Item in place'
     end
 
     def temp_library_availability_summary

--- a/spec/adapters/alma_adapter_spec.rb
+++ b/spec/adapters/alma_adapter_spec.rb
@@ -292,6 +292,7 @@ RSpec.describe AlmaAdapter do
                     temp_library_label: 'Lewis Library - Term Loan Reserves', temp_location_code: 'lewis$resterm',
                     temp_location_label: 'Lewis Library - Term Loan Reserves' }
       expect(item).to eq item_test
+      expect(availability.first[:status]).to eq 'Available'
     end
 
     it 'defaults the pickup location to the library' do
@@ -341,6 +342,20 @@ RSpec.describe AlmaAdapter do
       expect(item[:status]).to eq 'Available'
       expect(item[:status_label]).to eq 'Item in place'
       expect(item[:status_source]).to eq 'base_status'
+    end
+
+    context 'when the item is requested and in place' do
+      before do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(AlmaAdapter::AlmaItem).to receive(:requested_and_item_in_place?).and_return(true)
+        # rubocop:enable RSpec/AnyInstance
+      end
+
+      it 'sets the status label to "Unavailable" if the item is requested and in place' do
+        availability = adapter.get_availability_holding(id: '9943506421', holding_id: '22261963850006421')
+        expect(availability.first[:status]).to eq 'Unavailable'
+        expect(availability.first[:status_label]).to eq 'Item in place'
+      end
     end
   end
 


### PR DESCRIPTION
When an Item is requested but  it's also available and has a status label Item in Place

change the status label in the holdings availability response to be Unavailable.

related to https://github.com/pulibrary/orangelight/issues/5715

<img width="1257" height="628" alt="screenshsot of request form" src="https://github.com/user-attachments/assets/3f93ea91-bb6f-4931-83cb-0370f2e37a66" />

