### PR TITLE
Update alma item to check for the first two characters of the location code

### DIFF
--- a/app/adapters/alma_adapter/alma_item.rb
+++ b/app/adapters/alma_adapter/alma_item.rb
@@ -162,13 +162,13 @@ class AlmaAdapter
       return unless recap_item?
       return 'PG' if item.location[0].casecmp('x').zero?
 
-      item.location.upcase
+      item.location[0..1].upcase
     end
 
     def recap_use_restriction
       return unless recap_item?
 
-      case item.location
+      case item.location[0..1]
       when *in_library_recap_groups
         'In Library Use'
       when *supervised_recap_groups
@@ -180,7 +180,7 @@ class AlmaAdapter
       return unless recap_item?
       return 'Committed' if item_cgd_committed?
 
-      case item.location
+      case item.location[0..1]
       when 'pv', 'pa', 'gp', 'qk', 'pf'
         'Shared'
       when *(in_library_recap_groups_and_private + supervised_recap_groups + no_access_recap_groups)
@@ -189,7 +189,7 @@ class AlmaAdapter
     end
 
     def recap_item?
-      all_recap_groups.include?(holding_location)
+      holding_location[0..1].in?(all_recap_groups)
     end
 
     def all_recap_groups

--- a/spec/adapters/alma_adapter/alma_item_spec.rb
+++ b/spec/adapters/alma_adapter/alma_item_spec.rb
@@ -81,6 +81,16 @@ RSpec.describe AlmaAdapter::AlmaItem do
         expect(item.recap_customer_code).to eq 'PA'
       end
     end
+
+    context 'When location has three characters' do
+      it 'creates the customer code using the first two and capitalizes them' do
+        item = described_class.new(
+          build_item(code: 'pjm', retention_reason: 'other')
+        )
+
+        expect(item.recap_customer_code).to eq 'PJ'
+      end
+    end
   end
 
   describe '#group_designation' do
@@ -104,7 +114,8 @@ RSpec.describe AlmaAdapter::AlmaItem do
 
     context "When it's not committed to retain and in committed retention reason" do
       %w[ReCAPItalianImprints IPLCBrill ReCAPSACAP].each do |retention_reason|
-        %w[pv pa gp qk pf].each do |code|
+        # pfh is a fake location to test the first two letters of the location code
+        %w[pv pa gp qk pf pfh].each do |code|
           context "when retention reason is #{retention_reason} and not committed to retain and location is #{code}" do
             it 'is checking the location and returns Shared' do
               item = described_class.new(
@@ -132,7 +143,8 @@ RSpec.describe AlmaAdapter::AlmaItem do
   end
 
   describe '#recap_use_restriction' do
-    %w[pj pk pl pm pn pt].each do |code|
+    # pjg is a fake location to test the first two letters of the location code
+    %w[pj pk pl pm pn pt pjg].each do |code|
       context "When location is #{code}" do
         it 'returns In Library Use' do
           item = described_class.new(


### PR DESCRIPTION
closes #3022

Update alma item to check for the first two characters of the location code

It helps to accept new recap locations with three characters that match the first two of the existing recap location characters.

related to [#3022]


[SCSB accession documentation](https://htcrecap.atlassian.net/wiki/spaces/RTG/pages/2123825250/SCSB+Accession)