### PR TITLE
Add a way to pass --timings to cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ Given the above challenges, one approach to profiling is:
 4. Samply will open up the Firefox profiler with the results.  Note that samply also profiles the rust compiler, so if your results are filled with `rustc`, you can remove those tracks (or simply re-run the previous `samply` command) to remove those distractions.
 5. The Flame Graph and Stack Chart tabs within the Firefox profiler are the most useful.
 
+#### Profiling compilation
+
+Compiling might be slow, and you wish to speed it up!  To get a sense for where the bottlenecks are:
+
+1. `cargo clean`
+1. `PROFILE_COMPILATION=yes bundle exec rake compile`
+1. In the output, it will mention 2 HTML files that contain timing information.  Open the first in your browser.
+
 ## Compiling
 
 Some business logic is written in Rust.  This code is compiled when you

--- a/lib/bibdata_rs/extconf.rb
+++ b/lib/bibdata_rs/extconf.rb
@@ -6,7 +6,9 @@ require 'rb_sys/mkmf'
 module BibdataRs
   module Extconf
     def self.makefile
-      create_rust_makefile 'bibdata_rs'
+      create_rust_makefile 'bibdata_rs' do |builder|
+        builder.extra_cargo_args << '--timings' if ENV['PROFILE_COMPILATION']
+      end
     end
   end
 end

--- a/spec/bibdata_rs/extconf_spec.rb
+++ b/spec/bibdata_rs/extconf_spec.rb
@@ -9,5 +9,21 @@ describe 'extconf' do
     expect(File).to exist 'Makefile'
     File.delete 'Makefile'
   end
+
+  it 'does not add --timings to the cargo command by default' do
+    FileUtils.rm_f 'Makefile'
+    BibdataRs::Extconf.makefile
+    expect(File.read('Makefile')).not_to include '--timings'
+    File.delete 'Makefile'
+  end
+
+  it 'adds --timings to the cargo command if PROFILE_COMPILATION=yes' do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('PROFILE_COMPILATION').and_return 'yes'
+    FileUtils.rm_f 'Makefile'
+    BibdataRs::Extconf.makefile
+    expect(File.read('Makefile')).to include '--timings'
+    File.delete 'Makefile'
+  end
 end
 # rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
This produces a nice HTML report that lists where cargo spent its time while compiling.