### PR TITLE
Update holding_locations_controller to use new implementation for show page

### DIFF
--- a/app/controllers/holding_locations_controller.rb
+++ b/app/controllers/holding_locations_controller.rb
@@ -16,6 +16,7 @@ class HoldingLocationsController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_holding_location
       # nosemgrep
+      @holding_location_rust = BibdataRs::Location.holding_location(params[:id])
       @holding_location = HoldingLocation.friendly.find(params[:id])
     end
 end

--- a/app/controllers/holding_locations_controller.rb
+++ b/app/controllers/holding_locations_controller.rb
@@ -15,8 +15,8 @@ class HoldingLocationsController < ApplicationController
 
     # Use callbacks to share common setup or constraints between actions.
     def set_holding_location
-      # nosemgrep
       @holding_location_rust = BibdataRs::Location.holding_location(params[:id])
+      # nosemgrep
       @holding_location = HoldingLocation.friendly.find(params[:id])
     end
 end

--- a/app/views/holding_locations/index.json.jbuilder
+++ b/app/views/holding_locations/index.json.jbuilder
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 json.array!(@holding_locations) do |holding_location|
+  json.extract! holding_location, :label, :code
   json.partial! 'holding_locations/json_partials/show_fields',
                 holding_location: holding_location
 

--- a/app/views/holding_locations/json_partials/_show_fields.json.jbuilder
+++ b/app/views/holding_locations/json_partials/_show_fields.json.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.extract! holding_location, :label, :code, :aeon_location,
+json.extract! holding_location, :aeon_location,
               :recap_electronic_delivery_location, :open, :requestable,
               :always_requestable, :circulates, :remote_storage, :fulfillment_unit

--- a/app/views/holding_locations/json_partials/_show_rust_fields.json.jbuilder
+++ b/app/views/holding_locations/json_partials/_show_rust_fields.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.extract! holding_location_rust, :label, :code

--- a/app/views/holding_locations/show.html.erb
+++ b/app/views/holding_locations/show.html.erb
@@ -1,11 +1,11 @@
 <p>
   <strong>Label:</strong>
-  <%= @holding_location.label %>
+  <%= @holding_location_rust.label %>
 </p>
 
 <p>
   <strong>Code:</strong>
-  <%= @holding_location.code %>
+  <%= @holding_location_rust.code %>
 </p>
 
 <p>

--- a/app/views/holding_locations/show.json.jbuilder
+++ b/app/views/holding_locations/show.json.jbuilder
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+json.partial! 'holding_locations/json_partials/show_rust_fields',
+              holding_location_rust: @holding_location_rust
+
 json.partial! 'holding_locations/json_partials/show_fields',
               holding_location: @holding_location
 

--- a/lib/bibdata_rs/src/lib.rs
+++ b/lib/bibdata_rs/src/lib.rs
@@ -50,6 +50,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
         function!(languages::two_letter_code_owned, 1),
     )?;
     marc::register_ruby_methods(&module)?;
+    locations::register_ruby_methods(&ruby, &module)?;
     Ok(())
 }
 

--- a/lib/bibdata_rs/src/lib.rs
+++ b/lib/bibdata_rs/src/lib.rs
@@ -50,7 +50,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
         function!(languages::two_letter_code_owned, 1),
     )?;
     marc::register_ruby_methods(&module)?;
-    locations::register_ruby_methods(&ruby, &module)?;
+    locations::register_ruby_methods(ruby, &module)?;
     Ok(())
 }
 

--- a/lib/bibdata_rs/src/locations.rs
+++ b/lib/bibdata_rs/src/locations.rs
@@ -1,6 +1,7 @@
-use std::{collections::HashMap, sync::LazyLock};
 use serde::Deserialize;
-
+use std::{collections::HashMap, sync::LazyLock};
+pub mod ruby_bindings;
+pub use ruby_bindings::register_ruby_methods;
 #[derive(Deserialize)]
 pub struct Library<'a> {
     pub label: &'a str,
