### PR TITLE
Normalize author_sort field before sending it to solr

### DIFF
--- a/lib/bibdata_rs/src/marc/contributors.rs
+++ b/lib/bibdata_rs/src/marc/contributors.rs
@@ -1,6 +1,9 @@
 use marctk::{Field, Record};
 
-use crate::{marc::trim_punctuation, solr::AuthorRoles};
+use crate::{
+    marc::{trim_punctuation, variable_length_field::extract_marc},
+    solr::AuthorRoles,
+};
 
 impl From<&Record> for AuthorRoles {
     fn from(record: &Record) -> Self {
@@ -62,6 +65,17 @@ impl From<&Field> for ContributorType {
             _ => Self::Other,
         }
     }
+}
+
+pub fn author_sort(record: &Record) -> Option<String> {
+    let authors = extract_marc!("100aqbcdk", "110abcdfgkln", "111abcdfgklnpq")(record);
+    authors.first().map(|name| {
+        name.chars()
+            .filter(|c| c.is_alphabetic() || c == &' ')
+            .collect::<String>()
+            .trim()
+            .to_owned()
+    })
 }
 
 fn find_potential_relator(field: &Field, subfield: &str) -> Option<String> {
@@ -139,6 +153,15 @@ mod tests {
                 editors: vec!["Eugenides, Jeffrey".to_owned()],
                 compilers: vec!["Cole, Teju".to_owned()]
             }
+        )
+    }
+
+    #[test]
+    fn it_normalizes_authors_for_sorting() {
+        let record = Record::from_breaker(r#"=100 \\$aBhaṭanāgara, Mahendra, $d 1926-"#).unwrap();
+        assert_eq!(
+            author_sort(&record),
+            Some(String::from("Bhaṭanāgara Mahendra"))
         )
     }
 }

--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -109,7 +109,7 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
         .ok()
         .and_then(|date| date.maybe_to_string());
 
-    let hash = ruby.hash_new_capa(117);
+    let hash = ruby.hash_new_capa(118);
     hash.aset("aat_s", ruby.ary_from_iter(genre::aat_s(&record)))?;
     hash.aset("action_notes_1display", action_notes_1display)?;
     hash.aset("access_restrictions_note_display", access_notes(&record))?;
@@ -124,6 +124,7 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
     )?;
     hash.aset("arrangement_display", extract_marc!("351abc")(&record))?;
     hash.aset("author_roles_1display", author_roles_1display)?;
+    hash.aset("author_sort", contributors::author_sort(&record))?;
     hash.aset("bib_ref_notes_display", extract_marc!("504ab")(&record))?;
     hash.aset("binding_note_display", extract_marc!("563au3")(&record))?;
     hash.aset(

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -119,7 +119,7 @@ rust_single_value_field 'figgy_1display'
 #    111 XX abcdefgklnpq A ab
 
 rust_multi_value_field 'author_display'
-to_field 'author_sort', extract_marc('100aqbcdk:110abcdfgkln:111abcdfgklnpq', trim_punctuation: true, first: true)
+rust_single_value_field 'author_sort'
 to_field 'author_citation_display', extract_marc('100a:110a:111a:700a:710a:711a', trim_punctuation: true, alternate_script: false)
 
 rust_single_value_field 'author_roles_1display'

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -523,6 +523,16 @@ describe 'From traject_config.rb', :indexing do
       end
     end
 
+    describe 'the author_sort field' do
+      it 'takes from the 100 field' do
+        expect(@sample1['author_sort'][0]).to eq 'Singh Digvijai'
+      end
+
+      it 'takes from the 110 field' do
+        expect(@sample3['author_sort'][0]).to eq 'World Data Center A for Glaciology'
+      end
+    end
+
     describe 'the author_citation_display field' do
       it 'shows only the 100 a subfield' do
         expect(@sample1['author_citation_display'][0]).to eq 'Singh, Digvijai'


### PR DESCRIPTION
We are migrating from an author_sort TextField in solr to an author_sort_key ICUCollationField.  The author_sort analysis removes all numbers and puncutation from the author name.  To acheive a similar effect, we normalize the value before sending it to solr, so that it works with both the author_sort and the new author_sort_key (which is being populated via a copyField).