### PR TITLE
Use Rust to calculate location names  for advanced_location_s field

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -1375,14 +1375,14 @@ each_record do |record, context|
     holding_library = Traject::TranslationMap.new('holding_library')
 
     # Add library and location for advanced multi-select facet
-    advanced_search_location = context.output_hash['advanced_location_s'] = Array.new(location_codes)
+    context.output_hash['advanced_location_s'] = Array.new(location_codes)
 
     location_codes.each do |l|
       code_location_label = BibdataRs::Marc.mapped_codes_location_label(l)
       if code_location_label.any?
         context.output_hash['location_display'] ||= []
         context.output_hash['location_display'] << code_location_label[l]
-        advanced_search_location << BibdataRs::Marc.library_label(l)
+        context.output_hash['advanced_location_s'] << BibdataRs::Marc.library_label(l)
       else
         logger.error "#{record['001']} - Invalid Location Code: #{l}"
       end

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -1369,25 +1369,24 @@ each_record do |record, context|
   if location_codes.any?
     location_codes.uniq!
     context.output_hash['location_code_s'] = location_codes
-    location_names = Traject::TranslationMap.new('location_display').translate_array(location_codes).uniq
 
     # The holding_library is used with some locations to add an additional owning library,
     # which is included in advanced search but not facets.
     holding_library = Traject::TranslationMap.new('holding_library')
+
+    # Add library and location for advanced multi-select facet
+    advanced_search_location = context.output_hash['advanced_location_s'] = Array.new(location_codes)
+
     location_codes.each do |l|
       code_location_label = BibdataRs::Marc.mapped_codes_location_label(l)
       if code_location_label.any?
         context.output_hash['location_display'] ||= []
         context.output_hash['location_display'] << code_location_label[l]
+        advanced_search_location << BibdataRs::Marc.library_label(l)
       else
         logger.error "#{record['001']} - Invalid Location Code: #{l}"
       end
     end
-
-    # Add library and location for advanced multi-select facet
-    context.output_hash['advanced_location_s'] = Array.new(location_codes)
-    context.output_hash['advanced_location_s'] << location_names
-    context.output_hash['advanced_location_s'].flatten!
   end
 end
 

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -156,6 +156,7 @@ describe 'From traject_config.rb', :indexing do
       it 'indexes the location_code_s' do
         record = @indexer.map_record(fixture_record('9992320213506421'))
         expect(record['location_code_s']).to eq ['lewis$stacks', 'firestone$stacks']
+        expect(record['advanced_location_s']).to eq ['lewis$stacks', 'firestone$stacks', 'Lewis Library', 'Firestone Library']
       end
     end
 


### PR DESCRIPTION
Use Rust to calculate location names to assign to advanced_location_s field
and remove translation maps for this case

related to #3176

The current advanced_location_s would return `expect(record['advanced_location_s']).to eq ['lewis$stacks', 'Lewis Library', 'firestone$stacks', 'Firestone Library']` 

I tested it in orangelight by reindexing the record and there is no impact. 