### PR TITLE
Migrate title_vern_sort to Rust

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,20 @@
 # Agents Guide for Bibdata
 
-This application is a middleware that supports the Princeton University Library Catalog by:
+This application is a middleware that supports the [Princeton University Library Catalog](https://catalog.princeton.edu) by:
 * Indexing records from various sources into Solr for searching.  See docs/indexing.md
   for more information about the various record sources.
 * Providing data from Alma and SCSB systems about the real-time
   availability of items in the catalog.
+
+Documentation is in README.md and /docs.
 
 ## Rust migration
 
 We are currently migrating the indexing code from Ruby (using the traject gem) to Rust
 (using the marctk crate to handle MARC parsing), with goals of increasing performance
 and throughput.  The Rust code for indexing can mainly be found at lib/bibdata_rs.
+
+The traject configuration is at `marc_to_solr/lib/traject_config.rb`.
 
 We use the magnus crate to make Rust code available in Ruby.  See
 lib/bibdata_rs/src/marc/ruby_bindings.rs for an example of how the bindings work.
@@ -22,6 +26,10 @@ in traject_config.rb as context.clipboard[:solr_fields].
 ### Best practices when migrating logic from Ruby to Rust
 
 * Ensure that the Ruby tests keep passing (`bundle exec rspec spec/marc_to_solr`)
+  * Test fixtures are in `spec/fixtures/marc_to_solr/*.mrx`.  Note that these are in the
+  [MarcXML](https://www.loc.gov/standards/marcxml/) format, rather than in MarcBreaker
+  format (which is used in most Rust tests).
+  * Main config spec is at `spec/marc_to_solr/lib/config_spec.rb`
 * Add rust unit tests.  Make sure they pass with `cargo test`
     * Match the style of existing tests as much as possible.
     * When testing the MARC logic, prefer creating MARC records using the
@@ -50,5 +58,14 @@ Most data in our Solr index comes from [MARC bibliographic records](https://www.
 
 * MARC data field subfields often contain preceding and trailing space/punctuation to adhere to
   ISBD formatting (or other formatting) standards.  Be careful of this when doing string comparisons.
+* Most MARC data fields should only contain Latin script content.  Content in non-Latin scripts
+  can be found in a parallel 880 field that is connected via subfield $6.  We typically
+  want data from both the latin and non-Latin scripts unless otherwise specified.  The
+  parallel non-Latin field is sometimes called "vernacular" or "alternate script" in
+  traject.
+* Some MARC fields (notably 245) have non-filing characters.  When processing field 245 in Rust for the
+  purposes of title sorting, use marctk `field.ind2()`  to get the count of leading non-filing characters
+  (as a string), then parse and skip that many UTF-8 chars with `chars().skip(count)`.  For display, we
+  should not skip non-filing characters.
 * Do not rely on Rails or Activesupport in `marc_to_solr`, they are not required in this directory.
   Use standard Ruby.

--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -104,7 +104,7 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
         .ok()
         .and_then(|date| date.maybe_to_string());
 
-    let hash = ruby.hash_new_capa(39);
+    let hash = ruby.hash_new_capa(40);
     hash.aset("aat_s", ruby.ary_from_iter(genre::aat_s(&record)))?;
     hash.aset("action_notes_1display", action_notes_1display)?;
     hash.aset("access_restrictions_note_display", access_notes(&record))?;
@@ -194,6 +194,7 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
         standard_numbers_for_ruby(ruby, &record),
     )?;
     hash.aset("title_sort", title::title_sort(&record))?;
+    hash.aset("title_vern_sort", title::non_latin_title_sort(&record))?;
     hash.aset("title_t", title_t)?;
 
     Ok(hash)

--- a/lib/bibdata_rs/src/marc/title.rs
+++ b/lib/bibdata_rs/src/marc/title.rs
@@ -6,7 +6,7 @@ use crate::marc::{
     trim_punctuation,
     variable_length_field::{
         SubfieldIterator, join_subfields_by_code, latin_or_non_latin_tag_included_in,
-        latin_tag_included_in,
+        latin_tag_included_in, non_latin_tag_included_in,
     },
 };
 use itertools::Itertools;
@@ -66,6 +66,21 @@ fn without_non_filing_characters<'a>(title: &'a str, non_filing_characters: u8) 
     }
 }
 
+/// Returns the non-Latin version of the main title,
+/// with non-filing characters removed.  Looks at 880 fields pointing to 245.
+pub fn non_latin_title_sort(record: &Record) -> Option<String> {
+    record.first_matching_field_value(non_latin_tag_included_in(&["245"]), |field| {
+        let joined =
+            join_subfields_by_code(field, &["a", "b", "c", "f", "g", "h", "k", "n", "p", "s"]);
+        let non_filing_characters = field.ind2().parse::<u8>();
+        let trimmed = match non_filing_characters {
+            Ok(count) => without_non_filing_characters(&joined, count).to_string(),
+            Err(_) => joined,
+        };
+        maybe_not_empty(trimmed)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -92,5 +107,25 @@ mod tests {
         let record = Record::from_breaker(r"=245 \4 $a  ").unwrap();
         let title_sort = title_sort(&record);
         assert_eq!(title_sort, None);
+    }
+
+    #[test]
+    fn it_can_find_non_latin_title_sort() {
+        let record = Record::from_breaker(
+            r#"=245 10 $aal-Dulfīn al-alīf / $c [taʼlīf Muḥyī al-Dīn Salīmah].
+=880 10$6245-02/ $a الدلفين الاليف / $c [تأليف محيي الدين سليمة]."#,
+        )
+        .unwrap();
+        let non_latin_title_sort = non_latin_title_sort(&record).unwrap();
+        assert_eq!(
+            non_latin_title_sort,
+            "الدلفين الاليف / [تأليف محيي الدين سليمة]."
+        );
+    }
+
+    #[test]
+    fn it_returns_non_latin_title_sort_none_when_no_880() {
+        let record = Record::from_breaker(r"=245 \0 $aPlain title").unwrap();
+        assert_eq!(non_latin_title_sort(&record), None);
     }
 }

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -177,12 +177,8 @@ to_field 'title_sort' do |_record, accumulator, context|
   accumulator << context.clipboard[:solr_fields]['title_sort'] if context.clipboard[:solr_fields]['title_sort']
 end
 
-to_field 'title_vern_sort' do |record, accumulator|
-  MarcExtractor.cached('245abcfghknps', alternate_script: :only).collect_matching_lines(record) do |field, spec, extractor|
-    str = extractor.collect_subfields(field, spec).first
-    str = str.slice(field.indicator2.to_i, str.length) if str
-    accumulator << str if accumulator[0].nil?
-  end
+to_field 'title_vern_sort' do |_record, accumulator, context|
+  accumulator << context.clipboard[:solr_fields]['title_vern_sort'] if context.clipboard[:solr_fields]['title_vern_sort']
 end
 
 # roman and alt-script title with and without non-filing characters, excluding $h


### PR DESCRIPTION
This was created with help from pi coding agent and QWEN 2.6 running locally via ollama.  It includes some improvements to AGENTS.md based on the problems it had with the task :-).