### PR TITLE
Remove unneeded use<> lifetime captures in impl Trait bounds

### DIFF
--- a/lib/bibdata_rs/src/marc/cjk.rs
+++ b/lib/bibdata_rs/src/marc/cjk.rs
@@ -123,7 +123,7 @@ pub fn cjk_series_titles(record: &Record) -> impl Iterator<Item = String> {
     series_title_fields.chain(fields_with_author_and_title_info)
 }
 
-pub fn notes_cjk(record: &Record) -> impl Iterator<Item = String> + use<'_> {
+pub fn notes_cjk(record: &Record) -> impl Iterator<Item = String> {
     // These notes are supposedly in Latin script, but still may contain some
     // CJK characters
     let latin_script_note_fields = record.extract_fields(500..=599);
@@ -145,7 +145,7 @@ pub fn notes_cjk(record: &Record) -> impl Iterator<Item = String> + use<'_> {
         .filter(|note| has_cjk_chars(note))
 }
 
-pub fn subjects_cjk(record: &Record) -> impl Iterator<Item = String> + use<'_> {
+pub fn subjects_cjk(record: &Record) -> impl Iterator<Item = String> {
     record.extract_field_values_by(
         non_latin_tag_included_in(&["600", "610", "611", "630", "650", "651"]),
         |field| {

--- a/lib/bibdata_rs/src/marc/identifier.rs
+++ b/lib/bibdata_rs/src/marc/identifier.rs
@@ -36,7 +36,7 @@ pub fn map_024_indicators_to_labels(indicator: char) -> &'static str {
 
 // Record control numbers can either be OCLC numbers (which are normalized to a format like ocn991350412)
 // or some other type of control number (which are normalized and include the prefix BIB)
-fn linked_record_control_numbers(record: &Record) -> impl Iterator<Item = String> + use<'_> {
+fn linked_record_control_numbers(record: &Record) -> impl Iterator<Item = String> {
     record
         .extract_values("776w:787w")
         .into_iter()

--- a/lib/bibdata_rs/src/marc/identifier/isbn.rs
+++ b/lib/bibdata_rs/src/marc/identifier/isbn.rs
@@ -1,7 +1,7 @@
 use library_stdnums::{isbn::ISBN, traits::Normalize};
 use marctk::Record;
 
-pub fn normalized_isbns_for_all_versions(record: &Record) -> impl Iterator<Item = String> + use<'_> {
+pub fn normalized_isbns_for_all_versions(record: &Record) -> impl Iterator<Item = String> {
     record
         .extract_values("020az:776z")
         .into_iter()

--- a/lib/bibdata_rs/src/marc/identifier/issn.rs
+++ b/lib/bibdata_rs/src/marc/identifier/issn.rs
@@ -1,7 +1,7 @@
 use library_stdnums::{issn::ISSN, traits::Normalize};
 use marctk::Record;
 
-pub fn normalized_issns_for_all_versions(record: &Record) -> impl Iterator<Item = String> + use<'_> {
+pub fn normalized_issns_for_all_versions(record: &Record) -> impl Iterator<Item = String> {
     record
         .extract_values("022alyz:776x")
         .into_iter()

--- a/lib/bibdata_rs/src/marc/identifier/oclc.rs
+++ b/lib/bibdata_rs/src/marc/identifier/oclc.rs
@@ -6,7 +6,7 @@ use marctk::Record;
 use regex::Regex;
 use std::sync::LazyLock;
 
-pub fn normalized_oclc_numbers(record: &Record) -> impl Iterator<Item = String> + use<> {
+pub fn normalized_oclc_numbers(record: &Record) -> impl Iterator<Item = String> {
     system_control_numbers(record)
         .into_iter()
         .filter_map(|number| match number {

--- a/lib/bibdata_rs/src/marc/publication.rs
+++ b/lib/bibdata_rs/src/marc/publication.rs
@@ -12,7 +12,7 @@ use super::{
 use itertools::Itertools;
 use marctk::Record;
 
-pub fn pub_created_display(record: &Record) -> impl Iterator<Item = String> + use<'_> {
+pub fn pub_created_display(record: &Record) -> impl Iterator<Item = String> {
     statements_from_260(record)
         .chain(statements_from_parallel_260(record))
         .chain(statements_from_264(record))
@@ -41,7 +41,7 @@ pub fn pub_citation_display(record: &Record) -> impl Iterator<Item = String> {
         .unique()
 }
 
-fn statements_from_264(record: &Record) -> impl Iterator<Item = String> + use<'_> {
+fn statements_from_264(record: &Record) -> impl Iterator<Item = String> {
     record
         .extract_partial_fields("264abcefg3")
         .into_iter()
@@ -49,7 +49,7 @@ fn statements_from_264(record: &Record) -> impl Iterator<Item = String> + use<'_
         .map(|field| join_all_subfields(&field))
 }
 
-fn statements_from_260(record: &Record) -> impl Iterator<Item = String> + use<'_> {
+fn statements_from_260(record: &Record) -> impl Iterator<Item = String> {
     record
         .extract_partial_fields("260abcefg")
         .into_iter()
@@ -59,7 +59,7 @@ fn statements_from_260(record: &Record) -> impl Iterator<Item = String> + use<'_
         })
 }
 
-fn statements_from_parallel_264(record: &Record) -> impl Iterator<Item = String> + use<'_> {
+fn statements_from_parallel_264(record: &Record) -> impl Iterator<Item = String> {
     record
         .get_parallel_fields("264")
         .into_iter()
@@ -72,7 +72,7 @@ fn statements_from_parallel_264(record: &Record) -> impl Iterator<Item = String>
         })
 }
 
-fn statements_from_parallel_260(record: &Record) -> impl Iterator<Item = String> + use<'_> {
+fn statements_from_parallel_260(record: &Record) -> impl Iterator<Item = String> {
     record
         .get_parallel_fields("260")
         .into_iter()


### PR DESCRIPTION
These are no longer needed in Rust 2024

See https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html