### PR TITLE
Use bundle install, rather than circleci ruby/install-deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,11 +111,11 @@ jobs:
       - image: cimg/ruby:3.4
     steps:
       - checkout
-      - ruby/install-deps
+      - run: bundle install
       - rust/install
       - run:
           name: Install cargo-llvm-cov
-          command: cargo +stable install cargo-llvm-cov --locked
+          command: cargo install cargo-llvm-cov --locked
       - run:
           name: Run tests with coverage
           command: bundle exec cargo llvm-cov --lcov --output-path lcov.info --ignore-filename-regex iso_639


### PR DESCRIPTION
The ruby/install-deps keeps failing with the message 'Killed'