### PR TITLE
Remove legacy lc_facet field in favor of lc_pipe_facet

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -913,21 +913,6 @@ to_field 'lc_pipe_facet' do |record, accumulator|
   end
 end
 
-# TODO: Remove in favor of lc_pipe_facet once reindex complete
-to_field 'lc_facet' do |record, accumulator|
-  delimiter = ':'
-  if record['050'] && record['050']['a']
-    first_letter = record['050']['a'].lstrip.slice(0, 1)
-    letters = /([[:alpha:]])*/.match(record['050']['a'])[0]
-    map_first = Traject::TranslationMap.new('callnumber_map')[first_letter]
-    map_rest = Traject::TranslationMap.new('callnumber_map')[letters]
-    accumulator << Traject::TranslationMap.new('callnumber_map')[first_letter]
-    if map_first && map_rest
-      accumulator << "#{Traject::TranslationMap.new('callnumber_map')[first_letter]}#{delimiter}#{Traject::TranslationMap.new('callnumber_map')[letters]}"
-    end
-  end
-end
-
 to_field 'sudoc_facet' do |record, accumulator|
   MarcExtractor.cached('086|0 |a').collect_matching_lines(record) do |field, spec, extractor|
     if /([[:alpha:]])*/.match?(extractor.collect_subfields(field, spec).first)

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -1167,47 +1167,22 @@ describe 'From traject_config.rb', :indexing do
       let(:record) { @indexer.map_record(MARC::Record.new_from_hash('fields' => [t050], 'leader' => leader)) }
 
       it 'includes a field with data for the classification facet' do
-        lc_facet = @sample40['lc_pipe_facet']
-        expect(lc_facet).to contain_exactly('R - Medicine', 'R - Medicine|||RA - Public Aspects of Medicine')
+        lc_pipe_facet = @sample40['lc_pipe_facet']
+        expect(lc_pipe_facet).to contain_exactly('R - Medicine', 'R - Medicine|||RA - Public Aspects of Medicine')
       end
 
       it 'handles cases where the call number is a single letter' do
-        lc_facet = @sample44['lc_pipe_facet']
-        expect(lc_facet).to contain_exactly('Z - Bibliography, Library Science, Information Resources', 'Z - Bibliography, Library Science, Information Resources|||Z - Bibliography, Library Science, Information Resources')
+        lc_pipe_facet = @sample44['lc_pipe_facet']
+        expect(lc_pipe_facet).to contain_exactly('Z - Bibliography, Library Science, Information Resources', 'Z - Bibliography, Library Science, Information Resources|||Z - Bibliography, Library Science, Information Resources')
       end
 
       it 'handles cases where there is no call number' do
-        lc_facet = @record_no_call_number['lc_pipe_facet']
-        expect(lc_facet).to be_nil
+        lc_pipe_facet = @record_no_call_number['lc_pipe_facet']
+        expect(lc_pipe_facet).to be_nil
       end
 
-      it 'does not index data into the lc_facet field if the call number is invalid' do
+      it 'does not index data into the lc_pipe_facet field if the call number is invalid' do
         expect(record['lc_pipe_facet']).to be_nil
-      end
-    end
-    # TODO: Remove in favor of lc_pipe_facet once reindex complete
-
-    describe 'lc_facet' do
-      let(:t050) { { '050' => { 'ind1' => '0', 'ind2' => '0', 'subfields' => [{ 'a' => 'IN PROCESS' }] } } }
-      let(:record) { @indexer.map_record(MARC::Record.new_from_hash('fields' => [t050], 'leader' => leader)) }
-
-      it 'includes a field with data for the classification facet' do
-        lc_facet = @sample40['lc_facet']
-        expect(lc_facet).to contain_exactly('R - Medicine', 'R - Medicine:RA - Public Aspects of Medicine')
-      end
-
-      it 'handles cases where the call number is a single letter' do
-        lc_facet = @sample44['lc_facet']
-        expect(lc_facet).to contain_exactly('Z - Bibliography, Library Science, Information Resources', 'Z - Bibliography, Library Science, Information Resources:Z - Bibliography, Library Science, Information Resources')
-      end
-
-      it 'handles cases where there is no call number' do
-        lc_facet = @record_no_call_number['lc_facet']
-        expect(lc_facet).to be_nil
-      end
-
-      it 'does not index data into the lc_facet field if the call number is invalid' do
-        expect(record['lc_facet']).to be_nil
       end
     end
 


### PR DESCRIPTION
The new field was introduced in #2684 and is working well.  We can remove it as soon as https://github.com/pulibrary/orangelight/pull/6178 is merged (keeping this as a draft until then).