### PR TITLE
Add some documentation to Fixed Field enums

### DIFF
--- a/lib/bibdata_rs/src/marc/fixed_field/leader/bibliographic_level.rs
+++ b/lib/bibdata_rs/src/marc/fixed_field/leader/bibliographic_level.rs
@@ -1,12 +1,20 @@
 use marctk::Record;
 
+/// The Bibliographic Level is taken from LDR/07 of a MARC record
 pub enum BibliographicLevel {
+    /// LDR/07 a
     MonographicComponentPart,
+    /// LDR/07 b
     SerialComponentPart,
+    /// LDR/07 c
     Collection,
+    /// LDR/07 d
     Subunit,
+    /// LDR/07 i
     IntegratingResource,
+    /// LDR/07 m
     MonographItem,
+    /// LDR/07 s
     Serial,
 }
 

--- a/lib/bibdata_rs/src/marc/fixed_field/leader/type_of_record.rs
+++ b/lib/bibdata_rs/src/marc/fixed_field/leader/type_of_record.rs
@@ -1,19 +1,34 @@
 use marctk::Record;
 
+/// The Type of Record is taken from LDR/06 of a MARC record
 pub enum TypeOfRecord {
+    /// LDR/06 a
     LanguageMaterial,
+    /// LDR/06 c
     NotatedMusic,
+    /// LDR/06 d
     ManuscriptNotatedMusic,
+    /// LDR/06 e
     CartographicMaterial,
+    /// LDR/06 f
     ManuscriptCartographicMaterial,
+    /// LDR/06 g
     ProjectedMedium,
+    /// LDR/06 i
     NonmusicalSoundRecording,
+    /// LDR/06 j
     MusicalSoundRecording,
+    /// LDR/06 k
     TwoDimensionalNonProjectableGraphic,
+    /// LDR/06 m
     ComputerFile,
+    /// LDR/06 o
     Kit,
+    /// LDR/06 p
     MixedMaterials,
+    /// LDR/06 r
     ThreeDimensionalArtifactOrNaturallyOcurringObject,
+    /// LDR/06 t
     ManuscriptLanguageMaterial,
 }
 

--- a/lib/bibdata_rs/src/marc/fixed_field/literary_form.rs
+++ b/lib/bibdata_rs/src/marc/fixed_field/literary_form.rs
@@ -1,17 +1,29 @@
 use marctk::Record;
 
+/// The Literary Form is taken from 008/33 in the MARC record
 #[derive(Debug, PartialEq)]
 pub enum LiteraryForm {
+    /// 008/33 0
     NotFiction,
+    /// 008/33 1
     Fiction,
+    /// 008/33 d
     Dramas,
+    /// 008/33 e
     Essays,
+    /// 008/33 f
     Novels,
+    /// 008/33 h
     HumorSatireEtc,
+    /// 008/33 i
     Letters,
+    /// 008/33 j
     ShortStories,
+    /// 008/33 m
     MixedForms,
+    /// 008/33 p
     Poetry,
+    /// 008/33 s
     Speeches,
 }
 


### PR DESCRIPTION
This allows helpful reminders to pop up when you hover over these enums and values elsewhere in the code in your editor.