### PR TITLE
Fix original language display regression

### DIFF
--- a/lib/bibdata_rs/src/marc/non_latin.rs
+++ b/lib/bibdata_rs/src/marc/non_latin.rs
@@ -191,7 +191,14 @@ pub fn non_latin_non_cjk_series_titles(record: &Record) -> impl Iterator<Item = 
 
 /// These are 880 fields from the record that do not have a pair with a Latin-script field
 pub fn unmatched_non_latin_strings(record: &Record) -> Vec<String> {
-    extract_marc!("880abc")(record)
+    // extract_marc!(latin "880abc")(record)
+    record.extract_field_values_by(
+        |field| field.tag() == "880",
+        |field| {
+            let joined = join_subfields_except(field, &["6"]);
+            maybe_has_cjk_text(joined)
+        },
+    ).collect()
 }
 
 fn maybe_has_non_cjk_text(original: String) -> Option<String> {

--- a/lib/bibdata_rs/src/marc/non_latin.rs
+++ b/lib/bibdata_rs/src/marc/non_latin.rs
@@ -199,7 +199,7 @@ pub fn unmatched_parallel_strings(record: &Record) -> Vec<String> {
         )
         .collect()
 }
-
+ 
 fn maybe_has_non_cjk_text(original: String) -> Option<String> {
     if !has_cjk_chars(&original) && !original.is_empty() {
         Some(original)
@@ -242,6 +242,14 @@ mod tests {
         let record = Record::from_breaker(r#"=110 2\$6880-01 $a Nihon Bungaku Kyōkai. $0 http://id.loc.gov/authorities/names/n84194096
 =880 2\$6110-01/{dollar}1 $a 日本文學協會.
 =880 \\$a第一版."#).unwrap();
+        let unmatched = unmatched_parallel_strings(&record);
+        assert_eq!(unmatched, vec![String::from("第一版.")]);
+    }
+    #[test]
+    fn it_can_find_parallel_strings_with_unlinked_subfield6() {
+        let record = Record::from_breaker(r#"=110 2\$6880-01 $a Nihon Bungaku Kyōkai. $0 http://id.loc.gov/authorities/names/n84194096
+=880 2\$6110-01/{dollar}1 $a 日本文學協會.
+=880 \\$6245-01$a第一版."#).unwrap();
         let unmatched = unmatched_parallel_strings(&record);
         assert_eq!(unmatched, vec![String::from("第一版.")]);
     }

--- a/lib/bibdata_rs/src/marc/non_latin.rs
+++ b/lib/bibdata_rs/src/marc/non_latin.rs
@@ -1,13 +1,13 @@
 //! This module is responsible for fields that contain text in
 //! non-Latin and non-CJK languages
 
-use crate::marc::variable_length_field::extract_marc;
 use crate::marc::{
     cjk::has_cjk_chars,
     extract_values::ExtractValues,
     trim_punctuation,
     variable_length_field::{
-        SubfieldIterator, join_subfields_except, non_latin_tag, non_latin_tag_included_in,
+        SubfieldIterator, join_subfields_by_code, join_subfields_except, non_latin_tag,
+        non_latin_tag_included_in,
     },
 };
 use itertools::Itertools;
@@ -190,15 +190,14 @@ pub fn non_latin_non_cjk_series_titles(record: &Record) -> impl Iterator<Item = 
 }
 
 /// These are 880 fields from the record that do not have a pair with a Latin-script field
-pub fn unmatched_non_latin_strings(record: &Record) -> Vec<String> {
+pub fn unmatched_parallel_strings(record: &Record) -> Vec<String> {
     // extract_marc!(latin "880abc")(record)
-    record.extract_field_values_by(
-        |field| field.tag() == "880",
-        |field| {
-            let joined = join_subfields_except(field, &["6"]);
-            maybe_has_cjk_text(joined)
-        },
-    ).collect()
+    record
+        .extract_field_values_by(
+            |field| field.tag() == "880" && !field.has_subfield("6"),
+            |field| Some(join_subfields_by_code(field, &["a", "b", "c"])),
+        )
+        .collect()
 }
 
 fn maybe_has_non_cjk_text(original: String) -> Option<String> {
@@ -239,14 +238,11 @@ mod tests {
     }
 
     #[test]
-    fn original_language_display_only_includes_unmatched_880s() {
+    fn it_can_find_unmatched_parallel_strings() {
         let record = Record::from_breaker(r#"=110 2\$6880-01 $a Nihon Bungaku Kyōkai. $0 http://id.loc.gov/authorities/names/n84194096
 =880 2\$6110-01/{dollar}1 $a 日本文學協會.
 =880 \\$a第一版."#).unwrap();
-        let original_language_display_values = unmatched_non_latin_strings(&record);
-        assert_eq!(
-            original_language_display_values,
-            vec![String::from("第一版.")]
-        );
+        let unmatched = unmatched_parallel_strings(&record);
+        assert_eq!(unmatched, vec![String::from("第一版.")]);
     }
 }

--- a/lib/bibdata_rs/src/marc/non_latin.rs
+++ b/lib/bibdata_rs/src/marc/non_latin.rs
@@ -194,18 +194,43 @@ pub fn unmatched_parallel_strings(record: &Record) -> Vec<String> {
     // extract_marc!(latin "880abc")(record)
     record
         .extract_field_values_by(
-            |field| field.tag() == "880" && !field.has_subfield("6"),
+            |field| {
+                field.tag() == "880"
+                    && !parallel_field_pairs(record).any(|pair| pair.non_latin == field)
+            },
             |field| Some(join_subfields_by_code(field, &["a", "b", "c"])),
         )
         .collect()
 }
- 
+
 fn maybe_has_non_cjk_text(original: String) -> Option<String> {
     if !has_cjk_chars(&original) && !original.is_empty() {
         Some(original)
     } else {
         None
     }
+}
+
+struct ParallelFieldPair<'a> {
+    non_latin: &'a Field,
+    #[allow(unused)]
+    latin: &'a Field,
+}
+
+fn parallel_field_pairs<'a>(record: &'a Record) -> impl Iterator<Item = ParallelFieldPair<'a>> {
+    record
+        .get_fields("880")
+        .into_iter()
+        .filter_map(|non_latin| {
+            let linkage = non_latin.first_subfield("6")?;
+            let possible_pairs = record.get_fields(linkage.content().get(0..3)?);
+            let occurrence = linkage.content().get(4..6)?;
+            let index = occurrence.parse::<usize>().ok()? - 1;
+            Some(ParallelFieldPair {
+                non_latin,
+                latin: possible_pairs.get(index)?,
+            })
+        })
 }
 
 #[cfg(test)]

--- a/lib/bibdata_rs/src/marc/non_latin.rs
+++ b/lib/bibdata_rs/src/marc/non_latin.rs
@@ -1,6 +1,7 @@
 //! This module is responsible for fields that contain text in
 //! non-Latin and non-CJK languages
 
+use crate::marc::variable_length_field::extract_marc;
 use crate::marc::{
     cjk::has_cjk_chars,
     extract_values::ExtractValues,
@@ -188,6 +189,11 @@ pub fn non_latin_non_cjk_series_titles(record: &Record) -> impl Iterator<Item = 
     series_title_fields.chain(fields_with_author_and_title_info)
 }
 
+/// These are 880 fields from the record that do not have a pair with a Latin-script field
+pub fn unmatched_non_latin_strings(record: &Record) -> Vec<String> {
+    extract_marc!("880abc")(record)
+}
+
 fn maybe_has_non_cjk_text(original: String) -> Option<String> {
     if !has_cjk_chars(&original) && !original.is_empty() {
         Some(original)
@@ -223,5 +229,17 @@ mod tests {
         let mut names = non_latin_non_cjk_authors(&record);
         assert_eq!(names.next(), Some(String::from("Κινέζικα")));
         assert_eq!(names.next(), None);
+    }
+
+    #[test]
+    fn original_language_display_only_includes_unmatched_880s() {
+        let record = Record::from_breaker(r#"=110 2\$6880-01 $a Nihon Bungaku Kyōkai. $0 http://id.loc.gov/authorities/names/n84194096
+=880 2\$6110-01/{dollar}1 $a 日本文學協會.
+=880 \\$a第一版."#).unwrap();
+        let original_language_display_values = unmatched_non_latin_strings(&record);
+        assert_eq!(
+            original_language_display_values,
+            vec![String::from("第一版.")]
+        );
     }
 }

--- a/lib/bibdata_rs/src/marc/non_latin.rs
+++ b/lib/bibdata_rs/src/marc/non_latin.rs
@@ -191,7 +191,6 @@ pub fn non_latin_non_cjk_series_titles(record: &Record) -> impl Iterator<Item = 
 
 /// These are 880 fields from the record that do not have a pair with a Latin-script field
 pub fn unmatched_parallel_strings(record: &Record) -> Vec<String> {
-    // extract_marc!(latin "880abc")(record)
     record
         .extract_field_values_by(
             |field| {
@@ -222,8 +221,10 @@ fn parallel_field_pairs<'a>(record: &'a Record) -> impl Iterator<Item = Parallel
         .get_fields("880")
         .into_iter()
         .filter_map(|non_latin| {
+            // The linkage will have a string like 245-01
             let linkage = non_latin.first_subfield("6")?;
-            let possible_pairs = record.get_fields(linkage.content().get(0..3)?);
+            let tag = linkage.content().get(0..3)?;
+            let possible_pairs = record.get_fields(tag);
             let occurrence = linkage.content().get(4..6)?;
             let index = occurrence.parse::<usize>().ok()? - 1;
             Some(ParallelFieldPair {

--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -327,7 +327,7 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
     )?;
     hash.aset(
         "original_language_display",
-        extract_marc!("880abc")(&record),
+        non_latin::unmatched_non_latin_strings(&record),
     )?;
     hash.aset(
         "original_version_notes_display",

--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -327,7 +327,7 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
     )?;
     hash.aset(
         "original_language_display",
-        non_latin::unmatched_non_latin_strings(&record),
+        non_latin::unmatched_parallel_strings(&record),
     )?;
     hash.aset(
         "original_version_notes_display",


### PR DESCRIPTION
The solr field `original_language_display` is only intended to display 880 fields that do not match any non-880 fields.  However, I introduced a regression in #3365, and it started to display all 880 fields, regardless of whether or not they have a pair.