### PR TITLE
Migrate more simple solr fields to use the extract_marc! macro

### DIFF
--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -112,13 +112,19 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
         .ok()
         .and_then(|date| date.maybe_to_string());
 
-    let hash = ruby.hash_new_capa(63);
+    let hash = ruby.hash_new_capa(109);
     hash.aset("aat_s", ruby.ary_from_iter(genre::aat_s(&record)))?;
     hash.aset("action_notes_1display", action_notes_1display)?;
     hash.aset("access_restrictions_note_display", access_notes(&record))?;
     hash.aset("alt_title_246_display", extract_marc!("246abfnp")(&record))?;
     hash.aset("arrangement_display", extract_marc!("351abc")(&record))?;
     hash.aset("author_roles_1display", author_roles_1display)?;
+    hash.aset("bib_ref_notes_display", extract_marc!("504ab")(&record))?;
+    hash.aset("binding_note_display", extract_marc!("563au3")(&record))?;
+    hash.aset(
+        "biographical_historical_note_display",
+        extract_marc!("545ab")(&record),
+    )?;
     hash.aset(
         "call_number_browse_s",
         call_number_labels_for_browse(&record),
@@ -127,7 +133,12 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
         "call_number_display",
         call_number_labels_for_display(&record),
     )?;
+    hash.aset(
+        "case_file_notes_display",
+        extract_marc!("5653abcde")(&record),
+    )?;
     hash.aset("cataloged_date_tdt", cataloged_date(&record))?;
+    hash.aset("cite_as_display", extract_marc!("52423a")(&record))?;
     hash.aset("cjk_author", ruby.ary_from_iter(cjk::cjk_authors(&record)))?;
     hash.aset("cjk_all", ruby.ary_from_iter(cjk::cjk_all(&record)))?;
     hash.aset("cjk_notes", ruby.ary_from_iter(cjk::notes_cjk(&record)))?;
@@ -140,12 +151,26 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
         ruby.ary_from_iter(cjk::subjects_cjk(&record)),
     )?;
     hash.aset("cjk_title", ruby.ary_from_iter(cjk::cjk_titles(&record)))?;
+    hash.aset("coden_display", extract_marc!("030a")(&record))?;
     hash.aset("compiled_created_display", extract_marc!("245fg")(&record))?;
     hash.aset(
         "contains_title_index",
         ruby.ary_from_iter(title::contains_titles_index(&record)),
     )?;
     hash.aset("content_title_index", extract_marc!("505t")(&record))?;
+    hash.aset(
+        "copy_version_notes_display",
+        extract_marc!("5623abcde")(&record),
+    )?;
+    hash.aset("credits_notes_display", extract_marc!("508a")(&record))?;
+    hash.aset(
+        "data_quality_notes_display",
+        extract_marc!("514abcdefghijkm")(&record),
+    )?;
+    hash.aset(
+        "date_place_event_notes_display",
+        extract_marc!("5183adop")(&record),
+    )?;
     hash.aset(
         "description_display",
         extract_marc!(
@@ -183,19 +208,42 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
             "362az"
         )(&record),
     )?;
+    hash.aset(
+        "dissertation_notes_display",
+        extract_marc!("502abcdgo")(&record),
+    )?;
     hash.aset("edition_display", extract_marc!("250ab")(&record))?;
+    hash.aset("exhibitions_note_display", extract_marc!("5853a")(&record))?;
     hash.aset(
         "fast_subject_display",
         ruby.ary_from_iter(subject::fast_subjects(&record)),
     )?;
     hash.aset("figgy_1display", figgy_1display(&record))?;
     hash.aset("format", format)?;
+    hash.aset("former_frequency_display", extract_marc!("321ab")(&record))?;
+    hash.aset(
+        "former_title_complex_notes_display",
+        extract_marc!("547a")(&record),
+    )?;
+    hash.aset("frequency_display", extract_marc!("310ab")(&record))?;
+    hash.aset(
+        "funding_info_notes_display",
+        extract_marc!("536abcdefgh")(&record),
+    )?;
     hash.aset("genre_facet", genre::genres(&record))?;
