### PR TITLE
Reimplement an AugmentTheSubject method in Rust

### DIFF
--- a/lib/bibdata_rs/src/marc.rs
+++ b/lib/bibdata_rs/src/marc.rs
@@ -28,6 +28,7 @@ mod non_latin;
 mod ruby_bindings;
 mod string_normalize;
 mod title;
+mod utils;
 
 pub use ruby_bindings::register_ruby_methods;
 pub use string_normalize::trim_punctuation;

--- a/lib/bibdata_rs/src/marc/genre.rs
+++ b/lib/bibdata_rs/src/marc/genre.rs
@@ -1,7 +1,5 @@
 use crate::marc::{
-    extract_values::ExtractValues,
-    subject::hierarchical_heading,
-    variable_length_field::{SubfieldIterator, latin_or_non_latin_tag_included_in},
+    extract_values::ExtractValues, subject::hierarchical_heading, utils::slice::contains_subslice, variable_length_field::{SubfieldIterator, latin_or_non_latin_tag_included_in}
 };
 
 use super::{
@@ -209,11 +207,7 @@ impl ComparableTerm {
         //   * Fox art
         //   * art Pictorial
         //   * Pictorial works -- which is a match!!
-        self.0.windows(part.len()).any(|window| window == part.0)
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
+        contains_subslice(&self.0, &part.0)
     }
 }
 impl From<&str> for ComparableTerm {

--- a/lib/bibdata_rs/src/marc/indigenous_studies.rs
+++ b/lib/bibdata_rs/src/marc/indigenous_studies.rs
@@ -1,16 +1,23 @@
-use crate::marc::subject::SEPARATOR;
+use crate::marc::{subject::SEPARATOR, utils::slice::contains_subslice};
 use serde::{Deserialize, Deserializer};
-use std::{collections::HashSet, sync::LazyLock};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::LazyLock,
+};
 
 // This file can be re-created using `bundle exec rake augment:recreate_fixtures`
 const MAIN_TERMS_JSON: &str =
     include_str!("../../../../marc_to_solr/lib/augment_the_subject/standalone_subfield_a.json");
+// This file can be re-created using `bundle exec rake augment:recreate_fixtures`
+const COMBINED_TERMS_JSON: &str = include_str!(
+    "../../../../marc_to_solr/lib/augment_the_subject/indigenous_studies_required.json"
+);
 // This file must be created by hand from file provided by metadata librarians
 const SUBFIELDS_JSON: &str =
     include_str!("../../../../marc_to_solr/lib/augment_the_subject/standalone_subfield_x.json");
 
-fn normalize(raw: &str) -> String {
-    raw.to_lowercase()
+fn normalize(raw: impl AsRef<str>) -> String {
+    raw.as_ref().to_lowercase()
 }
 
 // Normalize terms as we deserialize, so that we don't have to do it for every comparison
@@ -19,7 +26,7 @@ where
     D: Deserializer<'de>,
 {
     let raw: HashSet<String> = HashSet::deserialize(deserializer)?;
-    Ok(raw.iter().map(|str| normalize(str)).collect())
+    Ok(raw.iter().map(normalize).collect())
 }
 
 #[derive(Deserialize)]
@@ -51,6 +58,23 @@ static LCSH_MAIN_TERMS: LazyLock<LcshIndigenousStudiesMainTerms> = LazyLock::new
         .expect("Could not parse AugmentTheSubject standalone_subfield_a file")
 });
 
+static LCSH_COMBINED_TERMS: LazyLock<HashMap<String, Vec<Vec<String>>>> = LazyLock::new(|| {
+    let raw: HashMap<&str, Vec<Vec<&str>>> = serde_json::from_str(COMBINED_TERMS_JSON)
+        .expect("Could not parse the AugmentTheSubject indigenous_studies_required file");
+
+    let mut normalized = HashMap::with_capacity(raw.capacity());
+    for (key, value) in raw.iter() {
+        let _ = normalized.insert(
+            normalize(key),
+            value
+                .iter()
+                .map(|terms| terms.iter().map(normalize).collect())
+                .collect(),
+        );
+    }
+    normalized
+});
+
 static LCSH_SUBFIELDS: LazyLock<LcshIndigenousStudiesSubfields> = LazyLock::new(|| {
     serde_json::from_str(SUBFIELDS_JSON)
         .expect("Could not parse AugmentTheSubject standalone_subfield_x file")
@@ -67,6 +91,26 @@ pub fn has_main_term_related_to_indigenous_studies(term: &str) -> bool {
     })
 }
 
