### PR TITLE
Increase traject solr writer threads

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -22,6 +22,7 @@ settings do
   provide 'reader_class_name', 'AlmaReader'
   provide 'marc_source.type', 'xml'
   provide 'solr_writer.max_skipped', '50'
+  provide 'solr_writer.thread_pool', 3
   provide 'marc4j_reader.source_encoding', 'UTF-8'
   provide 'log.error_file', './log/traject-error.log'
   provide 'allow_duplicate_values', false


### PR DESCRIPTION
This increases performance a lot for me locally:

Before:

```
INFO finished Traject::Indexer#process: 100000 records in 171.518 seconds; 583.0 records/second overall.
```

After:
```
INFO finished Traject::Indexer#process: 100000 records in 133.928 seconds; 746.7 records/second overall.
```