### PR TITLE
Use official ruby docker image instead of circleci's

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,14 +108,16 @@ jobs:
 
   rust_test:
     docker:
-      - image: cimg/ruby:3.4
+      - image: ruby:3.4
     steps:
       - checkout
-      - ruby/install-deps
+      - run: apt-get -y update
+      - run: apt-get install -y libclang-dev
       - rust/install
+      - ruby/install-deps
       - run:
           name: Install cargo-llvm-cov
-          command: cargo +stable install cargo-llvm-cov --locked
+          command: cargo install cargo-llvm-cov --locked
       - run:
           name: Run tests with coverage
           command: bundle exec cargo llvm-cov --lcov --output-path lcov.info --ignore-filename-regex iso_639


### PR DESCRIPTION
This seems to resolve the 'killed' signal that we were getting when running `bundle install`