### PR TITLE
Alternative json encoding implementation

### DIFF
--- a/lib/bibdata_rs/src/marc/contributors.rs
+++ b/lib/bibdata_rs/src/marc/contributors.rs
@@ -141,29 +141,4 @@ mod tests {
             }
         )
     }
-
-    #[test]
-    fn it_does_not_serialize_twice() {
-        let record = Record::from_breaker(
-            r#"=700 1\$aSethi, Bishnupada,$d1967-$1https://id.oclc.org/worldcat/entity/E39PCjvwtBJYbmJmWPHmjpwRGb
-=700 1\$India$bDirector of Census Operations, Odisha.
-=700 1\$aIndia$bOffice of the Registrar General & Census Commissioner."#,
-        )
-        .unwrap();
-        let json_string = serde_json::to_string(&AuthorRoles::from(&record)).unwrap_or_default();
-        assert_eq!(
-            json_string,
-            "{\"secondary_authors\":[\"Sethi, Bishnupada\",\"India\"],\"translators\":[],\"editors\":[],\"compilers\":[]}"
-        );
-        assert_eq!(
-            AuthorRoles::from(&record),
-            AuthorRoles {
-                primary_author: None,
-                secondary_authors: vec!["Sethi, Bishnupada".to_owned(), "India".to_owned()],
-                translators: vec![],
-                editors: vec![],
-                compilers: vec![]
-            }
-        )
-    }
 }

--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -86,13 +86,7 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
         action_notes_1display.push(notes)?;
     }
 
-    let author_roles_1display =
-        serde_json::to_string(&AuthorRoles::from(&record)).map_err(|err| {
-            magnus::Error::new(
-                ruby.exception_runtime_error(),
-                format!("Found error {} while serializing author roles", err),
-            )
-        })?;
+    let author_roles_1display = AuthorRoles::from(&record).to_string();
     let format: Vec<_> = record_facet_mapping::format_facets(&record)
         .iter()
         .map(|facet| format!("{facet}"))
@@ -319,6 +313,21 @@ mod tests {
         assert_eq!(
             rbgenr_s_value,
             vec![String::from("Dictionaries—French—18th century")]
+        );
+    }
+
+    #[ruby_test]
+    fn it_includes_author_roles_in_solr_fields() {
+        let ruby = unsafe { Ruby::get_unchecked() };
+        let ruby_record: magnus::RObject = ruby.eval(r"require 'marc';record = MARC::Record.new;record.append(MARC::DataField.new( '700', '1', '', ['a', 'Sethi, Bishnupada, '], ['d', '1967-']));record").unwrap();
+        let hash = solr_fields(&ruby, ruby_record).unwrap();
+
+        let author_roles_value = hash.aref::<&str, String>("author_roles_1display").unwrap();
+        assert_eq!(
+            author_roles_value,
+            String::from(
+                r#"{"secondary_authors":["Sethi, Bishnupada"],"translators":[],"editors":[],"compilers":[]}"#
+            )
         );
     }
 }

--- a/lib/bibdata_rs/src/solr/author_roles.rs
+++ b/lib/bibdata_rs/src/solr/author_roles.rs
@@ -1,7 +1,7 @@
 // This module is responsible for creating a JSON formatted list of authors
 // and their roles.
 
-use serde::{Deserialize, Serialize, ser::SerializeMap};
+use serde::{Deserialize, Serialize, ser::Error};
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq)]
 pub struct AuthorRoles {
@@ -29,12 +29,7 @@ impl Serialize for AuthorRoles {
         hash.insert(String::from("translators"), cloned.translators.into());
         hash.insert(String::from("editors"), cloned.editors.into());
         hash.insert(String::from("compilers"), cloned.compilers.into());
-
-        let mut map = serializer.serialize_map(Some(hash.len()))?;
-        for (key, val) in hash {
-            map.serialize_entry(&key, &val)?;
-        }
-        map.end()
+        serializer.serialize_str(&serde_json::to_string(&hash).map_err(S::Error::custom)?)
     }
 }
 
