### PR TITLE
Update test method to run the batches considering only the parent bid and not the to_a order

### DIFF
--- a/spec/models/index_manager_spec.rb
+++ b/spec/models/index_manager_spec.rb
@@ -10,15 +10,23 @@ RSpec.describe IndexManager, :indexing, :sidekiq, type: :model do
     solr.commit
   end
 
+  # rubocop:disable Rails/NegateInclude
   def run_all_callbacks
-    old_batch = nil
-    while (batch = Sidekiq::BatchSet.new.to_a.last).bid != old_batch&.bid
-      old_batch = batch
+    batches_processed = []
+    loop do
+      batch = Sidekiq::BatchSet.new.to_a.find do |b|
+        !batches_processed.include?(b.bid) && b.parent_bid.present?
+      end
+      break unless batch
+
+      batches_processed << batch.bid
       run_callback(batch)
     end
-    # Run callback for the parent batch.
-    run_callback(Sidekiq::BatchSet.new.to_a.first)
+
+    parent_batch = Sidekiq::BatchSet.new.to_a.find { |b| b.parent_bid.nil? }
+    run_callback(parent_batch) if parent_batch
   end
+  # rubocop:enable Rails/NegateInclude
 
   describe '.rebuild_solr_url' do
     it 'appends -rebuild to the URL' do


### PR DESCRIPTION
Update test method to run the batches considering only the parent bid and not the to_a
order of the redis ZRANGE. The ZRANGE to_a order changes in sidekiq-pro 8 to be [child, parent] so this test method will cause the spec that has an incremental and a full dump to fail because the parent job will wait for all the children jobs that are inside the block to run and finish. Then based on that test method it will run last with the sequence of the methods: reindex! will call .wipe! and delete the records that were indexed from the child.

sidekiq-pro gem -> batch.rb Sidekiq::Batch def jobs
notes:
zadd - a redis command that adds a member to a sorted set with a numeric score. Redis sorted sets store members in order by their score.

Pro 7 — score based when Batch.new was called creation time + expiry: m.zadd("batches", @created_f + expiry, bid)

Pro 8 — score based when the jobs block finishes, now + expiry: m.zadd("batches", (Time.now + expiry).to_f, bid)

This difference changes to_a ordering only in tests because of the Sidekiq::Testing.inline!: with inline! the jobs calls perform_async which runs the job synchronously. this job calls index_next_dump to_a order in pro7 is [parent,child] <- ZRANGE
to_a order in pro8 is [child, parent] <- ZRANGE

In pro7 the test assumes that to_a.last is the child because of the ZRANGE. In pro8 the parent will not finish until everything inside the parent block has run. because of the ZRANGE if we use to_a.last the parent will wait for everyhting inside to run then it will run last and the reindex! will call .wipe! and delete the records that were indexed from the child. So in this case to_a.last will call the parent.

helps with upgrading sidekiq-pro to 8
https://github.com/pulibrary/bibdata/pull/3280/