### PR TITLE
Remove step from setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ Note: You need to have PostgreSQL installed in your machine and available in you
 lpass login emailhere
 bin/setup_keys
 ```
-1. Install bundler version in Gemfile.lock
-```
-gem install bundler -v '2.2.27'
-```
 1. Install bundle
 ```
 bundle install


### PR DESCRIPTION
I was able to setup locally without this step -- perhaps we no longer need it?