### PR TITLE
Fix author_roles serialization in Solr documents

### DIFF
--- a/lib/bibdata_rs/src/marc/title.rs
+++ b/lib/bibdata_rs/src/marc/title.rs
@@ -24,20 +24,19 @@ pub fn contains_titles_index(record: &Record) -> impl Iterator<Item = String> {
 }
 
 pub fn latin_script_title(record: &Record) -> Option<String> {
-    record
-        .first_matching_field_value(
-            |field| field.tag() == "245",
-            |field| {
-                Some(
-                    field
-                        .subfields()
-                        .iter()
-                        .filter(|subfield| ["abchknps"].contains(&subfield.code()))
-                        .map(|subfield| subfield.content())
-                        .join(" "),
-                )
-            },
-        )
+    record.first_matching_field_value(
+        |field| field.tag() == "245",
+        |field| {
+            Some(
+                field
+                    .subfields()
+                    .iter()
+                    .filter(|subfield| ["abchknps"].contains(&subfield.code()))
+                    .map(|subfield| subfield.content())
+                    .join(" "),
+            )
+        },
+    )
 }
 
 pub fn title_sort(record: &Record) -> Option<String> {

--- a/lib/bibdata_rs/src/solr/author_roles.rs
+++ b/lib/bibdata_rs/src/solr/author_roles.rs
@@ -1,16 +1,36 @@
 // This module is responsible for creating a JSON formatted list of authors
 // and their roles.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, ser::Error};
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
 pub struct AuthorRoles {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub primary_author: Option<String>,
     pub secondary_authors: Vec<String>,
     pub translators: Vec<String>,
     pub editors: Vec<String>,
     pub compilers: Vec<String>,
+}
+
+impl Serialize for AuthorRoles {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut hash = serde_json::Map::new();
+        let cloned = self.clone();
+        if let Some(primary) = cloned.primary_author {
+            hash.insert(String::from("primary_author"), primary.into());
+        }
+        hash.insert(
+            String::from("secondary_authors"),
+            cloned.secondary_authors.into(),
+        );
+        hash.insert(String::from("translators"), cloned.translators.into());
+        hash.insert(String::from("editors"), cloned.editors.into());
+        hash.insert(String::from("compilers"), cloned.compilers.into());
+        serializer.serialize_str(&serde_json::to_string(&hash).map_err(S::Error::custom)?)
+    }
 }
 
 #[cfg(test)]
@@ -21,7 +41,7 @@ mod tests {
     fn it_serializes_correctly() {
         assert_eq!(
             serde_json::to_string(&AuthorRoles::default()).unwrap(),
-            r#"{"secondary_authors":[],"translators":[],"editors":[],"compilers":[]}"#
+            r#""{\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[]}""#
         );
         assert_eq!(
             serde_json::to_string(&AuthorRoles {
@@ -29,7 +49,7 @@ mod tests {
                 ..Default::default()
             })
             .unwrap(),
-            r#"{"primary_author":"Ginger","secondary_authors":[],"translators":[],"editors":[],"compilers":[]}"#
+            r#""{\"primary_author\":\"Ginger\",\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[]}""#
         );
         assert_eq!(
             serde_json::to_string(&AuthorRoles {
@@ -38,7 +58,7 @@ mod tests {
                 ..Default::default()
             })
             .unwrap(),
-            r#"{"primary_author":"Ginger","secondary_authors":[],"translators":[],"editors":[],"compilers":["Galangal"]}"#
+            r#""{\"primary_author\":\"Ginger\",\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[\"Galangal\"]}""#
         );
         assert_eq!(
             serde_json::to_string(&AuthorRoles {
@@ -46,7 +66,7 @@ mod tests {
                 ..Default::default()
             })
             .unwrap(),
-            r#"{"secondary_authors":["Cardamom","Turmeric"],"translators":[],"editors":[],"compilers":[]}"#
+            r#""{\"secondary_authors\":[\"Cardamom\",\"Turmeric\"],\"translators\":[],\"editors\":[],\"compilers\":[]}""#
         );
     }
 }

--- a/lib/bibdata_rs/src/solr/index.rs
+++ b/lib/bibdata_rs/src/solr/index.rs
@@ -21,16 +21,19 @@ pub fn index_string(ruby: &Ruby, solr_url: String, documents: String) -> Result<
             "No documents to index",
         ));
     }
-    let document_vec: Vec<SolrDocument> = serde_json::from_str(&documents).map_err(|e| {
-        magnus::Error::new(
-            ruby.exception_runtime_error(),
-            format!(
-                "Coulld not parse documents from JSON string: {:?}, {}",
-                e, documents
-            ),
-        )
-    })?;
-    index(&solr_url, &document_vec).expect("Failed to index documents");
+    let client = reqwest::blocking::Client::new();
+    let commit_url = format!("{solr_url}/update?commit=true");
+    client
+        .post(&commit_url)
+        .body(documents)
+        .header(CONTENT_TYPE, "application/json")
+        .send()
+        .map_err(|e| {
+            magnus::Error::new(
+                ruby.exception_runtime_error(),
+                format!("Error posting to solr, {}", e),
+            )
+        })?;
     Ok(())
 }
 

--- a/lib/bibdata_rs/src/solr/solr_document.rs
+++ b/lib/bibdata_rs/src/solr/solr_document.rs
@@ -175,4 +175,18 @@ mod tests {
             r#""electronic_access_1display":"{\"http://arks.princeton.edu/ark:/88435/dsp01b2773v788\":[\"DataSpace\",\"Full text\"]}""#
         ))
     }
+
+    #[test]
+    fn it_can_serialize_an_author_roles() {
+        let document = SolrDocument::builder()
+            .with_author_roles_1display(AuthorRoles {
+                primary_author: Some(String::from("Prang, Louis")),
+                ..Default::default()
+            })
+            .build();
+        let serialized = serde_json::to_string(&document).unwrap();
+        assert!(serialized.contains(
+            r#""author_roles_1display":"{\"primary_author\":\"Prang, Louis\",\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[]}""#
+        ))
+    }
 }


### PR DESCRIPTION
The author_roles_1display field should be a string with escaped JSON inside, but instead was incorrectly just regular JSON with no escaping.

As a result, we could not index ephemera because solr rejected it with an unintuitive error:

```
Exception
org.apache.solr.common.SolrException: Can't use SignatureUpdateProcessor with partial update request containing signature field: id
```

This commit fixes the serialization to be an escaped string again.