### PR TITLE
Migrate more fields to rust

### DIFF
--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -109,7 +109,7 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
         .ok()
         .and_then(|date| date.maybe_to_string());
 
-    let hash = ruby.hash_new_capa(119);
+    let hash = ruby.hash_new_capa(130);
     hash.aset("aat_s", ruby.ary_from_iter(genre::aat_s(&record)))?;
     hash.aset("action_notes_1display", action_notes_1display)?;
     hash.aset("access_restrictions_note_display", access_notes(&record))?;
@@ -172,6 +172,10 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
     hash.aset(
         "data_quality_notes_display",
         extract_marc!("514abcdefghijkm")(&record),
+    )?;
+    hash.aset(
+        "data_source_display",
+        extract_marc_trim_punctuation(ruby, "786at", &record),
     )?;
     hash.aset(
         "date_place_event_notes_display",
@@ -239,6 +243,22 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
     hash.aset("genre_facet", genre::genres(&record))?;
     hash.aset("geo_cov_notes_display", extract_marc!("522a")(&record))?;
     hash.aset(
+        "geo_related_record_display",
+        ruby.ary_from_iter(
+            extract_marc!("772at", "7733abdghikmnoprst", "777at")(&record)
+                .iter()
+                .map(|s| trim_punctuation(s)),
+        ),
+    )?;
+    hash.aset(
+        "has_subseries_display",
+        extract_marc_trim_punctuation(ruby, "762at", &record),
+    )?;
+    hash.aset(
+        "has_supplement_display",
+        extract_marc_trim_punctuation(ruby, "770at", &record),
+    )?;
+    hash.aset(
         "homoit_genre_s",
         ruby.ary_from_iter(genre::homoit_genre_s(&record)),
     )?;
@@ -251,6 +271,10 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
             .map(|field| field.content().to_owned()),
     )?;
     hash.aset(
+        "in_display",
+        extract_marc_trim_punctuation(ruby, "7733abdghikmnoprst", &record),
+    )?;
+    hash.aset(
         "info_document_notes_display",
         extract_marc!("556a")(&record),
     )?;
@@ -261,6 +285,10 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
     hash.aset(
         "issn_s",
         ruby.ary_from_iter(standard_number::normalized_issns(&record)),
+    )?;
+    hash.aset(
+        "issued_with_display",
+        extract_marc_trim_punctuation(ruby, "777at", &record),
     )?;
     hash.aset(
         "lccn_s",
@@ -333,6 +361,10 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
     hash.aset(
         "original_version_notes_display",
         extract_marc!("534abcefklmnpt3")(&record),
+    )?;
+    hash.aset(
+        "other_editions_display",
+        extract_marc_trim_punctuation(ruby, "775adhit", &record),
     )?;
     hash.aset("other_editions_s", extract_marc!("775w")(&record))?;
     hash.aset("other_format_display", extract_marc!("5303abcd")(&record))?;
@@ -426,8 +458,16 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
         "standard_no_index",
         standard_numbers_for_ruby(ruby, &record),
     )?;
+    hash.aset(
+        "subseries_of_display",
+        extract_marc_trim_punctuation(ruby, "760at", &record),
+    )?;
     hash.aset("sudoc_no_display", extract_marc!("086a")(&record))?;
     hash.aset("supplement_notes_display", extract_marc!("525a")(&record))?;
