### PR TITLE
Correct the name of solr field

### DIFF
--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -145,7 +145,7 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
         "case_file_notes_display",
         extract_marc!("5653abcde")(&record),
     )?;
-    hash.aset("cataloged_date_tdt", cataloged_date(&record))?;
+    hash.aset("cataloged_tdt", cataloged_date(&record))?;
     hash.aset("cite_as_display", extract_marc!("52423a")(&record))?;
     hash.aset("cjk_author", ruby.ary_from_iter(cjk::cjk_authors(&record)))?;
     hash.aset("cjk_all", ruby.ary_from_iter(cjk::cjk_all(&record)))?;

--- a/spec/marc_to_solr/lib/date_spec.rb
+++ b/spec/marc_to_solr/lib/date_spec.rb
@@ -26,4 +26,12 @@ RSpec.describe 'Date indexing' do
       expect(indexed).not_to have_key 'publication_date_citation_display'
     end
   end
+
+  describe 'cataloged_tdt' do
+    it 'can get the date from MARC 876' do
+      record = MARC::Record.new_from_hash('fields' => [{ '876' => { 'ind1' => ' ', 'ind2' => ' ', 'subfields' => [{ '0' => '22710806450006421' }, { 'd' => '2021-07-13 12:24:58' }] } }], 'leader' => '00726cas a2200229M 4500')
+      indexed = IndexerService.build.map_record(record)
+      expect(indexed['cataloged_tdt']).to eq ['2021-07-13T12:24:58Z']
+    end
+  end
 end


### PR DESCRIPTION
This led the `cataloged_tdt` field to not get indexed at all in the last full re-index, causing the Recently Added facet not to display