+    hash.aset("geo_cov_notes_display", extract_marc!("522a")(&record))?;
     hash.aset(
         "homoit_genre_s",
         ruby.ary_from_iter(genre::homoit_genre_s(&record)),
     )?;
     hash.aset("icpsr_subject_unstem_search", icpsr_subject_unstem_search)?;
+    hash.aset(
+        "info_document_notes_display",
+        extract_marc!("556a")(&record),
+    )?;
+    hash.aset("issn_display", extract_marc!("022a")(&record))?;
+    hash.aset("issuing_body_notes_display", extract_marc!("550a")(&record))?;
+    hash.aset("language_display", extract_marc!("5463a")(&record))?;
     hash.aset(
         "linked_series_index",
         extract_marc!("760acgst", "762acgst")(&record),
@@ -216,8 +264,18 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
     )?;
     hash.aset("lccn_display", extract_marc!("010a")(&record))?;
     hash.aset("lcgft_s", ruby.ary_from_iter(genre::lcgft_s(&record)))?;
+    hash.aset("linking_notes_display", extract_marc!("580a")(&record))?;
     hash.aset("location", holdings::library::location_facet(&record))?;
+    hash.aset(
+        "location_originals_notes_display",
+        extract_marc!("5353abcdg")(&record),
+    )?;
+    hash.aset(
+        "location_other_arch_notes_display",
+        extract_marc!("5443abcden")(&record),
+    )?;
     hash.aset("marcxml", marcxml_compressed(&record))?;
+    hash.aset("methodology_notes_display", extract_marc!("567a")(&record))?;
     hash.aset(
         "non_latin_non_cjk_all_index",
         ruby.ary_from_iter(non_latin::non_latin_non_cjk_all(&record)),
@@ -236,9 +294,23 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
     )?;
     hash.aset("notes_display", extract_marc!("5003a", "590a")(&record))?;
     hash.aset(
+        "numbering_pec_notes_display",
+        extract_marc!("515a")(&record),
+    )?;
+    hash.aset(
         "numeric_id_b",
         matches!(ControlNumber::from(&record), ControlNumber::Alma(_)),
     )?;
+    hash.aset(
+        "original_language_display",
+        extract_marc!("880abc")(&record),
+    )?;
+    hash.aset(
+        "original_version_notes_display",
+        extract_marc!("534abcefklmnpt3")(&record),
+    )?;
+    hash.aset("other_editions_s", extract_marc!("775w")(&record))?;
+    hash.aset("other_format_display", extract_marc!("5303abcd")(&record))?;
     hash.aset(
         "other_title_index",
         extract_marc!(
@@ -270,6 +342,11 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
         original_language_of_translation_facet,
     )?;
     hash.aset(
+        "participant_performer_display",
+        extract_marc!("511a")(&record),
+    )?;
+    hash.aset("place_name_display", extract_marc!("752abcd")(&record))?;
+    hash.aset(
         "pub_citation_display",
         ruby.ary_from_iter(publication::pub_citation_display(&record)),
     )?;
@@ -281,22 +358,52 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
         "pub_created_display",
         ruby.ary_from_iter(publication::pub_created_display(&record)),
     )?;
+    hash.aset(
+        "publications_about_display",
+        extract_marc!("581az36")(&record),
+    )?;
+    hash.aset("publisher_no_display", extract_marc!("028a")(&record))?;
     hash.aset("projection_display", extract_marc!("255b", "342a")(&record))?;
     hash.aset("pub_date_display", pub_date_start_sort.clone())?;
     hash.aset("pub_date_start_sort", pub_date_start_sort)?;
     hash.aset("pub_date_end_sort", pub_date_end_sort)?;
     hash.aset("rbgenr_s", ruby.ary_from_iter(genre::rbgenr_s(&record)))?;
     hash.aset("recap_notes_display", recap_partner_notes(&record))?;