+pub fn has_combined_term_related_to_indigenous_studies(term: &str) -> bool {
+    // Return early if the term has no subdivisions
+    if !term.contains(SEPARATOR) {
+        return false;
+    }
+
+    let mut subfields = term.split(SEPARATOR);
+    let main_term = subfields.next();
+    let subdivisions: Vec<String> = subfields.map(normalize).collect();
+
+    main_term
+        .and_then(|main| LCSH_COMBINED_TERMS.get(&normalize(main)))
+        .is_some_and(|subdivision_windows| {
+            subdivision_windows
+                .iter()
+                .any(|window| contains_subslice(&subdivisions, window))
+        })
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -79,5 +123,21 @@ mod tests {
     #[test]
     fn it_has_the_expected_number_of_subfields() {
         assert_eq!(LCSH_SUBFIELDS.standalone_subfield_x.len(), 26);
+    }
+
+    #[test]
+    fn it_can_find_a_combined_term() {
+        assert!(has_combined_term_related_to_indigenous_studies(
+            "Embroidery—Arctic regions"
+        ));
+        assert!(has_combined_term_related_to_indigenous_studies(
+            "Embroidery—ARctic regions"
+        ));
+        assert!(!has_combined_term_related_to_indigenous_studies(
+            "Embroidery"
+        ));
+        assert!(!has_combined_term_related_to_indigenous_studies(
+            "Embroidery—Conservation and restoration"
+        ));
     }
 }

--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -34,6 +34,10 @@ pub fn register_ruby_methods(parent_module: &RModule) -> Result<(), magnus::Erro
         function!(ruby_current_location_code, 1),
     )?;
     submodule_marc.define_singleton_method(
+        "has_combined_term_related_to_indigenous_studies",
+        function!(has_combined_term_related_to_indigenous_studies, 1),
+    )?;
+    submodule_marc.define_singleton_method(
         "has_main_term_related_to_indigenous_studies",
         function!(has_main_term_related_to_indigenous_studies, 1),
     )?;
@@ -195,6 +199,10 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
     hash.aset("title_t", title_t)?;
 
     Ok(hash)
+}
+
+fn has_combined_term_related_to_indigenous_studies(term: String) -> Result<bool, magnus::Error> {
+    Ok(indigenous_studies::has_combined_term_related_to_indigenous_studies(&term))
 }
 
 fn has_subfield_related_to_indigenous_studies(term: String) -> Result<bool, magnus::Error> {

--- a/lib/bibdata_rs/src/marc/utils.rs
+++ b/lib/bibdata_rs/src/marc/utils.rs
@@ -1,0 +1,1 @@
+pub mod slice;

--- a/lib/bibdata_rs/src/marc/utils/slice.rs
+++ b/lib/bibdata_rs/src/marc/utils/slice.rs
@@ -1,0 +1,34 @@
+//! Utilities related to slices
+
+/// See if a slice (e.g. &vec![1, 2, 3]) contains a subslice (e.g. &vec![2, 3])
+/// in order.
+pub fn contains_subslice<T: PartialEq>(slice: &[T], subslice: &[T]) -> bool {
+    if subslice.is_empty() {
+        return true;
+    }
+    if subslice.len() > slice.len() {
+        return false;
+    }
+    slice.windows(subslice.len()).any(|w| w == subslice)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_can_determine_if_slice_contains_subslice() {
+        assert!(contains_subslice(&[1, 2, 3], &[]));
+        assert!(contains_subslice(&[1, 2, 3], &[1]));
+        assert!(contains_subslice(&[1, 2, 3], &[1, 2]));
+        assert!(contains_subslice(&[1, 2, 3], &[1, 2, 3]));
+        assert!(contains_subslice(&[1, 2, 3], &[2, 3]));
+        assert!(contains_subslice(&[1, 2, 3], &[2]));
+        assert!(contains_subslice(&[1, 2, 3], &[3]));
+
+        assert!(!contains_subslice(&[1, 2, 3], &[3, 2, 1]));
+        assert!(!contains_subslice(&[1, 2, 3], &[1, 1]));
+        assert!(!contains_subslice(&[1, 2, 3], &[1, 2, 3, 4]));
+    }
+}

--- a/marc_to_solr/lib/augment_the_subject.rb
+++ b/marc_to_solr/lib/augment_the_subject.rb
@@ -86,17 +86,7 @@ class AugmentTheSubject
   # For example, "Alaska-Antiquities" should be a match, but "Alaska" by itself should not,
   # nor should "Antiquities" by itself.
   def subfield_a_with_required_subfields_match?(term)
-    subfields = term.split(SEPARATOR)
-    subfields = subfields.map { |subfield| normalize(subfield) }
-    subfield_a = subfields.shift.to_sym
-
-    required_subfields = indigenous_studies_required[subfield_a]
-    return false unless required_subfields
-
-    required_subfields.map do |req_terms|
-      return true if req_terms.subset?(subfields.to_set)
-    end
-    false
+    BibdataRs::Marc.has_combined_term_related_to_indigenous_studies(term)
   end
 
   # In order to re-write the fixture file based on a new CSV, run the rake task


### PR DESCRIPTION
It is 2 orders of magnitude faster on this benchmark:

```
require 'benchmark/ips'
def embroidery = AugmentTheSubject.new.indigenous_studies? ['Embroidery—Arctic regions']
Benchmark.ips_quick :embroidery
```

Before:
```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
          embroidery   281.000 i/100ms
Calculating -------------------------------------
          embroidery      2.796k (± 1.6%) i/s  (357.64 μs/i) -     14.050k in   5.026161s
```

After:
```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
          embroidery    20.961k i/100ms
Calculating -------------------------------------
          embroidery    206.179k (± 4.2%) i/s    (4.85 μs/i) -      1.048M in   5.092793s
```

Helps with #2871