### PR TITLE
Migrate scale_display field to Rust

### DIFF
--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -18,6 +18,7 @@ use crate::marc::marcxml_compressor::marcxml_compressed;
 use crate::marc::note::access_notes;
 use crate::marc::note::action_note::action_notes;
 use crate::marc::ruby_bindings::marc_gem::marctk_from_ruby_marc_record;
+use crate::marc::variable_length_field::extract_marc;
 use crate::marc::{fixed_field::dates::EndDate, scsb::recap_partner::recap_partner_notes};
 use crate::paths::APPLICATION_ROOT;
 use crate::solr::AuthorRoles;
@@ -111,7 +112,7 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
         .ok()
         .and_then(|date| date.maybe_to_string());
 
-    let hash = ruby.hash_new_capa(45);
+    let hash = ruby.hash_new_capa(46);
     hash.aset("aat_s", ruby.ary_from_iter(genre::aat_s(&record)))?;
     hash.aset("action_notes_1display", action_notes_1display)?;
     hash.aset("access_restrictions_note_display", access_notes(&record))?;
@@ -199,6 +200,7 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
     hash.aset("pub_date_end_sort", pub_date_end_sort)?;
     hash.aset("rbgenr_s", ruby.ary_from_iter(genre::rbgenr_s(&record)))?;
     hash.aset("recap_notes_display", recap_partner_notes(&record))?;
+    hash.aset("scale_display", extract_marc!("255a")(&record))?;
     hash.aset(
         "siku_subject_display",
         ruby.ary_from_iter(subject::siku_subjects_display(&record)),
@@ -385,5 +387,20 @@ mod tests {
 
         let oclc_value = hash.aref::<&str, Vec<String>>("oclc_s").unwrap();
         assert_eq!(oclc_value, vec![String::from("989083934")]);
+    }
+
+    #[ruby_test]
+    fn it_includes_scale_display_in_solr_fields() {
+        let ruby = unsafe { Ruby::get_unchecked() };
+        let ruby_record: magnus::RObject = ruby.eval(r#"require 'marc';record = MARC::Record.new;record.append(MARC::DataField.new('255', '', '', ['a', 'Scale [1:6,336,000]. 1" = 100 miles. Vertical scale [1:192,000]. 1/16" = approx. 1000\'.']));record"#).unwrap();
+        let hash = solr_fields(&ruby, ruby_record).unwrap();
+
+        let scale_display_value = hash.aref::<&str, Vec<String>>("scale_display").unwrap();
+        assert_eq!(
+            scale_display_value,
+            vec![String::from(
+                r#"Scale [1:6,336,000]. 1" = 100 miles. Vertical scale [1:192,000]. 1/16" = approx. 1000'."#
+            )]
+        );
     }
 }

--- a/lib/bibdata_rs/src/marc/variable_length_field.rs
+++ b/lib/bibdata_rs/src/marc/variable_length_field.rs
@@ -1,3 +1,4 @@
+use crate::marc::string_normalize::maybe_not_empty;
 use itertools::Itertools;
 use marctk::{Field, Subfield};
 
@@ -85,8 +86,79 @@ fn combine_consecutive_whitespace(original: &str) -> String {
     original.split_whitespace().join(" ")
 }
 
+#[derive(Debug, PartialEq)]
+pub struct ExtractSpec<'a> {
+    tag: &'a str,
+    subfields: Vec<&'a str>,
+}
+
+impl<'a> ExtractSpec<'a> {
+    pub fn get_subfields(&'a self) -> impl Fn(&'a Field) -> Option<String> + 'a {
+        move |field: &Field| {
+            if self.tag_matcher()(field) {
+                maybe_not_empty(join_subfields_by_code(field, &self.subfields))
+            } else {
+                None
+            }
+        }
+    }
+
+    pub fn tag_matcher(&self) -> impl Fn(&Field) -> bool + 'a {
+        let tag = self.tag;
+        move |field| latin_or_non_latin_tag_included_in(&[tag])(field)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct IncorrectExtractSpec {}
+impl<'a> TryFrom<&'a str> for ExtractSpec<'a> {
+    type Error = IncorrectExtractSpec;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        let length = value.len();
+        if length < 3 {
+            return Err(IncorrectExtractSpec {});
+        }
+        let mut subfields = Vec::new();
+        for i in 3..length {
+            subfields.push(value.get(i..i + 1).unwrap());
+        }
+        Ok(ExtractSpec {
+            tag: value.get(0..3).expect("Extract spec is not 3 bytes!"),
+            subfields,
+        })
+    }
+}
+
+/// This macro can be used similarly to the traject extract_marc macro:
+/// `extract_marc!("245abc", "100a");` will return a closure that you can
+/// call to extract the desired fields from a record.
+macro_rules! extract_marc {
+    ( $( $spec:expr),+ ) => {{
+        use crate::marc::variable_length_field::ExtractSpec;
+        use crate::marc::extract_values::ExtractValues;
+        use marctk::Record;
+
+        let mut specs = Vec::new();
+        $(
+            specs.push(ExtractSpec::try_from($spec).unwrap());
+        )+
+        move |record: &Record| {
+            record
+                .extract_field_values_by(
+                    |field| specs.iter().any(|spec| spec.tag_matcher()(field)),
+                    |field| specs.iter().map(|spec| spec.get_subfields()(field)).flatten().next())
+                .collect::<Vec<String>>()
+        }
+    }};
+}
+
+pub(crate) use extract_marc;
+
 #[cfg(test)]
 mod tests {
+    use marctk::Record;
+
     use super::*;
     #[test]
     fn it_can_combine_consecutive_whitespace() {
@@ -133,5 +205,28 @@ mod tests {
             .content()
             .collect();
         assert_eq!(after_t, "squidorca");
+    }
+
+    #[test]
+    fn it_can_make_an_extract_spec() {
+        let expected = ExtractSpec {
+            tag: "245",
+            subfields: vec!["a", "b", "c"],
+        };
+        assert_eq!(ExtractSpec::try_from("245abc"), Ok(expected))
+    }
+
+    #[test]
+    fn extract_marc_macro() {
+        let record = Record::from_breaker(
+            r#"=100 \\$aDog
+=245 \\$aHello$bHi$cGoodbye"#,
+        )
+        .unwrap();
+        let extractor = extract_marc!("100a", "245abc");
+        assert_eq!(
+            extractor(&record),
+            vec![String::from("Dog"), String::from("Hello Hi Goodbye")]
+        );
     }
 }

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -314,7 +314,7 @@ to_field 'geocode_display' do |record, acc|
   )
 end
 
-to_field 'scale_display', extract_marc('255a')
+rust_multi_value_field 'scale_display'
 
 to_field 'projection_display', extract_marc('255b:342a')
 


### PR DESCRIPTION
This commit introduces a macro extract_marc! that works similarly to the extract_marc method in traject.

In traject, you might write:

```
extract_marc('255b:342a')
```

With this macro, you can achieve a similar effect with:

```
extract_marc!("255b", "342a")(record)
```