+    hash.aset(
+        "related_record_info_display",
+        extract_marc!("776i")(&record),
+    )?;
+    hash.aset(
+        "reproduction_notes_display",
+        extract_marc!("5333abcdefmn")(&record),
+    )?;
+    hash.aset(
+        "restrictions_note_display",
+        extract_marc!("5063abcde")(&record),
+    )?;
+    hash.aset(
+        "rights_reproductions_note_display",
+        extract_marc!("5403abcd")(&record),
+    )?;
     hash.aset("scale_display", extract_marc!("255a")(&record))?;
+    hash.aset("script_display", extract_marc!("546b")(&record))?;
     hash.aset("series_statement_index", extract_marc!("490avx")(&record))?;
     hash.aset(
         "siku_subject_display",
         ruby.ary_from_iter(subject::siku_subjects_display(&record)),
     )?;
+    hash.aset("standard_no_024_index", extract_marc!("024a")(&record))?;
     hash.aset(
         "standard_no_index",
         standard_numbers_for_ruby(ruby, &record),
     )?;
+    hash.aset("sudoc_no_display", extract_marc!("086a")(&record))?;
+    hash.aset("supplement_notes_display", extract_marc!("525a")(&record))?;
+    hash.aset(
+        "system_details_notes_display",
+        extract_marc!("5383ai")(&record),
+    )?;
+    hash.aset("target_aud_notes_display", extract_marc!("5213ab")(&record))?;
     hash.aset(
         "title_no_h_index",
         ruby.ary_from_iter(title::title_no_h_index(&record)),
@@ -304,6 +411,8 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
     hash.aset("title_sort", title::title_sort(&record))?;
     hash.aset("title_vern_sort", title::non_latin_title_sort(&record))?;
     hash.aset("title_t", title_t)?;
+    hash.aset("type_period_notes_display", extract_marc!("513ab")(&record))?;
+    hash.aset("with_notes_display", extract_marc!("501a")(&record))?;
 
     Ok(hash)
 }

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -383,11 +383,14 @@ to_field 'changed_back_to_display', extract_marc('785|08|at', trim_punctuation: 
 
 # Frequency:
 #    310 XX ab
-to_field 'frequency_display', extract_marc('310ab')
+
+# Frequency:
+#    310 XX ab
+rust_multi_value_field 'frequency_display'
 
 # Former frequency:
 #    321 XX a
-to_field 'former_frequency_display', extract_marc('321ab')
+rust_multi_value_field 'former_frequency_display'
 
 # Has supplement:
 #    770 XX at
@@ -399,7 +402,7 @@ to_field 'supplement_to_display', extract_marc('772at', trim_punctuation: true)
 
 # Linking notes:
 #    580 XX a
-to_field 'linking_notes_display', extract_marc('580a')
+rust_multi_value_field 'linking_notes_display'
 
 # Subseries of:
 #    760 XX at
@@ -491,21 +494,21 @@ to_field 'related_record_s' do |record, accumulator|
 end
 
 # Link to BIB of other edition
-to_field 'other_editions_s', extract_marc('775w')
+rust_multi_value_field 'other_editions_s'
 
 # Description for the related record
-to_field 'related_record_info_display', extract_marc('776i')
+rust_multi_value_field 'related_record_info_display'
 
 # Notes index field 5XX
 to_field 'notes_index', extract_all_marc_values(from: '500', to: '599')
 
 # Restrictions note:
 #    506 XX 3abcde
-to_field 'restrictions_note_display', extract_marc('5063abcde')
+rust_multi_value_field 'restrictions_note_display'
 
 # Biographical/Historical note:
 #    545 XX ab
-to_field 'biographical_historical_note_display', extract_marc('545ab')
+rust_multi_value_field 'biographical_historical_note_display'
 
 # Summary note:
 #    520 XX 3ab
@@ -546,37 +549,37 @@ to_field 'content_advice_display', extract_marc('520|4*|3abc')
 #    570 XX a
 rust_multi_value_field 'notes_display'
 
-to_field 'with_notes_display', extract_marc('501a')
+rust_multi_value_field 'with_notes_display'
 to_field 'bibliographic_notes_display', extract_marc('503a') # obsolete
-to_field 'dissertation_notes_display', extract_marc('502abcdgo')
-to_field 'bib_ref_notes_display', extract_marc('504ab')
+rust_multi_value_field 'dissertation_notes_display'
+rust_multi_value_field 'bib_ref_notes_display'
 to_field 'scale_notes_display', extract_marc('507ab') # added
-to_field 'credits_notes_display', extract_marc('508a')
-to_field 'type_period_notes_display', extract_marc('513ab')
-to_field 'data_quality_notes_display', extract_marc('514abcdefghijkm')
-to_field 'numbering_pec_notes_display', extract_marc('515a')
+rust_multi_value_field 'credits_notes_display'
+rust_multi_value_field 'type_period_notes_display'
+rust_multi_value_field 'data_quality_notes_display'
+rust_multi_value_field 'numbering_pec_notes_display'
 to_field 'type_comp_data_notes_display', extract_marc('516a') # added
-to_field 'date_place_event_notes_display', extract_marc('5183adop')
-to_field 'target_aud_notes_display', extract_marc('5213ab')
-to_field 'geo_cov_notes_display', extract_marc('522a')
+rust_multi_value_field 'date_place_event_notes_display'
+rust_multi_value_field 'target_aud_notes_display'
+rust_multi_value_field 'geo_cov_notes_display'
 to_field 'time_period_notes_display', extract_marc('523a') # obsolete
-to_field 'supplement_notes_display', extract_marc('525a')
+rust_multi_value_field 'supplement_notes_display'
 to_field 'study_prog_notes_display', extract_marc('526abcdixz') # added
 to_field 'censorship_notes_display', extract_marc('527a') # obsolete
-to_field 'reproduction_notes_display', extract_marc('5333abcdefmn')
-to_field 'original_version_notes_display', extract_marc('534abcefklmnpt3')
-to_field 'location_originals_notes_display', extract_marc('5353abcdg')
-to_field 'funding_info_notes_display', extract_marc('536abcdefgh')
+rust_multi_value_field 'reproduction_notes_display'
+rust_multi_value_field 'original_version_notes_display'
+rust_multi_value_field 'location_originals_notes_display'
+rust_multi_value_field 'funding_info_notes_display'
 to_field 'source_data_notes_display', extract_marc('537a') # obsolete
-to_field 'system_details_notes_display', extract_marc('5383ai')
+rust_multi_value_field 'system_details_notes_display'
 to_field 'related_copyright_notes_display', extract_marc('542|1*|:542| *|') # is this in any record?
-to_field 'location_other_arch_notes_display', extract_marc('5443abcden')
-to_field 'former_title_complex_notes_display', extract_marc('547a')
-to_field 'issuing_body_notes_display', extract_marc('550a')
-to_field 'info_document_notes_display', extract_marc('556a')
-to_field 'copy_version_notes_display', extract_marc('5623abcde')
-to_field 'case_file_notes_display', extract_marc('5653abcde')
-to_field 'methodology_notes_display', extract_marc('567a')
+rust_multi_value_field 'location_other_arch_notes_display'
+rust_multi_value_field 'former_title_complex_notes_display'
+rust_multi_value_field 'issuing_body_notes_display'
+rust_multi_value_field 'info_document_notes_display'
+rust_multi_value_field 'copy_version_notes_display'
+rust_multi_value_field 'case_file_notes_display'
+rust_multi_value_field 'methodology_notes_display'
 to_field 'editor_notes_display', extract_marc('570a') # added
 to_field 'accumulation_notes_display', extract_marc('584ab3') # added
 to_field 'awards_notes_display', extract_marc('586a3') # added
@@ -584,7 +587,7 @@ to_field 'source_desc_notes_display', extract_marc('588a') # added
 
 # Binding note:
 #    563 XX au3
-to_field 'binding_note_display', extract_marc('563au3')
+rust_multi_value_field 'binding_note_display'
 
 # Local notes:
 #    590 XX a
@@ -594,19 +597,19 @@ to_field 'local_notes_display', extract_marc('591a:592a')
 
 # Rights and reproductions note:
 #    540 XX 3abcd
-to_field 'rights_reproductions_note_display', extract_marc('5403abcd')
+rust_multi_value_field 'rights_reproductions_note_display'
 
 # Exhibitions note:
 #    585 XX 3a
-to_field 'exhibitions_note_display', extract_marc('5853a')
+rust_multi_value_field 'exhibitions_note_display'
 
 # Participant(s)/Performer(s):
 #    511 XX a
-to_field 'participant_performer_display', extract_marc('511a')
+rust_multi_value_field 'participant_performer_display'
 
 # Language(s):
 #    546 XX 3a
-to_field 'language_display', extract_marc('5463a')
+rust_multi_value_field 'language_display'
 
 # Languages for the show page
 #    008, 041$a and 041$d
@@ -629,7 +632,7 @@ end
 
 # Script:
 #    546 XX b
-to_field 'script_display', extract_marc('546b')
+rust_multi_value_field 'script_display'
 
 # The language_iana_s field is used in the record page to calculate the html lang attribute
 # Based on https://www.loc.gov/marc/bibliographic/bd008a.html section 35-37 - Language,
@@ -690,7 +693,7 @@ to_field 'source_acquisition_display', extract_marc('541|1*|abcdefhno36:541| *|a
 
 # Publications about:
 #    581 XX az36
-to_field 'publications_about_display', extract_marc('581az36')
+rust_multi_value_field 'publications_about_display'
 
 # Action note - formatted with link
 rust_multi_value_field 'action_notes_1display'
@@ -710,12 +713,12 @@ to_field 'references_url_display', extract_marc('510|3*|3abcu:510|4*|3abcu')
 
 # Cite as:
 #    524 XX 23a
-to_field 'cite_as_display', extract_marc('52423a')
+rust_multi_value_field 'cite_as_display'
 
 # Other format(s):
 #    530 XX 3abcd
 #    533 XX 3abcdefmn
-to_field 'other_format_display', extract_marc('5303abcd')
+rust_multi_value_field 'other_format_display'
 
 # Cumulative index/Finding aid:
 #    555 XX 3abcd
@@ -1076,7 +1079,7 @@ to_field 'instrumentation_facet', marc_instrumentation_humanized
 
 # Place name(s):
 #    752 XX abcd
-to_field 'place_name_display', extract_marc('752abcd')
+rust_multi_value_field 'place_name_display'
 
 # Other title(s):
 #    246 XX abfnp
@@ -1164,11 +1167,11 @@ end
 
 # ISSN:
 #    022 XX a
-to_field 'issn_display', extract_marc('022a')
+rust_multi_value_field 'issn_display'
 
 # SuDoc no.:
 #    086 XX a
-to_field 'sudoc_no_display', extract_marc('086a')
+rust_multi_value_field 'sudoc_no_display'
 
 # Tech. report no.:
 #    027 XX a
@@ -1177,15 +1180,15 @@ to_field 'tech_report_no_display', extract_marc('027a:088a')
 
 # Publisher. no.:
 #    028 XX a
-to_field 'publisher_no_display', extract_marc('028a')
+rust_multi_value_field 'publisher_no_display'
 
 # Standard no.:
 #    010 XX a
 #    030 XX a
 rust_multi_value_field 'lccn_display'
-to_field 'coden_display', extract_marc('030a')
+rust_multi_value_field 'coden_display'
 
-to_field 'standard_no_024_index', extract_marc('024a')
+rust_multi_value_field 'standard_no_024_index'
 
 to_field 'standard_no_1display' do |record, accumulator|
   standard_no = standard_no_hash(record)
@@ -1226,7 +1229,7 @@ rust_multi_value_field 'other_version_s'
 
 # Original language:
 #    880 XX abc
-to_field 'original_language_display', extract_marc('880abc')
+rust_multi_value_field 'original_language_display'
 
 to_field 'subject_era_facet', marc_era_facet
 


### PR DESCRIPTION
The change in performance is negligible.  My theory is that most of these fields are quite uncommon.