### PR TITLE
Rescue in case theh index cannot find a trnalsation map for the record

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -120,10 +120,12 @@ end
 
 to_field 'figgy_1display' do |record, accumulator|
   figgy_items = Traject::TranslationMap.new('figgy_mms_ids')[record['001']&.value]
-
   next unless figgy_items
 
   accumulator << figgy_items.to_json
+rescue Traject::TranslationMap::NotFound
+  Rails.logger.warn("figgy_mms_ids translation map not found for record #{record['001']&.value}")
+  next
 end
 
 # Author/Artist:


### PR DESCRIPTION
In hoeneybadger we're getting 
```
line 177 of [GEM_ROOT]/gems/traject-3.8.2/lib/traject/translation_map.rb: Traject::TranslationMap#initialize
line 122 of marc_to_solr/lib/traject_config.rb: Class#new
line 122 of marc_to_solr/lib/traject_config.rb: block (2 levels) in Traject::Indexer#load_config_file
```
```
[Traject::TranslationMap::NotFound](https://app.honeybadger.io/projects/54497/faults/128954630): No translation map definition file found at 'translation_maps/figgy_mms_ids.[rb|yaml|properties]' in load path: ["/opt/bibdata/releases/20260325150632/marc_to_solr",
```

when the index cannot find a translation map for this record.