### PR TITLE
Stop indexing into specific unstem subject fields

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -772,14 +772,6 @@ rust_multi_value_field 'icpsr_subject_unstem_search'
 # Note that lc unstem search should include both archaic and replaced terms
 each_record do |_record, context|
   context.output_hash['subject_unstem_search'] = context.output_hash['lc_subject_include_archaic_search_terms_index']
-
-  # The lines below this comment can be removed once we remove the relevant fields from the default qf and pf in the solr config
-  context.output_hash['local_subject_unstem_search'] = context.output_hash['local_subject_display']
-  context.output_hash['siku_subject_unstem_search'] = context.output_hash['siku_subject_display']
-  context.output_hash['homoit_subject_unstem_search'] = context.output_hash['homoit_subject_display']
-  context.output_hash['fast_subject_unstem_search'] = context.output_hash['fast_subject_display']
-  # The lines above this comment can be removed once we remove the relevant fields from the default qf and pf in the solr config
-
   context.output_hash['specialized_thesaurus_subject_unstem_search'] = ['local_subject_display', 'siku_subject_display', 'homoit_subject_display', 'fast_subject_display'].reduce([]) do |accumulator, field|
     if context.output_hash[field]
       accumulator + context.output_hash[field]


### PR DESCRIPTION
As of https://github.com/pulibrary/pul_solr/pull/577, we no longer use these fields, and instead use a single consolidated field to reduce the number of queries that solr generates.

A cleanup as part of #5691