@@ -11,6 +12,46 @@ pub struct Location<'a> {
     pub label: &'a str,
     pub code: &'a str,
     pub library: Library<'a>,
+}
+
+#[magnus::wrap(class = "BibdataRs::Library", free_immediately, size)]
+#[derive(Clone)]
+pub struct LibraryRuby {
+    pub label: String,
+}
+
+#[magnus::wrap(class = "BibdataRs::Location", free_immediately, size)]
+#[derive(Clone)]
+pub struct LocationRuby {
+    pub label: String,
+    pub code: String,
+    pub library: LibraryRuby,
+}
+
+impl<'a> From<&Location<'a>> for LocationRuby {
+    fn from(location: &Location<'a>) -> Self {
+        LocationRuby {
+            label: location.label.to_string(),
+            code: location.code.to_string(),
+            library: LibraryRuby {
+                label: location.library.label.to_string(),
+            },
+        }
+    }
+}
+
+impl LocationRuby {
+    fn label(&self) -> String {
+        self.label.clone()
+    }
+
+    fn code(&self) -> String {
+        self.code.clone()
+    }
+
+    fn holding_location(code: String) -> Option<Self> {
+        HOLDING_LOCATIONS.get(code.as_str()).map(LocationRuby::from)
+    }
 }
 
 const HOLDING_LOCATION_JSON: &str =
@@ -25,3 +66,24 @@ pub static HOLDING_LOCATIONS: LazyLock<HashMap<&str, Location>> = LazyLock::new(
     }
     hash
 });
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_can_get_a_location_label() {
+        assert_eq!(
+            HOLDING_LOCATIONS.get("engineer$stacks").unwrap().label,
+            "Stacks"
+        );
+    }
+
+    #[test]
+    fn it_can_get_a_location_code() {
+        assert_eq!(
+            HOLDING_LOCATIONS.get("engineer$stacks").unwrap().code,
+            "engineer$stacks"
+        );
+    }
+}

