### PR TITLE
Index title_sort_key directly, rather than title_sort

### DIFF
--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -444,7 +444,7 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
         "title_no_h_index",
         ruby.ary_from_iter(title::title_no_h_index(&record)),
     )?;
-    hash.aset("title_sort", title::title_sort(&record))?;
+    hash.aset("title_sort_key", title::title_sort_key(&record))?;
     hash.aset("title_vern_sort", title::non_latin_title_sort(&record))?;
     hash.aset("title_t", title_t)?;
     hash.aset("type_period_notes_display", extract_marc!("513ab")(&record))?;

--- a/lib/bibdata_rs/src/marc/title.rs
+++ b/lib/bibdata_rs/src/marc/title.rs
@@ -45,7 +45,7 @@ pub fn latin_script_title(record: &Record) -> Option<String> {
     )
 }
 
-pub fn title_sort(record: &Record) -> Option<String> {
+pub fn title_sort_key(record: &Record) -> Option<String> {
     record.first_matching_field_value(latin_tag_included_in(&["245"]), |field| {
         let field = Field245(field);
         let joined =
@@ -134,7 +134,7 @@ mod tests {
     #[test]
     fn it_can_find_title_sort() {
         let record = Record::from_breaker(r"=245 \4 $aThe octopus").unwrap();
-        let title_sort = title_sort(&record).unwrap();
+        let title_sort = title_sort_key(&record).unwrap();
         assert_eq!(title_sort, "octopus");
     }
 
@@ -142,14 +142,14 @@ mod tests {
     fn it_can_remove_punctuation_from_title_sort() {
         let record =
             Record::from_breaker(r"=245 \0 $a. The octopus - Αρχαία ελληνικἀ: ὀκτώπους").unwrap();
-        let title_sort = title_sort(&record).unwrap();
+        let title_sort = title_sort_key(&record).unwrap();
         assert_eq!(title_sort, "The octopus  Αρχαία ελληνικἀ ὀκτώπους");
     }
 
     #[test]
     fn it_returns_title_sort_none_if_245_empty() {
         let record = Record::from_breaker(r"=245 \4 $a  ").unwrap();
-        let title_sort = title_sort(&record);
+        let title_sort = title_sort_key(&record);
         assert_eq!(title_sort, None);
     }
 

--- a/lib/bibdata_rs/src/solr/builder.rs
+++ b/lib/bibdata_rs/src/solr/builder.rs
@@ -16,7 +16,7 @@ pub struct SolrDocumentBuilder {
     title_t: Option<Vec<String>>,
     title_citation_display: Option<String>,
     title_display: Option<String>,
-    title_sort: Option<String>,
+    title_sort_key: Option<String>,
     electronic_access_1display: Option<ElectronicAccess>,
     restrictions_display_text: Option<Vec<String>>,
     restrictions_note_display: Option<Vec<String>>,
@@ -135,8 +135,8 @@ impl SolrDocumentBuilder {
         self.publisher_citation_display = publisher_citation_display;
         self
     }
-    pub fn with_title_sort(&mut self, title_sort: Option<String>) -> &mut Self {
-        self.title_sort = title_sort;
+    pub fn with_title_sort_key(&mut self, title_sort_key: Option<String>) -> &mut Self {
+        self.title_sort_key = title_sort_key;
         self
     }
 
@@ -362,7 +362,7 @@ impl SolrDocumentBuilder {
             pub_date_end_sort: self.pub_date_end_sort,
             title_citation_display: self.title_citation_display.clone(),
             title_display: self.title_display.clone(),
-            title_sort: self.title_sort.clone(),
+            title_sort_key: self.title_sort_key.clone(),
             title_t: self.title_t.clone(),
             thumbnail_display: self.thumbnail_display.clone(),
             contributor_display: self.contributor_display.clone(),

--- a/lib/bibdata_rs/src/solr/dataspace_solr_mapping.rs
+++ b/lib/bibdata_rs/src/solr/dataspace_solr_mapping.rs
@@ -41,7 +41,7 @@ impl From<&DataspaceDocument> for SolrDocument {
                 Some(titles) => titles.first().cloned(),
                 None => None,
             })
-            .with_title_sort(title_sort(doc.title.as_ref()))
+            .with_title_sort_key(title_sort_key(doc.title.as_ref()))
             .with_title_t(doc.title_search_versions())
             .with_language_facet(doc.languages())
             .with_language_name_display(doc.languages())
@@ -92,7 +92,7 @@ impl From<&LegacyDataspaceDocument> for SolrDocument {
                 Some(titles) => titles.first().cloned(),
                 None => None,
             })
-            .with_title_sort(title_sort(doc.title.as_ref()))
+            .with_title_sort_key(title_sort_key(doc.title.as_ref()))
             .with_title_t(doc.title_search_versions())
             .with_language_facet(doc.languages())
             .with_language_name_display(doc.languages())
@@ -106,7 +106,7 @@ impl From<&LegacyDataspaceDocument> for SolrDocument {
     }
 }
 
-fn title_sort(titles: Option<&Vec<String>>) -> Option<String> {
+fn title_sort_key(titles: Option<&Vec<String>>) -> Option<String> {
     match titles {
         Some(title_vec) => {
             let first = title_vec.first()?;
@@ -165,7 +165,7 @@ mod tests {
             solr.title_display.unwrap(),
             "Dysfunction: A Play in One Act"
         );
-        assert_eq!(solr.title_sort.unwrap(), "dysfunctionaplayinoneact");
+        assert_eq!(solr.title_sort_key.unwrap(), "dysfunctionaplayinoneact");
         assert_eq!(
             solr.author_citation_display.unwrap(),
             vec!["Clark, Hillary"]
@@ -493,28 +493,28 @@ mod tests {
         }
     }
 
-    mod title_sort {
+    mod title_sort_key {
         use super::*;
 
         #[test]
         fn it_can_create_sortable_version_of_title() {
             assert_eq!(
-                title_sort(Some(&vec!["\"Some quote\" : Blah blah".to_owned()])).unwrap(),
+                title_sort_key(Some(&vec!["\"Some quote\" : Blah blah".to_owned()])).unwrap(),
                 "somequoteblahblah",
                 "it should strip punctuation"
             );
             assert_eq!(
-                title_sort(Some(&vec!["A title : blah blah".to_owned()])).unwrap(),
+                title_sort_key(Some(&vec!["A title : blah blah".to_owned()])).unwrap(),
                 "titleblahblah",
                 "it should strip articles"
             );
             assert_eq!(
-                title_sort(Some(&vec!["\"A quote\" : Blah blah".to_owned()])).unwrap(),
+                title_sort_key(Some(&vec!["\"A quote\" : Blah blah".to_owned()])).unwrap(),
                 "quoteblahblah",
                 "it should strip punctuation and articles"
             );
             assert_eq!(
-                title_sort(Some(&vec!["thesis".to_owned()])).unwrap(),
+                title_sort_key(Some(&vec!["thesis".to_owned()])).unwrap(),
                 "thesis",
                 "it should leave words that start with articles alone"
             );
@@ -559,7 +559,7 @@ mod legacy_tests {
             solr.title_display.unwrap(),
             "Dysfunction: A Play in One Act"
         );
-        assert_eq!(solr.title_sort.unwrap(), "dysfunctionaplayinoneact");
+        assert_eq!(solr.title_sort_key.unwrap(), "dysfunctionaplayinoneact");
     }
 
     #[test]
@@ -877,28 +877,28 @@ mod legacy_tests {
         }
     }
 
-    mod title_sort {
+    mod title_sort_key {
         use super::*;
 
         #[test]
         fn it_can_create_sortable_version_of_title() {
             assert_eq!(
-                title_sort(Some(&vec!["\"Some quote\" : Blah blah".to_owned()])).unwrap(),
+                title_sort_key(Some(&vec!["\"Some quote\" : Blah blah".to_owned()])).unwrap(),
                 "somequoteblahblah",
                 "it should strip punctuation"
             );
             assert_eq!(
-                title_sort(Some(&vec!["A title : blah blah".to_owned()])).unwrap(),
+                title_sort_key(Some(&vec!["A title : blah blah".to_owned()])).unwrap(),
                 "titleblahblah",
                 "it should strip articles"
             );
             assert_eq!(
-                title_sort(Some(&vec!["\"A quote\" : Blah blah".to_owned()])).unwrap(),
+                title_sort_key(Some(&vec!["\"A quote\" : Blah blah".to_owned()])).unwrap(),
                 "quoteblahblah",
                 "it should strip punctuation and articles"
             );
             assert_eq!(
-                title_sort(Some(&vec!["thesis".to_owned()])).unwrap(),
+                title_sort_key(Some(&vec!["thesis".to_owned()])).unwrap(),
                 "thesis",
                 "it should leave words that start with articles alone"
             );

--- a/lib/bibdata_rs/src/solr/ephemera_solr_mapping.rs
+++ b/lib/bibdata_rs/src/solr/ephemera_solr_mapping.rs
@@ -33,7 +33,7 @@ impl From<&EphemeraFolder> for SolrDocument {
             .with_publisher_no_display(value.publisher.clone())
             .with_publisher_citation_display(value.publisher.clone())
             .with_title_display(value.title.first().cloned())
-            .with_title_sort(value.first_sort_title())
+            .with_title_sort_key(value.first_sort_title())
             .with_title_citation_display(value.title.first().cloned())
             .with_thumbnail_display(value.thumbnail_url())
             .build()
@@ -482,7 +482,7 @@ mod tests {
             .unwrap();
         let solr_document = SolrDocument::from(&ephemera_item);
         assert_eq!(
-            solr_document.title_sort,
+            solr_document.title_sort_key,
             Some("The book of trees".to_string())
         );
     }
@@ -495,7 +495,7 @@ mod tests {
             .unwrap();
         let solr_document = SolrDocument::from(&ephemera_item);
         assert_eq!(
-            solr_document.title_sort,
+            solr_document.title_sort_key,
             Some("Our favorite book".to_string())
         );
     }

--- a/lib/bibdata_rs/src/solr/solr_document.rs
+++ b/lib/bibdata_rs/src/solr/solr_document.rs
@@ -131,7 +131,7 @@ pub struct SolrDocument {
 
     pub title_display: Option<String>,
 
-    pub title_sort: Option<String>,
+    pub title_sort_key: Option<String>,
 
     pub title_t: Option<Vec<String>>,
 }

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -163,7 +163,7 @@ rust_multi_value_field 'title_a_index'
 
 to_field 'title_vern_display', extract_marc('245abcfghknps', alternate_script: :only, first: true)
 
-rust_single_value_field 'title_sort'
+rust_single_value_field 'title_sort_key'
 rust_single_value_field 'title_vern_sort'
 
 # roman and alt-script title with and without non-filing characters, excluding $h

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -389,12 +389,10 @@
              input string is preserved as a single token
           -->
         <tokenizer name="keyword"/>
-        <!-- The LowerCase TokenFilter does what you expect, which can be
-             when you want your sorting to be case insensitive
-          -->
-        <filter name="lowercase" />
         <!-- The TrimFilter removes any leading or trailing whitespace -->
         <filter name="trim" />
+        <!-- Convert UTF-8 characters to their lowercase equivalents -->
+        <filter name="icuFolding" />
         <!-- The PatternReplaceFilter gives you the flexibility to use
              Java Regular expression to replace any sequence of characters
              matching a pattern with an arbitrary replacement string,
@@ -455,6 +453,8 @@
         <tokenizer name="pathHierarchy"/>
       </analyzer>
     </fieldType>
+
+    <fieldType name="icuSortKey" class="solr.ICUCollationField" locale="" strength="primary" />
 
     <!-- since fields of this type are by default not stored or indexed,
          any data added to them will be ignored outright.  -->
@@ -532,6 +532,7 @@
    <field name="original_language_of_translation_facet" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="author_int" type="author" indexed="true" stored="false" multiValued="true"/>
    <field name="title_sort" type="alphaNumSort" indexed="true" stored="false" />
+   <field name="title_sort_key" type="icuSortKey" indexed="false" stored="false" docValues="true" />
     <!-- pub_date sort uses new trie-based int fields, which are recommended for any int and are displayable, sortable, and range-quer
    we use 'pint' for faster range-queries. -->
    <field name="pub_date_start_sort" type="pint" indexed="true" stored="true" multiValued="false"/>
@@ -546,8 +547,8 @@
    <field name="standard_no_index" type="string" indexed="true" stored="false" multiValued="true" />
    <field name="uniform_title_s" type="text" indexed="true" stored="true" multiValued="true" />
    <field name="_version_" type="plong" indexed="true" stored="true" multiValued="false"/>
-   
-    <!-- MARCXML field - stores gzipped+base64 MARCXML as string -->
+
+    <!-- MARCXML field - stores the full MARCXML record as a string -->
    <field name="marcxml" type="string" indexed="false" stored="true" multiValued="false"/>
 
     <!-- Dynamic field definitions.  If a field name is not found, dynamicFields
@@ -729,7 +730,10 @@
    <copyField source="title_la" dest="text"/>
    <copyField source="title_addl_la" dest="text"/>
 
-  <!-- copy notes_index to cjk_notes_copied -->
-   <copyField source="notes_index" dest="cjk_notes_copied"/>
-   <copyField source="notes_index" dest="cjk_text"/>
+   <copyField source="cjk_notes" dest="cjk_text"/>
+
+   <!-- temporary copy Field for backwards compatibility. Once orangelight uses title_sort_key
+    for sorting and we have done a full reindex, we can start indexing directly
+    into title_sort_key directly, and remove title_sort altogether -->
+  <copyField source="title_sort" dest="title_sort_key" />
 </schema>

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -159,6 +159,7 @@
         description_t^2.2
         cjk_all^2.2
         cjk_text^2.2
+        non_latin_non_cjk_all_index^2.2
       </str>
       <str name="pf">
         title_245a_lr^35200
@@ -186,18 +187,21 @@
         description_t^22
         cjk_all^22
         cjk_text^22
+        non_latin_non_cjk_all_index^22
       </str>
       <str name="author_qf">
         author_main_unstem_search^44
         author_unstem_search^22
         author_int^22
         cjk_author^2.2
+        non_latin_non_cjk_author_index^2.2
       </str>
       <str name="author_pf">
         author_main_unstem_search^440
         author_unstem_search^220
         author_int^22
         cjk_author^22
+        non_latin_non_cjk_author_index^22
       </str>
       <str name="left_anchor_qf">
         title_245a_la^50
@@ -231,12 +235,10 @@
       <str name="notes_qf">
         notes_index^2.2
         cjk_notes^2.2
-        cjk_notes_copied^2.2
       </str>
       <str name="notes_pf">
         notes_index^2.2
         cjk_notes^2.2
-        cjk_notes_copied^2.2
       </str>
       <str name="series_title_qf">
         series_title_index^11
@@ -246,6 +248,7 @@
         linked_series_index^2.2
         original_version_series_index^2.2
         cjk_series_title^2.2
+        non_latin_non_cjk_series_title_index^2.2
       </str>
       <str name="series_title_pf">
         series_title_index^110
@@ -255,6 +258,7 @@
         linked_series_index^22
         original_version_series_index^22
         cjk_series_title^22
+        non_latin_non_cjk_series_title_index^22
       </str>
       <str name="title_qf">
         title_a_index^1100
@@ -273,6 +277,7 @@
         linked_series_index^2.2
         original_version_series_index^2.2
         cjk_title^2.2
+        non_latin_non_cjk_title_index^2.2
       </str>
       <str name="title_pf">
         title_245a_lr^12100
@@ -293,6 +298,7 @@
         linked_series_index^22
         original_version_series_index^22
         cjk_title^22
+        non_latin_non_cjk_title_index^22
       </str>
       <str name="subject_qf">
         subject_topic_unstem_search^55
@@ -302,6 +308,8 @@
         local_subject_unstem_search^2.2
         homoit_subject_unstem_search^2.2
         cjk_subject^2.2
+        non_latin_non_cjk_subject_index^2.2
+        icpsr_subject_unstem_search
       </str>
       <str name="subject_pf">
         subject_topic_unstem_search^550
@@ -311,6 +319,7 @@
         local_subject_unstem_search^22
         homoit_subject_unstem_search^22
         cjk_subject^22
+        non_latin_non_cjk_subject_index^22
       </str>
 
       <int name="ps">3</int>
@@ -328,12 +337,15 @@
         isbn_s,
         oclc_s,
         lccn_s,
+        marcxml,
         holdings_1display,
         electronic_access_1display,
         electronic_portfolio_s,
+        figgy_1display,
         cataloged_tdt,
         contained_in_s,
         call_number_display,
+        language_iana_s,
         thumbnail_display
       </str>
 

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -503,9 +503,9 @@ describe 'From traject_config.rb', :indexing do
       end
     end
 
-    describe 'the title_sort field' do
+    describe 'the title_sort_key field' do
       it 'does not have initial articles' do
-        expect(@sample1['title_sort'][0].start_with?('Advanced concepts')).to be_truthy
+        expect(@sample1['title_sort_key'][0].start_with?('Advanced concepts')).to be_truthy
       end
     end
 


### PR DESCRIPTION
See https://github.com/pulibrary/pul_solr/pull/564

Currently, there is a copyField that copies title_sort into title_sort_key.  However, once https://github.com/pulibrary/orangelight/pull/6079 is merged and deployed, we will use title_sort_key directly, and can safely stop indexing into title_sort.