@@ -46,7 +41,7 @@ mod tests {
     fn it_serializes_correctly() {
         assert_eq!(
             serde_json::to_string(&AuthorRoles::default()).unwrap(),
-            "{\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[]}"
+            r#""{\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[]}""#
         );
         assert_eq!(
             serde_json::to_string(&AuthorRoles {
@@ -54,7 +49,7 @@ mod tests {
                 ..Default::default()
             })
             .unwrap(),
-            "{\"primary_author\":\"Ginger\",\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[]}"
+            r#""{\"primary_author\":\"Ginger\",\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[]}""#
         );
         assert_eq!(
             serde_json::to_string(&AuthorRoles {
@@ -63,7 +58,7 @@ mod tests {
                 ..Default::default()
             })
             .unwrap(),
-            "{\"primary_author\":\"Ginger\",\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[\"Galangal\"]}"
+            r#""{\"primary_author\":\"Ginger\",\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[\"Galangal\"]}""#
         );
         assert_eq!(
             serde_json::to_string(&AuthorRoles {
@@ -71,7 +66,7 @@ mod tests {
                 ..Default::default()
             })
             .unwrap(),
-            "{\"secondary_authors\":[\"Cardamom\",\"Turmeric\"],\"translators\":[],\"editors\":[],\"compilers\":[]}"
+            r#""{\"secondary_authors\":[\"Cardamom\",\"Turmeric\"],\"translators\":[],\"editors\":[],\"compilers\":[]}""#
         );
     }
 }

--- a/lib/bibdata_rs/src/solr/author_roles.rs
+++ b/lib/bibdata_rs/src/solr/author_roles.rs
@@ -1,7 +1,8 @@
 // This module is responsible for creating a JSON formatted list of authors
 // and their roles.
 
-use serde::{Deserialize, Serialize, ser::Error};
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq)]
 pub struct AuthorRoles {
@@ -12,11 +13,19 @@ pub struct AuthorRoles {
     pub compilers: Vec<String>,
 }
 
+/// Serialize the author roles to be a json string, with all the necessary escaping
 impl Serialize for AuthorRoles {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+/// Serialize the author roles to be a regular string, with no JSON escaping
+impl Display for AuthorRoles {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut hash = serde_json::Map::new();
         let cloned = self.clone();
         if let Some(primary) = cloned.primary_author {
@@ -29,7 +38,11 @@ impl Serialize for AuthorRoles {
         hash.insert(String::from("translators"), cloned.translators.into());
         hash.insert(String::from("editors"), cloned.editors.into());
         hash.insert(String::from("compilers"), cloned.compilers.into());
-        serializer.serialize_str(&serde_json::to_string(&hash).map_err(S::Error::custom)?)
+        if let Ok(str) = serde_json::to_string(&hash) {
+            f.write_str(&str)
+        } else {
+            Ok(())
+        }
     }
 }
 

--- a/lib/bibdata_rs/src/solr/electronic_access.rs
+++ b/lib/bibdata_rs/src/solr/electronic_access.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Deserializer, Serialize, ser::SerializeMap};
+use serde::{Deserialize, Deserializer, Serialize, ser::Error};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ElectronicAccess {
@@ -46,11 +46,7 @@ impl Serialize for ElectronicAccess {
             );
         }
 
-        let mut map = serializer.serialize_map(Some(hash.len()))?;
-        for (key, val) in hash {
-            map.serialize_entry(&key, &val)?;
-        }
-        map.end()
+        serializer.serialize_str(&serde_json::to_string(&hash).map_err(S::Error::custom)?)
     }
 }
 
@@ -117,7 +113,7 @@ mod tests {
         };
         assert_eq!(
             serde_json::to_string(&access).unwrap(),
-            "{\"http://arks.princeton.edu/ark:/88435/dch989rf19q\":[\"Electronic Resource\"]}"
+            r#""{\"http://arks.princeton.edu/ark:/88435/dch989rf19q\":[\"Electronic Resource\"]}""#
         );
     }
 
@@ -144,19 +140,5 @@ mod tests {
         );
         assert_eq!(parsed.link_text, "Electronic Resource");
         assert_eq!(parsed.link_description.unwrap(), "My nice description");
-    }
-
-    #[test]
-    fn it_does_not_serialize_twice() {
-        let access = ElectronicAccess {
-            url: "http://arks.princeton.edu/ark:/88435/dch989rf19q".to_owned(),
-            link_text: "Electronic Resource".to_owned(),
-            link_description: None,
-            iiif_manifest_paths: None,
-        };
-        assert_eq!(
-            serde_json::to_string(&access).unwrap(),
-            "{\"http://arks.princeton.edu/ark:/88435/dch989rf19q\":[\"Electronic Resource\"]}"
-        );
     }
 }

--- a/lib/bibdata_rs/src/solr/solr_document.rs
+++ b/lib/bibdata_rs/src/solr/solr_document.rs
@@ -172,7 +172,7 @@ mod tests {
             .build();
         let serialized = serde_json::to_string(&document).unwrap();
         assert!(serialized.contains(
-            "\"electronic_access_1display\":{\"http://arks.princeton.edu/ark:/88435/dsp01b2773v788\":[\"DataSpace\",\"Full text\"]}"
+            r#""electronic_access_1display":"{\"http://arks.princeton.edu/ark:/88435/dsp01b2773v788\":[\"DataSpace\",\"Full text\"]}""#
         ))
     }
 
@@ -186,7 +186,7 @@ mod tests {
             .build();
         let serialized = serde_json::to_string(&document).unwrap();
         assert!(serialized.contains(
-            "{\"author_roles_1display\":{\"primary_author\":\"Prang, Louis\",\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[]}"
+            r#""author_roles_1display":"{\"primary_author\":\"Prang, Louis\",\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[]}""#
         ))
     }
 }


### PR DESCRIPTION
This reverts PR #3257, and provides an alternate implementation.

I confirmed that with this branch:

- I can index ephemera locally
- When I index MARC records locally, the author_roles_1display field is only escaped once (desired behavior), and the Send to RIS feature does not throw an error.

Closes #3302