--- a/lib/bibdata_rs/src/locations/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/locations/ruby_bindings.rs
@@ -1,0 +1,38 @@
+use crate::locations::LocationRuby;
+use magnus::{RModule, Ruby, function, method, prelude::*};
+
+pub fn register_ruby_methods(ruby: &Ruby, parent_module: &RModule) -> Result<(), magnus::Error> {
+    let class = parent_module.define_class("Location", ruby.class_object())?;
+    class.define_method("label", method!(LocationRuby::label, 0))?;
+    class.define_method("code", method!(LocationRuby::code, 0))?;
+    class.define_singleton_method(
+        "holding_location",
+        function!(LocationRuby::holding_location, 1),
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_can_get_a_location_label() {
+        assert_eq!(
+            LocationRuby::holding_location("engineer$stacks".to_owned())
+                .unwrap()
+                .label(),
+            "Stacks"
+        );
+    }
+
+    #[test]
+    fn it_can_get_a_location_code() {
+        assert_eq!(
+            LocationRuby::holding_location("engineer$stacks".to_owned())
+                .unwrap()
+                .code(),
+            "engineer$stacks"
+        );
+    }
+}

--- a/spec/requests/holding_locations_json_view_spec.rb
+++ b/spec/requests/holding_locations_json_view_spec.rb
@@ -3,6 +3,20 @@
 require 'rails_helper'
 
 describe 'HoldingLocation', type: :request do
+  def stub_holding_location_rust(holding_location, label: nil, code: nil)
+    rust_holding_location = instance_double(
+      BibdataRs::Location,
+      label: label || "Rust #{holding_location.label}",
+      code: code || "rust:#{holding_location.code}"
+    )
+
+    allow(BibdataRs::Location).to receive(:holding_location)
+      .with(holding_location.code)
+      .and_return(rust_holding_location)
+
+    rust_holding_location
+  end
+
   context 'with a json view' do
     it 'Renders the json template' do
       get holding_locations_path, params: { format: :json }
@@ -73,14 +87,15 @@ describe 'HoldingLocation', type: :request do
         create(:library)
         create(:delivery_location)
         holding_location = create(:holding_location)
+        holding_location_rust = stub_holding_location_rust(holding_location)
         2.times do
           dl = create(:delivery_location)
           holding_location.delivery_locations << dl
         end
         holding_location.reload
         expected = {
-          label: holding_location.label,
-          code: holding_location.code,
+          label: holding_location_rust.label,
+          code: holding_location_rust.code,
           aeon_location: holding_location.aeon_location,
           recap_electronic_delivery_location: holding_location.recap_electronic_delivery_location,
           open: holding_location.open,
@@ -122,6 +137,7 @@ describe 'HoldingLocation', type: :request do
         create(:library)
         create(:delivery_location)
         holding_location = create(:holding_location)
+        holding_location_rust = stub_holding_location_rust(holding_location)
         2.times do
           dl = create(:delivery_location)
           holding_location.delivery_locations << dl
@@ -129,8 +145,8 @@ describe 'HoldingLocation', type: :request do
         holding_location.update(holding_library: create(:library))
         holding_location.reload
         expected = {
-          label: holding_location.label,
-          code: holding_location.code,
+          label: holding_location_rust.label,
+          code: holding_location_rust.code,
           aeon_location: holding_location.aeon_location,
           recap_electronic_delivery_location: holding_location.recap_electronic_delivery_location,
           open: holding_location.open,
@@ -227,14 +243,15 @@ describe 'HoldingLocation', type: :request do
         create(:library)
         create(:delivery_location)
         holding_location = create(:holding_location)
+        holding_location_rust = stub_holding_location_rust(holding_location)
         2.times do
           dl = create(:delivery_location)
           holding_location.delivery_locations << dl
         end
         holding_location.reload
         expected = [
-          CGI.escapeHTML(holding_location.label),
-          holding_location.code,
+          CGI.escapeHTML(holding_location_rust.label),
+          holding_location_rust.code,
           holding_location.aeon_location,
           holding_location.recap_electronic_delivery_location,
           holding_location.open,

--- a/spec/system/location_views_associated_links_spec.rb
+++ b/spec/system/location_views_associated_links_spec.rb
@@ -6,6 +6,19 @@ describe 'Holding Location views link to other associated locations' do
   let(:library) { create(:library) }
   let(:delivery_location) { create(:delivery_location) }
   let(:holding_location) { create(:holding_location) }
+  let(:holding_location_rust) do
+    instance_double(
+      BibdataRs::Location,
+      label: "Rust #{holding_location.label}",
+      code: "rust:#{holding_location.code}"
+    )
+  end
+
+  before do
+    allow(BibdataRs::Location).to receive(:holding_location)
+      .with(holding_location.code)
+      .and_return(holding_location_rust)
+  end
 
   it 'Link to library from library label rather than extra show link' do
     library
@@ -17,6 +30,8 @@ describe 'Holding Location views link to other associated locations' do
     holding_location
     visit holding_locations_path
     click_link holding_location.code
+    expect(page).to have_content(holding_location_rust.label)
+    expect(page).to have_content(holding_location_rust.code)
   end
 
   it 'Link to delivery location from delivery location label rather than extra show link' do


### PR DESCRIPTION
Update holding_locations_controller to use new implementation for show page

We assign a new var to replace with rust and move away from the DB start replacing instances of holding location specifically code and label

Create new ruby_bindings for locations.rs module
In locations use magnus::wrap to wrap the location rust struct
 and serve it to ruby as a ruby class.
We make LocationRuby to behave like a ruby object

Create implementation LocationRuby that uses owned String so that ruby can use it and expose rust methods as ruby methods

related to [#3287]