### PR TITLE
Store Metadatum contents as a CoW rather than an owned string

### DIFF
--- a/lib/bibdata_rs/src/theses/dataspace/document.rs
+++ b/lib/bibdata_rs/src/theses/dataspace/document.rs
@@ -1,5 +1,6 @@
 // This module is responsible for representing Dataspace Document's metadata
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use serde::de::Deserializer;
@@ -32,15 +33,30 @@ pub struct DataspaceDocument {
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
-pub struct Metadatum {
-    pub value: Option<String>,
+pub struct Metadatum<'a> {
+    #[serde(borrow)]
+    pub value: Option<Cow<'a, str>>,
 }
 
-impl From<&str> for Metadatum {
+impl<'a> From<&str> for Metadatum<'a> {
     fn from(str: &str) -> Self {
         Metadatum {
-            value: Some(str.to_string()),
+            value: Some(Cow::Owned(str.to_string())),
         }
+    }
+}
+
+pub struct EmptyMetadata {}
+
+impl<'a> TryFrom<&Metadatum<'a>> for String {
+    type Error = EmptyMetadata;
+
+    fn try_from(value: &Metadatum<'a>) -> Result<Self, Self::Error> {
+        value
+            .value
+            .as_ref()
+            .map(|s| s.to_string())
+            .ok_or(Self::Error {})
     }
 }
 
@@ -52,9 +68,10 @@ impl<'de> Deserialize<'de> for DataspaceDocument {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
-        struct RawDocument {
+        struct RawDocument<'a> {
             handle: String,
-            metadata: HashMap<String, Vec<Metadatum>>,
+            #[serde(borrow)]
+            metadata: HashMap<String, Vec<Metadatum<'a>>>,
         }
 
         let raw = RawDocument::deserialize(deserializer)?;
@@ -108,9 +125,9 @@ mod tests {
 
     use super::*;
 
-    fn metadatum_vec_from_string(value: &str) -> Vec<Metadatum> {
+    fn metadatum_vec_from_string(value: &str) -> Vec<Metadatum<'_>> {
         vec![Metadatum {
-            value: Some(value.to_string()),
+            value: Some(value.into()),
         }]
     }
 
@@ -186,6 +203,6 @@ mod tests {
         let json = r#"[{"handle":"88435/dsp01b2773v788","metadata":{"dc.contributor":[{ "value":null }]}}]"#;
         let documents: Vec<DataspaceDocument> = serde_json::from_str(json).unwrap();
         assert_eq!(documents.len(), 1);
-        assert_eq!(documents[0].contributor, Some(vec!("".to_string())));
+        assert_eq!(documents[0].contributor, Some(vec![]));
     }
 }

--- a/lib/bibdata_rs/src/theses/dataspace/document/builder.rs
+++ b/lib/bibdata_rs/src/theses/dataspace/document/builder.rs
@@ -33,16 +33,12 @@ impl DataspaceDocumentBuilder {
 
     pub fn with_certificate(mut self, certificate: Vec<Metadatum>) -> Self {
         if let Some(ref mut vec) = self.certificate {
-            vec.extend(
-                certificate
-                    .iter()
-                    .map(|cert| cert.value.clone().unwrap_or_default()),
-            )
+            vec.extend(certificate.iter().filter_map(|cert| cert.try_into().ok()))
         } else {
             self.certificate = Some(
                 certificate
                     .iter()
-                    .map(|md| md.value.clone().unwrap_or_default())
+                    .filter_map(|md| md.try_into().ok())
                     .collect::<Vec<String>>(),
             )
         }
@@ -54,13 +50,13 @@ impl DataspaceDocumentBuilder {
             vec.extend(
                 contributors
                     .iter()
-                    .map(|contributor| contributor.value.clone().unwrap_or_default()),
+                    .filter_map(|contributor| contributor.try_into().ok()),
             )
         } else {
             self.contributor = Some(
                 contributors
                     .iter()
-                    .map(|md| md.value.clone().unwrap_or_default())
+                    .filter_map(|md| md.try_into().ok())
                     .collect::<Vec<String>>(),
             )
         }
@@ -72,13 +68,13 @@ impl DataspaceDocumentBuilder {
             vec.extend(
                 contributor_advisors
                     .iter()
-                    .map(|ca| ca.value.clone().unwrap_or_default()),
+                    .filter_map(|ca| ca.try_into().ok()),
             )
         } else {
             self.contributor_advisor = Some(
                 contributor_advisors
                     .iter()
-                    .map(|md| md.value.clone().unwrap_or_default())
+                    .filter_map(|md| md.try_into().ok())
                     .collect::<Vec<String>>(),
             )
         }
@@ -90,13 +86,13 @@ impl DataspaceDocumentBuilder {
             vec.extend(
                 contributor_author
                     .iter()
-                    .map(|ca| ca.value.clone().unwrap_or_default()),
+                    .filter_map(|ca| ca.try_into().ok()),
             )
         } else {
             self.contributor_author = Some(
                 contributor_author
                     .iter()
-                    .map(|md| md.value.clone().unwrap_or_default())
+                    .filter_map(|md| md.try_into().ok())
                     .collect::<Vec<String>>(),
             )
         }
@@ -108,13 +104,13 @@ impl DataspaceDocumentBuilder {
             vec.extend(
                 date_classyear
                     .iter()
-                    .map(|date| date.value.clone().unwrap_or_default()),
+                    .filter_map(|date| date.try_into().ok()),
             )
         } else {
             self.date_classyear = Some(
                 date_classyear
                     .iter()
-                    .map(|md| md.value.clone().unwrap_or_default())
+                    .filter_map(|md| md.try_into().ok())
                     .collect::<Vec<String>>(),
             )
         }
@@ -126,13 +122,13 @@ impl DataspaceDocumentBuilder {
             vec.extend(
                 description_abstract
                     .iter()
-                    .map(|abs| abs.value.clone().unwrap_or_default()),
+                    .filter_map(|abs| abs.try_into().ok()),
             )
         } else {
             self.description_abstract = Some(
                 description_abstract
                     .iter()
-                    .map(|md| md.value.clone().unwrap_or_default())
+                    .filter_map(|md| md.try_into().ok())
                     .collect::<Vec<String>>(),
             )
         }
@@ -144,13 +140,13 @@ impl DataspaceDocumentBuilder {
             vec.extend(
                 &mut department
                     .iter()
-                    .map(|department| department.value.clone().unwrap_or_default()),
+                    .filter_map(|department| department.try_into().ok()),
             )
         } else {
             self.department = Some(
                 department
                     .iter()
-                    .map(|md| md.value.clone().unwrap_or_default())
+                    .filter_map(|md| md.try_into().ok())
                     .collect::<Vec<String>>(),
             )
         }
@@ -159,16 +155,12 @@ impl DataspaceDocumentBuilder {
 
     pub fn with_embargo_lift(mut self, embargo_lift: Vec<Metadatum>) -> Self {
         if let Some(ref mut vec) = self.embargo_lift {
-            vec.extend(
-                embargo_lift
-                    .iter()
-                    .map(|el| el.value.clone().unwrap_or_default()),
-            )
+            vec.extend(embargo_lift.iter().filter_map(|el| el.try_into().ok()))
         } else {
             self.embargo_lift = Some(
                 embargo_lift
                     .iter()
-                    .map(|md| md.value.clone().unwrap_or_default())
+                    .filter_map(|md| md.try_into().ok())
                     .collect::<Vec<String>>(),
             )
         }
@@ -180,13 +172,13 @@ impl DataspaceDocumentBuilder {
             vec.extend(
                 embargo_terms
                     .iter()
-                    .map(|terms| terms.value.clone().unwrap_or_default()),
+                    .filter_map(|terms| terms.try_into().ok()),
             )
         } else {
             self.embargo_terms = Some(
                 embargo_terms
                     .iter()
-                    .map(|md| md.value.clone().unwrap_or_default())
+                    .filter_map(|md| md.try_into().ok())
                     .collect::<Vec<String>>(),
             )
         }
@@ -198,13 +190,13 @@ impl DataspaceDocumentBuilder {
             vec.extend(
                 format_extent
                     .iter()
-                    .map(|format| format.value.clone().unwrap_or_default()),
+                    .filter_map(|format| format.try_into().ok()),
             )
         } else {
             self.format_extent = Some(
                 format_extent
                     .iter()
-                    .map(|md| md.value.clone().unwrap_or_default())
+                    .filter_map(|md| md.try_into().ok())
                     .collect::<Vec<String>>(),
             )
         }
@@ -216,13 +208,13 @@ impl DataspaceDocumentBuilder {
             vec.extend(
                 identifier_other
                     .iter()
-                    .map(|identifier| identifier.value.clone().unwrap_or_default()),
+                    .filter_map(|identifier| identifier.try_into().ok()),
             )
         } else {
             self.identifier_other = Some(
                 identifier_other
                     .iter()
-                    .map(|md| md.value.clone().unwrap_or_default())
+                    .filter_map(|md| md.try_into().ok())
                     .collect::<Vec<String>>(),
             )
         }
@@ -231,16 +223,12 @@ impl DataspaceDocumentBuilder {
 
     pub fn with_identifier_uri(mut self, identifier_uri: Vec<Metadatum>) -> Self {
         if let Some(ref mut vec) = self.identifier_uri {
-            vec.extend(
-                identifier_uri
-                    .iter()
-                    .map(|uri| uri.value.clone().unwrap_or_default()),
-            )
+            vec.extend(identifier_uri.iter().filter_map(|uri| uri.try_into().ok()))
         } else {
             self.identifier_uri = Some(
                 identifier_uri
                     .iter()
-                    .map(|md| md.value.clone().unwrap_or_default())
+                    .filter_map(|md| md.try_into().ok())
                     .collect::<Vec<String>>(),
             )
         }
@@ -249,16 +237,12 @@ impl DataspaceDocumentBuilder {
 
     pub fn with_language_iso(mut self, language_iso: Vec<Metadatum>) -> Self {
         if let Some(ref mut vec) = self.language_iso {
-            vec.extend(
-                language_iso
-                    .iter()
-                    .map(|lang| lang.value.clone().unwrap_or_default()),
-            )
+            vec.extend(language_iso.iter().filter_map(|lang| lang.try_into().ok()))
         } else {
             self.language_iso = Some(
                 language_iso
                     .iter()
-                    .map(|md| md.value.clone().unwrap_or_default())
+                    .filter_map(|md| md.try_into().ok())
                     .collect::<Vec<String>>(),
             )
         }
@@ -270,13 +254,13 @@ impl DataspaceDocumentBuilder {
             vec.extend(
                 location
                     .iter()
-                    .map(|location| location.value.clone().unwrap_or_default()),
+                    .filter_map(|location| location.try_into().ok()),
             )
         } else {
             self.location = Some(
                 location
                     .iter()
-                    .map(|md| md.value.clone().unwrap_or_default())
+                    .filter_map(|md| md.try_into().ok())
                     .collect::<Vec<String>>(),
             )
         }
@@ -285,16 +269,12 @@ impl DataspaceDocumentBuilder {
 
     pub fn with_mudd_walkin(mut self, mudd_walkin: Vec<Metadatum>) -> Self {
         if let Some(ref mut vec) = self.mudd_walkin {
-            vec.extend(
-                mudd_walkin
-                    .iter()
-                    .map(|mw| mw.value.clone().unwrap_or_default()),
-            );
+            vec.extend(mudd_walkin.iter().filter_map(|mw| mw.try_into().ok()));
         } else {
             self.mudd_walkin = Some(
                 mudd_walkin
                     .iter()
-                    .map(|md| md.value.clone().unwrap_or_default())
+                    .filter_map(|md| md.try_into().ok())
                     .collect::<Vec<String>>(),
             )
         }
@@ -306,13 +286,13 @@ impl DataspaceDocumentBuilder {
             vec.extend(
                 rights_access_rights
                     .iter()
-                    .map(|rights| rights.value.clone().unwrap_or_default()),
+                    .filter_map(|rights| rights.try_into().ok()),
             )
         } else {
             self.rights_access_rights = Some(
                 rights_access_rights
                     .iter()
-                    .map(|md| md.value.clone().unwrap_or_default())
+                    .filter_map(|md| md.try_into().ok())
                     .collect::<Vec<String>>(),
             )
         }
@@ -321,16 +301,12 @@ impl DataspaceDocumentBuilder {
 
     pub fn with_title(mut self, title: Vec<Metadatum>) -> Self {
         if let Some(ref mut vec) = self.title {
-            vec.extend(
-                title
-                    .iter()
-                    .map(|title| title.value.clone().unwrap_or_default()),
-            )
+            vec.extend(title.iter().filter_map(|title| title.try_into().ok()))
         } else {
             self.title = Some(
                 title
                     .iter()
-                    .map(|md| md.value.clone().unwrap_or_default())
+                    .filter_map(|md| md.try_into().ok())
                     .collect::<Vec<String>>(),
             )
         }

--- a/lib/bibdata_rs/src/theses/dataspace/document/normalize.rs
+++ b/lib/bibdata_rs/src/theses/dataspace/document/normalize.rs
@@ -218,9 +218,9 @@ mod tests {
     use super::*;
     use crate::theses::dataspace::document::Metadatum;
 
-    fn metadatum_vec_from_string(value: &str) -> Vec<Metadatum> {
+    fn metadatum_vec_from_string(value: &str) -> Vec<Metadatum<'_>> {
         vec![Metadatum {
-            value: Some(value.to_string()),
+            value: Some(value.into()),
         }]
     }
 


### PR DESCRIPTION
Previously, the `Metadatum` struct stored an owned string inside.  This PR changes it to a `CoW`

This does not directly cause any change in benchmark performance, but it opens up possibilities for us to avoid more allocations in future work.

Also, there is one change in behavior.  When a value is missing, we now represent it as an empty vec rather than a vec that contains an empty string.