### PR TITLE
Migrate uniform_title_s field to Rust

### DIFF
--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -109,7 +109,7 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
         .ok()
         .and_then(|date| date.maybe_to_string());
 
-    let hash = ruby.hash_new_capa(130);
+    let hash = ruby.hash_new_capa(131);
     hash.aset("aat_s", ruby.ary_from_iter(genre::aat_s(&record)))?;
     hash.aset("action_notes_1display", action_notes_1display)?;
     hash.aset("access_restrictions_note_display", access_notes(&record))?;
@@ -501,6 +501,10 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
         extract_marc_trim_punctuation(&ruby, "765at", &record),
     )?;
     hash.aset("type_period_notes_display", extract_marc!("513ab")(&record))?;
+    hash.aset(
+        "uniform_title_s",
+        ruby.ary_from_iter(title::uniform_title(&record)),
+    )?;
     hash.aset(
         "uniform_130_vern",
         ruby.ary_from_iter(title::uniform_130_non_latin(&record)),

--- a/lib/bibdata_rs/src/marc/title.rs
+++ b/lib/bibdata_rs/src/marc/title.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use crate::marc::{
     extract_values::ExtractValues,
     string_normalize::{maybe_not_empty, remove_all_punctuation, trim_punctuation},
@@ -10,6 +8,10 @@ use crate::marc::{
 };
 use itertools::Itertools;
 use marctk::{Field, Record};
+use std::borrow::Cow;
+
+mod uniform_title;
+pub use uniform_title::{uniform_130_non_latin, uniform_title};
 
 struct Field245<'a>(&'a Field);
 impl<'a> Field245<'a> {
@@ -102,19 +104,6 @@ pub fn title_no_h_index(record: &Record) -> impl Iterator<Item = String> {
             Some(vec![joined, without_nf_chars])
         })
         .flatten()
-}
-
-pub fn uniform_130_non_latin(record: &Record) -> impl Iterator<Item = String> {
-    record
-        .extract_field_values_by(non_latin_tag_included_in(&["130"]), |field| {
-            Some(join_subfields_by_code(
-                field,
-                &[
-                    "a", "p", "l", "d", "f", "h", "k", "m", "n", "o", "r", "s", "t",
-                ],
-            ))
-        })
-        .map(|s| s.to_string())
 }
 
 #[cfg(test)]
@@ -241,17 +230,5 @@ mod tests {
         let record = Record::from_breaker(r"=245 10 $a   ").unwrap();
         let title_values: Vec<_> = title_no_h_index(&record).collect();
         assert!(title_values.is_empty());
-    }
-
-    #[test]
-    fn it_can_find_uniform_130_vern() {
-        let record = Record::from_breaker(
-            r#"=130 00$aUniform title test $d2020 $lEnglish
-=880 00$6130-01$aعنوان کتاب"#,
-        )
-        .unwrap();
-        let mut titles = uniform_130_non_latin(&record);
-        assert_eq!(titles.next(), Some(String::from("عنوان کتاب")));
-        assert_eq!(titles.next(), None);
     }
 }

