### PR TITLE
Remove dependency on ActiveSupport #try extension from AccessFacetBuilder

### DIFF
--- a/marc_to_solr/lib/access_facet_builder.rb
+++ b/marc_to_solr/lib/access_facet_builder.rb
@@ -44,7 +44,7 @@ class AccessFacetBuilder
     # it's second indicator is 0, 1, or blank
     def marc_indicator
       field = record.find { |f| f.tag == '856' }
-      indicator = field.try(:indicator2)
+      indicator = field&.indicator2
 
       'Online' if ['0', '1', ' '].include?(indicator)
     end


### PR DESCRIPTION
AccessFacetBuilder uses the Rails `#try` method, which is required by the ark cache classes.

This use of `#try` can be replaced with Ruby's built-in safe navigation, so that we no longer depend on the ark cache classes to provide the Rails `#try` method.