### PR TITLE
Handle location codes Harvard records that have 852$8

### DIFF
--- a/lib/bibdata_rs/src/marc/holdings/holding_location.rs
+++ b/lib/bibdata_rs/src/marc/holdings/holding_location.rs
@@ -68,6 +68,7 @@ pub fn location_codes(record: &Record) -> Vec<String> {
 
 pub fn permanent_location_code(field: &Field) -> Option<String> {
     match field.first_subfield("8") {
+        // These are Princeton Alma records
         Some(alma_code) if alma_code_start_22(alma_code.content().to_string()) => {
             let b = field
                 .first_subfield("b")
@@ -83,9 +84,11 @@ pub fn permanent_location_code(field: &Field) -> Option<String> {
                 Some(format!("{b}${c}"))
             }
         }
-        None if field.first_subfield("0").is_some() => field
+        // These are SCSB Partner records (they may have $8, but we should ignore it)
+        Some(_) | None if field.first_subfield("0").is_some() => field
             .first_subfield("b")
             .map(|subfield| subfield.content().to_string()),
+        // These are some weird records that don't have enough data
         _ => None,
     }
 }
@@ -139,5 +142,14 @@ mod tests {
             location_codes(&record),
             vec!["marquand$stacks", "eastasian$pl"]
         )
+    }
+
+    #[test]
+    fn it_gets_location_codes_from_partner_record_with_852_subfield8() {
+        let record = Record::from_breaker(
+            r"=852 8\$cHD$hARG$i905$iAVE$8221940647990003941$010744464$bscsbhl",
+        )
+        .unwrap();
+        assert_eq!(location_codes(&record), vec!["scsbhl"]);
     }
 }


### PR DESCRIPTION
Harvard puts the Alma ID into the 852$8 of some records (which we should ignore).  Before this commit, we consulted the 852$8 and confirmed that it was a Princeton Alma holding, and then fell back to not including any location code.  We should instead disregard 852$8s in partner records and focus on the 852$0.