--- a/lib/bibdata_rs/src/marc/title/uniform_title.rs
+++ b/lib/bibdata_rs/src/marc/title/uniform_title.rs
@@ -1,0 +1,133 @@
+//! Uniform titles are distinctive titles that catalogers use to group together
+//! records for works that have appeared under multiple titles (e.g. translations)
+
+use marctk::Record;
+
+use crate::marc::{
+    extract_values::ExtractValues,
+    string_normalize::maybe_not_empty,
+    trim_punctuation,
+    variable_length_field::{
+        SubfieldIterator, join_subfields_by_code, latin_or_non_latin_tag,
+        latin_or_non_latin_tag_included_in, non_latin_tag_included_in,
+    },
+};
+
+/// The uniform title, including information about a translation, but without any information about the author
+pub fn uniform_title(record: &Record) -> impl Iterator<Item = String> {
+    let uniform_title_fields = record.extract_field_values_by(
+        latin_or_non_latin_tag_included_in(&["130", "240"]),
+        |field| {
+            let subfields: &[&str] = if latin_or_non_latin_tag(field) == "130" {
+                &["a", "p", "l", "d", "f", "h", "k", "m", "n", "o", "r", "t"]
+            } else {
+                &["a", "p", "l", "d", "f", "h", "k", "m", "n", "o", "r", "s"]
+            };
+            let joined = join_subfields_by_code(field, subfields);
+            maybe_not_empty(trim_punctuation(&joined))
+        },
+    );
+
+    let author_and_title_fields = record.extract_field_values_by(
+        latin_or_non_latin_tag_included_in(&["100", "110", "111"]),
+        |field| {
+            let joined = field.subfields().iter().subfields_after("t").join(" ");
+            maybe_not_empty(trim_punctuation(&joined))
+        },
+    );
+    uniform_title_fields.chain(author_and_title_fields)
+}
+
+pub fn uniform_130_non_latin(record: &Record) -> impl Iterator<Item = String> {
+    record
+        .extract_field_values_by(non_latin_tag_included_in(&["130"]), |field| {
+            Some(join_subfields_by_code(
+                field,
+                &[
+                    "a", "p", "l", "d", "f", "h", "k", "m", "n", "o", "r", "s", "t",
+                ],
+            ))
+        })
+        .map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_builds_uniform_title_from_130() {
+        let record = Record::from_breaker(r#"=130 0 $aMahābhārata."#).unwrap();
+        let mut titles = uniform_title(&record);
+        assert_eq!(titles.next(), Some(String::from("Mahābhārata")));
+        assert_eq!(titles.next(), None);
+    }
+
+    #[test]
+    fn it_builds_uniform_title_from_240() {
+        let record = Record::from_breaker(r#"=240 10$aNoruwei no mori. $l English"#).unwrap();
+        let mut titles = uniform_title(&record);
+        assert_eq!(
+            titles.next(),
+            Some(String::from("Noruwei no mori. English"))
+        );
+        assert_eq!(titles.next(), None);
+    }
+
+    #[test]
+    fn it_does_not_include_subfield_0() {
+        let record = Record::from_breaker(
+            r#"=240 10$a Pantomima $0 http://id.loc.gov/authorities/names/n95021885 "#,
+        )
+        .unwrap();
+        let mut titles = uniform_title(&record);
+        assert_eq!(titles.next(), Some(String::from("Pantomima")));
+        assert_eq!(titles.next(), None);
+    }
+
+    #[test]
+    fn it_includes_non_latin_880_uniform_title() {
+        let record = Record::from_breaker(
+            r#"=240 10 $6880-02$aNoruwei no mori. $l Chinese 
+=880 00$6240-02$aノルウェイの森. $l Chinese"#,
+        )
+        .unwrap();
+        let mut titles = uniform_title(&record);
+        assert_eq!(
+            titles.next(),
+            Some(String::from("Noruwei no mori. Chinese"))
+        );
+        assert_eq!(titles.next(), Some(String::from("ノルウェイの森. Chinese")));
+        assert_eq!(titles.next(), None);
+    }
+
+    #[test]
+    fn it_trims_trailing_punctuation_from_uniform_title() {
+        let record = Record::from_breaker(r#"=130 00$aGiovanni's room. $l Russian."#).unwrap();
+        let mut titles = uniform_title(&record);
+        assert_eq!(
+            titles.next(),
+            Some(String::from("Giovanni's room. Russian"))
+        );
+        assert_eq!(titles.next(), None);
+    }
+
+    #[test]
+    fn it_treats_empty_uniform_title_fields_as_absent() {
+        let record = Record::from_breaker(r#"=130 00$a    "#).unwrap();
+        let titles: Vec<_> = uniform_title(&record).collect();
+        assert!(titles.is_empty());
+    }
+
+    #[test]
+    fn it_can_find_uniform_130_vern() {
+        let record = Record::from_breaker(
+            r#"=130 00$aUniform title test $d2020 $lEnglish
+=880 00$6130-01$aعنوان کتاب"#,
+        )
+        .unwrap();
+        let mut titles = uniform_130_non_latin(&record);
+        assert_eq!(titles.next(), Some(String::from("عنوان کتاب")));
+        assert_eq!(titles.next(), None);
+    }
+}

--- a/lib/bibdata_rs/src/marc/variable_length_field.rs
+++ b/lib/bibdata_rs/src/marc/variable_length_field.rs
@@ -32,6 +32,10 @@ where
     }
 }
 
+pub fn latin_or_non_latin_tag(field: &Field) -> &str {
+    non_latin_tag(field).unwrap_or(field.tag())
+}
+
 pub fn latin_tag_included_in(tags: &[&str]) -> impl Fn(&Field) -> bool {
     |field| tags.contains(&field.tag())
 }

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -153,10 +153,7 @@ end
 # Uniform title:
 #    130 XX apldfhkmnorst T ap
 #    240 XX {a[%}pldfhkmnors"]" T ap
-to_field 'uniform_title_s', extract_marc('130apldfhkmnorst:240apldfhkmnors', trim_punctuation: true) do |record, accumulator|
-  accumulator << everything_after_t(record, '100:110:111')
-  accumulator.flatten!
-end
+rust_multi_value_field 'uniform_title_s'
 
 rust_multi_value_field 'title_display'
 rust_multi_value_field 'title_a_index'


### PR DESCRIPTION
Partially done by Qwen 3.8 + pi locally, but the tests it generated were pretty bad and needed a complete rewrite.