### PR TITLE
Be more selective about which gems we install for the rust tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,11 +111,13 @@ jobs:
       - image: cimg/ruby:3.4
     steps:
       - checkout
+      # Our rust tests only rely on production gem dependencies (like ruby-marc)
+      - run: bundle config set --local without development test
       - ruby/install-deps
       - rust/install
       - run:
           name: Install cargo-llvm-cov
-          command: cargo +stable install cargo-llvm-cov --locked
+          command: cargo install cargo-llvm-cov --locked
       - run:
           name: Run tests with coverage
           command: bundle exec cargo llvm-cov --lcov --output-path lcov.info --ignore-filename-regex iso_639


### PR DESCRIPTION
Hopefully this keeps us from getting the 'Killed' signal on bundle install...