+    hash.aset(
+        "supplement_to_display",
+        extract_marc_trim_punctuation(ruby, "772at", &record),
+    )?;
     hash.aset(
         "system_details_notes_display",
         extract_marc!("5383ai")(&record),
@@ -452,6 +492,14 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
     hash.aset("title_sort_key", title::title_sort_key(&record))?;
     hash.aset("title_vern_sort", title::non_latin_title_sort(&record))?;
     hash.aset("title_t", title_t)?;
+    hash.aset(
+        "translated_as_display",
+        extract_marc_trim_punctuation(&ruby, "767at", &record),
+    )?;
+    hash.aset(
+        "translation_of_display",
+        extract_marc_trim_punctuation(&ruby, "765at", &record),
+    )?;
     hash.aset("type_period_notes_display", extract_marc!("513ab")(&record))?;
     hash.aset(
         "uniform_130_vern",
@@ -554,6 +602,14 @@ fn manifest_url(
 
 fn mms_id(ruby: &Ruby, ark: magnus::RString) -> Result<Option<magnus::RString>, magnus::Error> {
     Ok(figgy::mms_id(&ark.to_string()?, None).map(|mms_id| ruby.str_new(mms_id)))
+}
+
+fn extract_marc_trim_punctuation(ruby: &Ruby, spec: &str, record: &Record) -> RArray {
+    ruby.ary_from_iter(
+        extract_marc!(spec)(&record)
+            .iter()
+            .map(|s| trim_punctuation(s)),
+    )
 }
 
 #[cfg(test)]

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -301,15 +301,15 @@ rust_multi_value_field 'arrangement_display'
 
 # Translation of:
 #    765 XX at
-to_field 'translation_of_display', extract_marc('765at', trim_punctuation: true)
+rust_multi_value_field 'translation_of_display'
 
 # Translated as:
 #    767 XX at
-to_field 'translated_as_display', extract_marc('767at', trim_punctuation: true)
+rust_multi_value_field 'translated_as_display'
 
 # Issued with:
 #    777 XX at
-to_field 'issued_with_display', extract_marc('777at', trim_punctuation: true)
+rust_multi_value_field 'issued_with_display'
 
 # Continues:
 #    780 00 at
@@ -380,11 +380,11 @@ rust_multi_value_field 'former_frequency_display'
 
 # Has supplement:
 #    770 XX at
-to_field 'has_supplement_display', extract_marc('770at', trim_punctuation: true)
+rust_multi_value_field 'has_supplement_display'
 
 # Supplement to:
 #    772 XX at
-to_field 'supplement_to_display', extract_marc('772at', trim_punctuation: true)
+rust_multi_value_field 'supplement_to_display'
 
 # Linking notes:
 #    580 XX a
@@ -392,11 +392,11 @@ rust_multi_value_field 'linking_notes_display'
 
 # Subseries of:
 #    760 XX at
-to_field 'subseries_of_display', extract_marc('760at', trim_punctuation: true)
+rust_multi_value_field 'subseries_of_display'
 
 # Has subseries:
 #    762 XX at
-to_field 'has_subseries_display', extract_marc('762at', trim_punctuation: true)
+rust_multi_value_field 'has_subseries_display'
 
 # Series:
 #    400 XX abcdefgklnpqtuvx
@@ -437,30 +437,7 @@ to_field 'more_in_this_series_t' do |record, accumulator|
   accumulator.flatten!.map! { |f| Traject::Macros::Marc21.trim_punctuation(f) }
 end
 
-# Other version(s):
-#    3500 020Z020A
-#    3500 020A020Z
-#    3500 024A022A
-#    3500 022A024A
-#    3500 BBID776W
-#    3500 BBID787W
-#    3500 776X022A
-#    3500 022A776X
-#    3500 020A776Z
-#    3500 776Z020A
-# to_field 'Other version(s)_display', extract_marc()
-# # #    3500 020Z020A
-# # #    3500 020A020Z
-# # #    3500 024A022A
-# # #    3500 022A024A
-# # #    3500 BBID776W
-# # #    3500 BBID787W
-# # #    3500 776X022A
-# # #    3500 022A776X
-# # #    3500 020A776Z
-# # #    3500 776Z020A
-
-to_field 'geo_related_record_display', extract_marc('772at:7733abdghikmnoprst:777at', trim_punctuation: true)
+rust_multi_value_field 'geo_related_record_display'
 
 # Contained in:
 #    3500 BBID773W
@@ -1115,15 +1092,9 @@ end
 
 # In:
 #    773 XX 3abdghikmnoprst
-to_field 'in_display', extract_marc('7733abdghikmnoprst', trim_punctuation: true)
-
-# Constituent part(s):
-#    774 XX abcdghikmnrstu
-to_field 'constituent_part_display', extract_marc('774abcdghikmnrstu', trim_punctuation: true)
-
-to_field 'other_editions_display', extract_marc('775adhit', trim_punctuation: true)
-
-to_field 'data_source_display', extract_marc('786at', trim_punctuation: true)
+rust_multi_value_field 'in_display'
+rust_multi_value_field 'other_editions_display'
+rust_multi_value_field 'data_source_display'
 
 # ISBN:
 #    020 XX a

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -1834,6 +1834,10 @@ describe 'From traject_config.rb', :indexing do
         expect(sample['location']).to eq(['Mendel Music Library'])
       end
     end
+
+    it 'indexes 772 field as supplement_to_display' do
+      expect(@added_custom_951['supplement_to_display']).to eq ['Times (London, England)']
+    end
   end
 
   context 'invalid utf8 record' do


### PR DESCRIPTION
Also, remove the unused `constituent_part_display` field (see https://github.com/pulibrary/orangelight/issues/3082)