### PR TITLE
Remove code that is never called

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -1372,10 +1372,6 @@ each_record do |record, context|
       if mapped_codes[l]
         context.output_hash['location_display'] ||= []
         context.output_hash['location_display'] << mapped_codes[l]
-
-        if /^ReCAP/ =~ mapped_codes[l] && ['Special Collections', 'Marquand Library'].include?(holding_library[l])
-          context.output_hash['location'] << holding_library[l]
-        end
       else
         logger.error "#{record['001']} - Invalid Location Code: #{l}"
       end


### PR DESCRIPTION
When it was first checked in (in 83109f1da2be2c892886693669b209307360da5d), the holding_library translation map included values like "Marquand Library" and "Special Collections".

However, today, it only includes a single value, "ReCAP". Therefore, this condition is never true and the code is never called.