### PR TITLE
Rewrite `mult_languages_iana_s` solr field in Rust

### DIFF
--- a/lib/bibdata_rs/src/languages.rs
+++ b/lib/bibdata_rs/src/languages.rs
@@ -47,13 +47,18 @@ pub fn language_name_owned(code: String) -> Option<String> {
     language_name(&code).ok().map(|name| name.to_owned())
 }
 
-pub fn is_valid_language_code(code: String) -> bool {
+pub fn is_valid_language_code(code: &str) -> bool {
     if code.is_empty() {
         return false;
     }
-    iso_639_2b::from_iso_639b_code(&code).is_some()
-        || iso_639_5::from_iso_639_5_code(&code).is_some()
-        || iso_639_3::from_iso_639_3_code(&code).is_some()
+    iso_639_2b::from_iso_639b_code(code).is_some()
+        || iso_639_5::from_iso_639_5_code(code).is_some()
+        || iso_639_3::from_iso_639_3_code(code).is_some()
+}
+
+// A wrapper for use in Ruby that uses owned strings
+pub fn is_valid_language_code_owned(code: String) -> bool {
+    is_valid_language_code(&code)
 }
 
 pub fn two_letter_code(code: &str) -> Option<&'static str> {
@@ -134,18 +139,18 @@ mod tests {
     #[test]
     fn it_can_validate_language_codes() {
         assert!(
-            is_valid_language_code("per".to_owned()),
+            is_valid_language_code("per"),
             "ISO 639-2b code is considered to be valid"
         );
         assert!(
-            is_valid_language_code("grc".to_owned()),
+            is_valid_language_code("grc"),
             "ISO 639-3 code is considered to be valid"
         );
         assert!(
-            is_valid_language_code("nah".to_owned()),
+            is_valid_language_code("nah"),
             "ISO 639-5 collective code is considered to be valid"
         );
-        assert!(!is_valid_language_code("123".to_owned()), "Invalid code");
+        assert!(!is_valid_language_code("123"), "Invalid code");
     }
 
     #[test]
@@ -177,8 +182,8 @@ mod tests {
 
     #[test]
     fn it_can_tell_if_a_language_code_is_valid() {
-        assert!(is_valid_language_code(String::from("ben")));
-        assert!(!is_valid_language_code(String::from("WRONG WRONG WRONG!")));
+        assert!(is_valid_language_code("ben"));
+        assert!(!is_valid_language_code("WRONG WRONG WRONG!"));
     }
 
     #[test]

--- a/lib/bibdata_rs/src/lib.rs
+++ b/lib/bibdata_rs/src/lib.rs
@@ -43,7 +43,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     )?;
     submodule_languages.define_singleton_method(
         "valid_language_code?",
-        function!(languages::is_valid_language_code, 1),
+        function!(languages::is_valid_language_code_owned, 1),
     )?;
     submodule_languages.define_singleton_method(
         "two_letter_code",

--- a/lib/bibdata_rs/src/marc/fixed_field/dates.rs
+++ b/lib/bibdata_rs/src/marc/fixed_field/dates.rs
@@ -115,7 +115,7 @@ impl<'a> TryFrom<&'a Record> for EndDate<'a> {
             DateType::DetailedDate => 7..11,
             _ => 11..15,
         };
-        let year = slice_from_008(record, range.into()).ok_or(NoEndDate)?;
+        let year = slice_from_008(record, range).ok_or(NoEndDate)?;
 
         match Date::try_from(year) {
             Ok(date) => Ok(Self(date)),
@@ -153,7 +153,7 @@ impl<'a> TryFrom<&'a Record> for BeginDate<'a> {
     type Error = NoBeginDate;
 
     fn try_from(record: &'a Record) -> Result<Self, Self::Error> {
-        let year = slice_from_008(record, (7..11).into()).ok_or(NoBeginDate)?;
+        let year = slice_from_008(record, 7..11).ok_or(NoBeginDate)?;
 
         match Date::try_from(year) {
             Ok(date) => Ok(Self(date)),

--- a/lib/bibdata_rs/src/marc/fixed_field/general_information.rs
+++ b/lib/bibdata_rs/src/marc/fixed_field/general_information.rs
@@ -14,11 +14,11 @@ pub fn char_from_008(record: &Record, index: usize) -> Option<char> {
 }
 
 /// Get the desired slice from the MARC 008 field
-pub fn slice_from_008(record: &Record, range: Range<usize>) -> Option<&str> {
+pub fn slice_from_008(record: &Record, range: impl Into<Range<usize>>) -> Option<&str> {
     record
         .get_control_fields("008")
         .first()
-        .and_then(|field| field.content().get(range))
+        .and_then(|field| field.content().get(range.into()))
 }
 
 #[cfg(test)]
@@ -46,6 +46,6 @@ mod tests {
     #[test]
     fn it_can_get_a_slice_from_008() {
         let record = Record::from_breaker("=008 940720d19761979it mr         0   a0ita d").unwrap();
-        assert_eq!(slice_from_008(&record, (0..6).into()), Some("940720"));
+        assert_eq!(slice_from_008(&record, 0..6), Some("940720"));
     }
 }

--- a/lib/bibdata_rs/src/marc/language.rs
+++ b/lib/bibdata_rs/src/marc/language.rs
@@ -1,4 +1,10 @@
-use crate::languages::{Language, iso_639_2b::from_iso_639b_code};
+use crate::{
+    languages::{
+        Language, is_valid_language_code, iso_639_2b::from_iso_639b_code, two_letter_code,
+    },
+    marc::fixed_field::general_information::slice_from_008,
+};
+use itertools::Itertools;
 use marctk::Record;
 
 pub fn original_languages_of_translation(record: &Record) -> Vec<Language> {
@@ -7,6 +13,28 @@ pub fn original_languages_of_translation(record: &Record) -> Vec<Language> {
         .iter()
         .filter_map(|code| from_iso_639b_code(code.trim()))
         .collect()
+}
+
+/// If a language code in the record has a 2-letter equivalent, use it.  Otherwise use the 3-letter version.
+pub fn simplified_language_codes(record: &Record) -> impl Iterator<Item = &str> {
+    language_codes(record).filter_map(|original_code| {
+        two_letter_code(original_code).or_else(|| {
+            if is_valid_language_code(original_code) {
+                Some(original_code)
+            } else {
+                None
+            }
+        })
+    })
+}
+
+pub fn language_codes(record: &Record) -> impl Iterator<Item = &str> {
+    record
+        .extract_values("041ad")
+        .into_iter()
+        .chain(slice_from_008(record, 35..38))
+        .map(str::trim)
+        .unique()
 }
 
 #[cfg(test)]
@@ -50,5 +78,54 @@ mod tests {
 
         let languages = original_languages_of_translation(&record);
         assert!(languages.is_empty());
+    }
+
+    #[test]
+    fn it_can_get_language_codes_from_008() {
+        let record = Record::from_breaker("=008 060302s1994    io a   j      000 1 may|d").unwrap();
+        let mut codes = language_codes(&record);
+        assert_eq!(codes.next(), Some("may"));
+        assert_eq!(codes.next(), None);
+    }
+
+    #[test]
+    fn it_can_get_language_codes_from_041() {
+        let record = Record::from_breaker(r"=041 0\ $aeng $achi $amay $atam").unwrap();
+        let mut codes = language_codes(&record);
+        assert_eq!(codes.next(), Some("eng"));
+        assert_eq!(codes.next(), Some("chi"));
+        assert_eq!(codes.next(), Some("may"));
+        assert_eq!(codes.next(), Some("tam"));
+        assert_eq!(codes.next(), None);
+    }
+
+    #[test]
+    fn it_can_determine_simplified_codes() {
+        let record = Record::from_breaker(
+            r#"=008 151221t20152015si a          001 m eng d
+=041 0\ $aeng $achi $amay $atam"#,
+        )
+        .unwrap();
+        let mut codes = simplified_language_codes(&record);
+        assert_eq!(codes.next(), Some("en"));
+        assert_eq!(codes.next(), Some("zh"));
+        assert_eq!(codes.next(), Some("ms"));
+        assert_eq!(codes.next(), Some("ta"));
+        assert_eq!(codes.next(), None);
+    }
+
+    #[test]
+    fn it_retains_3_letter_codes_when_there_is_no_2_letter_equivalent() {
+        let record =
+            Record::from_breaker(r"=041 \7 $aasb $a ats $a crd $a cro $a eng $a nez $2 iso639-3")
+                .unwrap();
+        let mut codes = simplified_language_codes(&record);
+        assert_eq!(codes.next(), Some("asb"));
+        assert_eq!(codes.next(), Some("ats"));
+        assert_eq!(codes.next(), Some("crd"));
+        assert_eq!(codes.next(), Some("cro"));
+        assert_eq!(codes.next(), Some("en"));
+        assert_eq!(codes.next(), Some("nez"));
+        assert_eq!(codes.next(), None);
     }
 }

--- a/lib/bibdata_rs/src/marc/ruby_bindings.rs
+++ b/lib/bibdata_rs/src/marc/ruby_bindings.rs
@@ -113,7 +113,7 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
         .ok()
         .and_then(|date| date.maybe_to_string());
 
-    let hash = ruby.hash_new_capa(131);
+    let hash = ruby.hash_new_capa(132);
     hash.aset("aat_s", ruby.ary_from_iter(genre::aat_s(&record)))?;
     hash.aset("action_notes_1display", action_notes_1display)?;
     hash.aset("access_restrictions_note_display", access_notes(&record))?;
@@ -346,6 +346,10 @@ fn solr_fields(ruby: &Ruby, record: magnus::RObject) -> Result<RHash, magnus::Er
     )?;
     hash.aset("marcxml", marcxml_compressed(&record))?;
     hash.aset("methodology_notes_display", extract_marc!("567a")(&record))?;
+    hash.aset(
+        "mult_languages_iana_s",
+        ruby.ary_from_iter(language::simplified_language_codes(&record)),
+    )?;
     hash.aset(
         "non_latin_non_cjk_all_index",
         ruby.ary_from_iter(non_latin::non_latin_non_cjk_all(&record)),

--- a/marc_to_solr/lib/language_service.rb
+++ b/marc_to_solr/lib/language_service.rb
@@ -6,12 +6,6 @@ require_relative 'indigenous_languages'
 class LanguageService
   include IndigenousLanguages
 
-  def loc_to_mult_iana(loc)
-    return nil unless valid_language_code?(loc)
-
-    BibdataRs::Languages.two_letter_code(loc.to_s) || loc
-  end
-
   def valid_language_code?(code)
     return false if code.blank?
 

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -608,12 +608,7 @@ to_field 'language_iana_s', extract_marc('008[35-37]:041a:041d') do |_record, ac
   accumulator.replace([single_iana_code])
 end
 
-to_field 'mult_languages_iana_s', extract_marc('008[35-37]:041a:041d') do |_record, accumulator|
-  codes = accumulator.compact.map { |m| m.length == 3 ? m : m.scan(/.{1,3}/) }.flatten.uniq
-  codes_iso_639 = codes.select { |m| language_service.valid_language_code?(m) }
-                       .map { |m| language_service.loc_to_mult_iana(m) }&.reject(&:blank?)
-  accumulator.replace(codes_iso_639)
-end
+rust_multi_value_field 'mult_languages_iana_s'
 
 # Contents:
 #    505 0X agrt


### PR DESCRIPTION
Also do 2 small cleanups:
* Separate `is_valid_language_code` into a version that deals only with owned strings (for use in Ruby) and a version that can accept a string slice (for use in Rust, avoiding the allocation needed to create a new String).
* Simplify calling the `slice_from_008` method: it calls `.into()` so that the caller does not have to.