### PR TITLE
Index subject unstem terms into a single field

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -768,14 +768,25 @@ end
 
 rust_multi_value_field 'icpsr_subject_unstem_search'
 
-# Adds lc, siku, local, and homoit subject unstem_search fields
+# Adds lc, siku, local, and homoit subject to a consolidated unstem_search field
 # Note that lc unstem search should include both archaic and replaced terms
 each_record do |_record, context|
   context.output_hash['subject_unstem_search'] = context.output_hash['lc_subject_include_archaic_search_terms_index']
+
+  # The lines below this comment can be removed once we remove the relevant fields from the default qf and pf in the solr config
   context.output_hash['local_subject_unstem_search'] = context.output_hash['local_subject_display']
   context.output_hash['siku_subject_unstem_search'] = context.output_hash['siku_subject_display']
   context.output_hash['homoit_subject_unstem_search'] = context.output_hash['homoit_subject_display']
   context.output_hash['fast_subject_unstem_search'] = context.output_hash['fast_subject_display']
+  # The lines above this comment can be removed once we remove the relevant fields from the default qf and pf in the solr config
+
+  context.output_hash['specialized_thesaurus_subject_unstem_search'] = ['local_subject_display', 'siku_subject_display', 'homoit_subject_display', 'fast_subject_display'].reduce([]) do |accumulator, field|
+    if context.output_hash[field]
+      accumulator + context.output_hash[field]
+    else
+      accumulator
+    end
+  end
 end
 
 # used for the browse lists and hierarchical subject/genre facet

--- a/spec/marc_to_solr/lib/config_spec.rb
+++ b/spec/marc_to_solr/lib/config_spec.rb
@@ -1326,18 +1326,17 @@ describe 'From traject_config.rb', :indexing do
 
         it 'includes siku subjects in separate fields' do
           expect(subject_marc['siku_subject_display']).to contain_exactly('Siku Subject', 'Siku Subject with skbb code')
-          expect(subject_marc['siku_subject_unstem_search']).to contain_exactly('Siku Subject', 'Siku Subject with skbb code')
+          expect(subject_marc['specialized_thesaurus_subject_unstem_search']).to include('Siku Subject', 'Siku Subject with skbb code')
         end
 
         it 'includes homoit subjects in separate fields' do
           expect(subject_marc['homoit_subject_display']).to contain_exactly('Homosaurus Subject')
-          expect(subject_marc['homoit_subject_unstem_search']).to contain_exactly('Homosaurus Subject')
+          expect(subject_marc['specialized_thesaurus_subject_unstem_search']).to include('Homosaurus Subject')
         end
 
-        it 'include lc, siku, and local subjects in separate unstem fields' do
-          expect(subject_marc['subject_unstem_search']).to contain_exactly('LC Subject')
-          expect(subject_marc['local_subject_display']).to contain_exactly('Local Subject')
-          expect(subject_marc['local_subject_unstem_search']).to contain_exactly('Local Subject')
+        it 'include lc, siku, and local subjects in the same unstem fields' do
+          expect(subject_marc['subject_unstem_search']).to include('LC Subject')
+          expect(subject_marc['specialized_thesaurus_subject_unstem_search']).to include('Local Subject')
         end
 
         it 'works using a fixture file' do
@@ -1566,7 +1565,7 @@ describe 'From traject_config.rb', :indexing do
 
       it 'works against a fixture' do
         expect(@homosaurus['homoit_subject_display']).to match_array(homosaurus_terms)
-        expect(@homosaurus['homoit_subject_unstem_search']).to match_array(homosaurus_terms)
+        expect(@homosaurus['specialized_thesaurus_subject_unstem_search']).to match_array(homosaurus_terms)
         expect(@homosaurus['lc_subject_display']).to match_array(lc_only_terms)
         expect(@homosaurus['subject_unstem_search']).to match_array(lc_only_terms)
         expect(@homosaurus['subject_facet']).to match_array(lc_and_homosaurus_terms)
@@ -1585,7 +1584,7 @@ describe 'From traject_config.rb', :indexing do
     describe 'fast subject heading fields' do
       it 'indexes fast headings' do
         expect(@fast_subject_heading['fast_subject_display']).to contain_exactly('Criticism, interpretation, etc', "Children's literature, Russian", 'Russia (Federation)')
-        expect(@fast_subject_heading['fast_subject_unstem_search']).to contain_exactly('Criticism, interpretation, etc', "Children's literature, Russian", 'Russia (Federation)')
+        expect(@fast_subject_heading['specialized_thesaurus_subject_unstem_search']).to contain_exactly('Criticism, interpretation, etc', "Children's literature, Russian", 'Russia (Federation)')
       end
 
       it 'does not add fast headings to subject_facet or subject_topic_facet' do


### PR DESCRIPTION
Prior to this commit, we indexed subject unstem terms into a variety of different fields, for example `siku_subject_unstem_search`, `homoit_subject_unstem_search`, etc.  All of these fields were used in the same qf and pf, and were weighted the same.  Having these as separate fields meant that the queries that solr generated for keyword searches had many more clauses than they needed

Getting this into production will take 3 separate PRS:
1. This one
1. https://github.com/pulibrary/pul_solr/pull/577, which can be merged after this goes in and we reindex.
1. A PR to remove the existing siku_subject_unstem_search, homoit_subject_unstem_search, local_subject_display, and fast_subject_display from the indexing, which can be merged after the pul_solr pr goes in.

Helps with https://github.com/pulibrary/orangelight/issues/5691