### PR TITLE
Remove default redis crate features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1573,25 +1573,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,11 +2107,9 @@ dependencies = [
  "arcstr",
  "combine",
  "itoa",
- "num-bigint",
  "percent-encoding",
  "r2d2",
  "ryu",
- "sha1_smol",
  "socket2",
  "url",
  "xxhash-rust",
@@ -2440,12 +2419,6 @@ dependencies = [
  "ryu",
  "serde",
 ]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"

--- a/figgy_marc/Cargo.toml
+++ b/figgy_marc/Cargo.toml
@@ -10,7 +10,7 @@ name = "cache_figgy_data"
 
 [dependencies]
 r2d2 = "0.8.10"
-redis = {version = "1.2.2", features = ["r2d2"]}
+redis = {version = "1.2.2", default-features = false, features = ["r2d2"]}
 reqwest = {version = "0.13.4", features = ["blocking", "json"] }
 serde = {version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"


### PR DESCRIPTION
We do not use any of them (acl, geospatial, scripts, or streams).  This removes a few small dependencies.  If it saves any compile time at all, it's very slight, but can't hurt!