### PR TITLE
Fix regression in calculating holding_location

### DIFF
--- a/lib/bibdata_rs/src/marc/holdings/holding_location.rs
+++ b/lib/bibdata_rs/src/marc/holdings/holding_location.rs
@@ -25,6 +25,9 @@ pub fn mapped_codes_location_label(code: &str) -> HashMap<&str, &str> {
 pub fn location_codes(record: &Record) -> Vec<String> {
     let mut codes = Vec::new();
     for field_852_ref in record.get_fields("852") {
+        if !field_852_ref.has_subfield("b") {
+            continue;
+        }
         let field_852 = field_852_ref.clone();
 
         let holding_id = field_852
@@ -117,5 +120,24 @@ mod tests {
             "Remote Storage (ReCAP): Firestone Library Use Only",
         );
         assert_eq!(mapped_code, expected);
+    }
+
+    #[test]
+    fn it_does_not_include_location_codes_without_library() {
+        let record = Record::from_breaker(
+            r#"=852 0\$bmarquand$cstacks$hND1053.4$i.K5 1934$822617214130006421
+=852 0\$cpa$hND1053.4$i.K5 1934$822617214130006421
+=852 0\$beastasian$cpl$hND1053.4$i.K5 1934$822966900120006421
+=876 \\$022966900120006421$zpl$yeastasian"#,
+        )
+        .unwrap();
+        assert!(
+            !location_codes(&record).contains(&String::from("$pa")),
+            "it does not include a partial location code $pa that has no library attached (no 852$b)"
+        );
+        assert_eq!(
+            location_codes(&record),
+            vec!["marquand$stacks", "eastasian$pl"]
+        )
     }
 }


### PR DESCRIPTION
Prior to 6c3c88df7ec41bfe1c01e55f0bd14dc4f4d52b3c, we did not index partial location codes when 852 was not present.  This commit restores this behavior so that records don't get assigned location codes like $pa
<img width="616" height="193" alt="the advanced search form location dropdown.  It has All Princeton Holdings, $pa, Architecture Library, and Commons Library" src="https://github.com/user-attachments/assets/3937628e-c2f5-442b-930f-385f5357cdc3" />
